### PR TITLE
add basic trace feature to ringpop; currently support traces that output

### DIFF
--- a/client.js
+++ b/client.js
@@ -54,6 +54,7 @@ RingpopClient.prototype._request = function _request(host, endpoint, head, body,
 
         self.subChannel.request({
             host: host,
+            serviceName: 'ringpop',
             hasNoParent: true,
             retryLimit: 1,
             trace: false,

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ var rawHead = require('./lib/request-proxy/util.js').rawHead;
 var RequestProxy = require('./lib/request-proxy/index.js');
 var safeParse = require('./lib/util').safeParse;
 var sendJoin = require('./lib/swim/join-sender.js').joinCluster;
+var TracerStore = require('./lib/trace/store.js');
 
 var HOST_PORT_PATTERN = /^(\d+.\d+.\d+.\d+):\d+$/;
 var MAX_JOIN_DURATION = 300000;
@@ -153,6 +154,8 @@ function RingPop(options) {
 
     createEventForwarder(this);
 
+    this.tracers = new TracerStore(this);
+
     this.clientRate = new metrics.Meter();
     this.serverRate = new metrics.Meter();
     this.totalRate = new metrics.Meter();
@@ -180,6 +183,7 @@ RingPop.prototype.destroy = function destroy() {
     this.suspicion.stopAll();
     this.membershipUpdateRollup.destroy();
     this.requestProxy.destroy();
+    this.tracers.destroy();
 
     this.clientRate.m1Rate.stop();
     this.clientRate.m5Rate.stop();

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -69,7 +69,8 @@ module.exports = {
     }),
     OptionRequiredError: TypedError({
         type: 'ringpop.option-required',
-        message: 'Expected `{option}` to be present',
+        message: '{context}: Expected `{option}` to be present',
+        context: 'ringpop',
         option: null
     }),
     OptionsRequiredError: TypedError({

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -58,13 +58,36 @@ Membership.prototype.computeChecksum = function computeChecksum() {
      */
     var start = new Date();
 
+    var prevChecksum = this.checksum;
     this.checksum = farmhash.hash32(this.generateChecksumString());
 
     this.emit('checksumComputed');
     this.ringpop.stat('timing', 'compute-checksum', start);
     this.ringpop.stat('gauge', 'checksum', this.checksum);
+    if (prevChecksum !== this.checksum) {
+        this._emitChecksumUpdate();
+    }
 
     return this.checksum;
+};
+
+Membership.prototype._emitChecksumUpdate = function _emitChecksumUpdate() {
+    // make counts = {'alive': 12, 'faulty': 3, 'suspect': 0, 'leave': 0}
+    var counts = {};
+    var keys = Object.keys(Member.Status);
+    for (var i = 0; i < keys.length; ++i) {
+        counts[Member.Status[keys[i]]] = 0;
+    }
+    for (i = 0; i < this.members.length; ++i) {
+        counts[this.members[i].status] += 1;
+    }
+
+    this.emit('checksumUpdate', {
+        local: this.ringpop.whoami(),
+        timestamp: Date.now(),
+        checksum: this.checksum,
+        membershipStatusCounts: counts,
+    });
 };
 
 Membership.prototype.findMemberByAddress = function findMemberByAddress(address) {

--- a/lib/swim/join-sender.js
+++ b/lib/swim/join-sender.js
@@ -84,6 +84,7 @@ function JoinCluster(opts) {
 
     if (!opts.ringpop) {
         throw errors.OptionRequiredError({
+            context: 'ringpop',
             option: 'ringpop'
         });
     }

--- a/lib/trace/config.js
+++ b/lib/trace/config.js
@@ -19,22 +19,18 @@
 // THE SOFTWARE.
 'use strict';
 
-var noop = require('./noop.js');
-
-module.exports = {
-    waitForIdentified: function (opts, callback) {
-        callback(null)
-    },
-    quit: noop,
-    close: noop,
-    request: function request(/* options */) {
-        return {
-            send: function(url, head, body, cb) {
-                cb(null, {
-                    ok: true
-                });
+var eventConfigMap = {
+    'membership.checksum.update': {
+        sourcePath: ['membership', 'checksumUpdate'],
+        sinkOptsDefaults: {
+            log: {
+                message: '/trace/membership.checksum.update'
+            },
+            tchannel: {
+                endpoint: '/trace/membership.checksum.update'
             }
-        };
-    },
-    register: function register() {}
+        }
+    }
 };
+
+module.exports = eventConfigMap;

--- a/lib/trace/core.js
+++ b/lib/trace/core.js
@@ -1,0 +1,128 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var events = require('events');
+var util = require('util');
+
+var _ = require('underscore');
+
+var errors = require('../errors');
+
+var tracerConfigMap = require('./config');
+
+// resolves and returns a tracer config object, with
+// traceEvent, sourceEmitter, and sourceEvent bound
+function resolveEventConfig(ringpop, traceEvent) {
+    var tracerConfig = tracerConfigMap[traceEvent];
+    if (!tracerConfig) {
+        return null;
+    }
+    var sourcePath = tracerConfig.sourcePath;
+
+    // subtle but important -- if we resolve here, then the underlying object
+    // can never change. if we do latent resolution, there may be a resource
+    // leak when we try to remove listener from something that is out of our
+    // reachable scope.
+    var emitter = getIn(ringpop, sourcePath.slice(0, -1));
+    var event = _.last(sourcePath);
+
+    return emitter && _.defaults(
+        {},
+        {
+            sourceEmitter: emitter,
+            sourceEvent: event,
+            traceEvent: traceEvent
+        },
+        tracerConfig
+    );
+}
+
+function getIn(obj, path) {
+    for (var i = 0;
+         (typeof obj === 'object' || Array.isArray(obj)) && i < path.length;
+         ++i) {
+        obj = obj[path[i]];
+    }
+    return obj;
+}
+
+var tracerOptsDefaults = {
+    expiresIn: 60000, // ms
+    // expiresAt: Date.now() + 60000,
+    sink: {type: 'log'}
+};
+
+// base for sink-specific tracers:
+// A Tracer conjoins an internal node event and a user-defined sink,
+// automatically forwarding data.
+function Tracer(ringpop, config, opts) {
+    if (!(this instanceof Tracer)) {
+        return new Tracer(opts);
+    }
+
+    this.ringpop = ringpop;
+    _.extend(this, config);
+    this.opts = _.defaults({}, opts, tracerOptsDefaults);
+    this.listener = null;
+}
+util.inherits(Tracer, events.EventEmitter);
+
+Tracer.invalidateOptions = function invalidateOptions(opts) {
+    if (!opts) {
+        return errors.InvalidOptionError({option: 'opts', reason: 'is missing'});
+    }
+    if ((opts.expiresIn && opts.expiresAt) ||
+        !(opts.expiresIn || opts.expiresAt)) {
+        return errors.InvalidOptionError({
+            option: 'expires',
+            reason: 'must specify exactly one of expiresAt, expiresIn'});
+    }
+    if (!opts.sink) {
+        return errors.InvalidOptionError({option: 'sink', reason: 'is missing'});
+    }
+    return false;
+};
+
+Tracer.prototype.invalidate = function invalidate() {
+    return Tracer.invalidateOptions(this.opts);
+};
+
+Tracer.prototype.connectSource = function connectSource() {
+    if (!this.listener) {
+        this.listener = this.send.bind(this);
+        this.sourceEmitter.on(this.sourceEvent, this.listener);
+    }
+    process.nextTick(this.emit.bind(this, 'connectSource'));
+};
+
+Tracer.prototype.disconnectSource = function disconnectSource() {
+    if (this.listener) {
+        this.sourceEmitter.removeListener(this.sourceEvent, this.listener);
+    }
+    this.listener = null;
+    process.nextTick(this.emit.bind(this, 'disconnectSource'));
+};
+
+module.exports = {
+    resolveEventConfig: resolveEventConfig,
+    Tracer: Tracer
+};
+

--- a/lib/trace/index.js
+++ b/lib/trace/index.js
@@ -17,24 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 'use strict';
 
-var noop = require('./noop.js');
+module.exports = require('./store');
 
-module.exports = {
-    waitForIdentified: function (opts, callback) {
-        callback(null)
-    },
-    quit: noop,
-    close: noop,
-    request: function request(/* options */) {
-        return {
-            send: function(url, head, body, cb) {
-                cb(null, {
-                    ok: true
-                });
-            }
-        };
-    },
-    register: function register() {}
-};

--- a/lib/trace/log.js
+++ b/lib/trace/log.js
@@ -1,0 +1,131 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var _ = require('underscore');
+var util = require('util');
+
+var errors = require('../errors');
+
+var core = require('./core');
+
+//
+// Log forwarder
+//
+// opts = {
+//     sink: {
+//         // REQUIRED
+//         type: "log"
+//
+//         // OPTIONAL/HAS DEFAULTS
+//         level: 'info', // from [error,warn,info,debug,trace]
+//         message: 'trace'
+//     }
+// }
+//
+
+var logOptsDefaults = {
+    sink: {
+        type: 'log',
+        level: 'info',
+        message: 'trace'
+    }
+};
+
+var logLevels = {
+    error: true,
+    warn: true,
+    info: true,
+    debug: true,
+    trace: true
+};
+
+function LogTracer(ringpop, config, opts) {
+    if (!(this instanceof LogTracer)) {
+        return new LogTracer(opts);
+    }
+
+    opts.sink = _.defaults(
+        {},
+        opts.sink,
+        config.sinkOptsDefaults.log,
+        logOptsDefaults.sink
+    );
+    core.Tracer.call(this, ringpop, config, opts);
+
+    this.level = this.opts.sink.level;
+    this.message = opts.sink.message || null;
+}
+util.inherits(LogTracer, core.Tracer);
+
+
+LogTracer.prototype.invalidate = function invalidate() {
+    var sinkOpts = this.opts.sink;
+    var err = core.Tracer.prototype.invalidate.call(this);
+
+    if (err) {
+        return err;
+    }
+    if (!logLevels[sinkOpts.level]) {
+        return errors.InvalidOptionError({option: 'log.level', reason: 'is missing'});
+    }
+    return false;
+};
+
+LogTracer.prototype.connectSink = function connectSink(callback) {
+    if (callback) {
+        this.once('connectSink', callback);
+    }
+    process.nextTick(this.emit.bind(this, 'connectSink'));
+};
+
+LogTracer.prototype.disconnectSink = function disconnectSink(callback) {
+    if (callback) {
+        this.once('disconnectSink', callback);
+    }
+
+    this.disconnectSource();
+    process.nextTick(this.emit.bind(this, 'disconnectSink'));
+};
+
+LogTracer.prototype.send = function send(blob, callback) {
+    if (callback) {
+        this.once('send', callback);
+    }
+
+    if (Buffer.isBuffer(blob)) {
+        blob = blob.toString();
+    } else if (typeof blob === 'object') {
+        blob = JSON.stringify(blob);
+    }
+
+    this.ringpop.logger[this.level](this.message, blob);
+    process.nextTick(this.emit.bind(this, 'send'));
+};
+
+LogTracer.prototype.matches = function matches(traceEvent, opts) {
+    return (
+        this.traceEvent === traceEvent &&
+        opts.sink.type === 'log' &&
+        opts.sink.message === this.opts.sink.message);
+};
+
+
+module.exports = LogTracer;

--- a/lib/trace/store.js
+++ b/lib/trace/store.js
@@ -1,0 +1,165 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+//
+// A lightweight store for managing tracers.
+//
+
+var EventEmitter = require('events').EventEmitter;
+
+var _ = require('underscore');
+
+var core = require('./core');
+var types = require('./types');
+
+function TracerStore(ringpop, opts) {
+    opts = opts || {};
+    opts.timers = opts.timers || {};
+
+    if (!(this instanceof TracerStore)) {
+        return new TracerStore(ringpop);
+    }
+    this.ringpop = ringpop;
+    this.tracers = {};
+    this.timers = {
+        nextTick: opts.timers.nextTick || process.nextTick,
+        setTimeout: opts.timers.setTimeout || ringpop.setTimeout || setTimeout,
+        clearTimeout: opts.timers.clearTimeout || clearTimeout,
+        now: opts.timers.now || Date.now
+    };
+}
+require('util').inherits(TracerStore, EventEmitter);
+
+TracerStore.prototype.add = function add(config, opts, callback) {
+    var self = this;
+    var tracerOptsStr = JSON.stringify(opts);
+
+    if (callback) {
+        self.once('add', callback);
+    }
+
+    var err = core.Tracer.invalidateOptions(opts);
+    if (err) {
+        process.nextTick(self.emit.bind(self, 'add', err));
+        return null;
+    }
+
+    var tracer = self._get(config, opts);
+    if (!tracer) {
+        var TracerType = types[opts.sink.type];
+        tracer = new TracerType(self.ringpop, config, opts);
+        err = tracer.invalidate(opts);
+        if (err) {
+            process.nextTick(self.emit.bind(self, 'add', err));
+            return null;
+        }
+
+        var eventTracers = self.tracers[config.traceEvent];
+        if (!eventTracers) {
+            eventTracers = [];
+            self.tracers[config.traceEvent] = eventTracers;
+        }
+        eventTracers.push(tracer);
+
+        tracer.connectSink(function onConnect(err) {
+            if (err) {
+                self.remove(config, opts, null);
+                self.emit('add', err, null);
+                return;
+            }
+            tracer.connectSource();
+            self._updateExpiration(config, opts, tracer);
+            process.nextTick(self.emit.bind(self, 'add', null, tracerOptsStr));
+        });
+    } else {
+        self._updateExpiration(config, opts, tracer);
+        process.nextTick(self.emit.bind(self, 'add', null, tracerOptsStr));
+    }
+
+    return tracer;
+};
+
+TracerStore.prototype.remove = function remove(config, opts, callback) {
+    if (callback) {
+        this.once('remove', callback);
+    }
+
+    var tracer = null;
+    var i = this._indexOf(config, opts);
+    if (i >= 0) {
+        tracer = this.tracers[config.traceEvent][i];
+    }
+    if (tracer) {
+        if (tracer._timer) {
+            this.timers.clearTimeout(tracer._timer);
+            tracer._timer = null;
+        }
+        this.tracers[config.traceEvent].splice(i, 1);
+        tracer.disconnectSink();
+        tracer.disconnectSource();
+    }
+    this.emit('remove', null, tracer);
+    return tracer;
+};
+
+TracerStore.prototype._indexOf = function _indexOf(config, opts) {
+    var traceEvent = config.traceEvent;
+    var tracers = this.tracers[traceEvent] || [];
+    for (var i = 0; i < tracers.length; ++i) {
+        var tracer = tracers[i];
+        if (tracer.matches(traceEvent, opts)) {
+            return i;
+        }
+    }
+    return -1;
+};
+
+TracerStore.prototype._get = function _get(config, opts) {
+    var i = this._indexOf(config, opts);
+    return i >= 0 ? this.tracers[config.traceEvent][i] : null;
+};
+
+TracerStore.prototype._updateExpiration = function _updateExpiration(config, opts, tracer) {
+    var now = this.timers.now();
+    var newOffset = Math.max(0, opts.expiresIn || (opts.expiresAt - now));
+    var removeFn = this.remove.bind(this, config, opts);
+
+    if (tracer._timer) {
+        this.timers.clearTimeout(tracer._timer);
+        tracer._timer = null;
+    }
+
+    // 0/null offset implies already expired, thus don't re-add
+    if (newOffset) {
+        tracer._timer = this.timers.setTimeout(removeFn, newOffset);
+    }
+};
+
+TracerStore.prototype.destroy = function destroy() {
+    var self = this;
+    _.each(self.tracers, function removeTracer(tracer) {
+        self.remove(tracer.config, tracer.opts);
+    });
+    self.emit('destroyed');
+};
+
+module.exports = TracerStore;

--- a/lib/trace/tchannel.js
+++ b/lib/trace/tchannel.js
@@ -1,0 +1,176 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var _ = require('underscore');
+var util = require('util');
+
+var errors = require('../errors');
+
+var core = require('./core');
+
+//
+// TChannel forwarder
+//
+// opts = {
+//     sink: {
+//         // REQUIRED
+//         "type": "tchannel"
+//         "host-port": '1.2.3.4:5000',
+//
+//         // OPTIONAL/HAS DEFAULTS
+//         "service-name": 'ringpop',
+//         endpoint: 'trace-<event>'
+//     }
+// }
+//
+
+var tchannelOptsDefaults = {
+    sink: {
+        type: 'tchannel',
+        serviceName: 'ringpop',
+        endpoint: 'trace'
+    }
+};
+
+function TChannelTracer(ringpop, config, opts) {
+    opts.sink = _.defaults(
+        {},
+        opts.sink,
+        config.sinkOptsDefaults.tchannel,
+        tchannelOptsDefaults.sink
+    );
+    core.Tracer.call(this, ringpop, config, opts);
+}
+util.inherits(TChannelTracer, core.Tracer);
+
+
+TChannelTracer.prototype.invalidate = function invalidate() {
+    var sinkOpts = this.opts.sink;
+    var err = core.Tracer.prototype.invalidate.call(this);
+
+    if (err) {
+        return err;
+    }
+    if (!sinkOpts.serviceName) {
+        return errors.InvalidOptionError({option: 'tchannel.serviceName', reason: 'is missing'});
+    }
+    if (!sinkOpts.endpoint) {
+        return errors.InvalidOptionError({option: 'tchannel.endpoint', reason: 'is missing'});
+    }
+    return false;
+};
+
+TChannelTracer.prototype.connectSink = function connectSink(callback) {
+    if (callback) {
+        this.once('connectSink', callback);
+    }
+
+    var sinkOpts = this.opts.sink;
+    this.reqOpts = _.extend(
+        {
+            host: sinkOpts.hostPort,
+            timeout: 1000,
+            serviceName: 'ringpop',
+            hasNoParent: true,
+            trace: false,
+            retryLimit: 3,
+            headers: {
+                'as': 'raw',
+                'cn': 'ringpop'
+            }
+        },
+        _.omit(sinkOpts, 'type', 'hostPort')
+    );
+
+    this.ringpop.logger.info('ringpop TChannelTracer.connectSink', {
+        local: this.ringpop.whoami(),
+        reqOpts: this.reqOpts,
+    });
+
+    // trigger early identification, minimize latency
+    this.ringpop.channel.waitForIdentified(
+        _.pick(this.reqOpts, 'host'),
+        this._remoteCallback.bind(this, 'connectSink'));
+};
+
+TChannelTracer.prototype.disconnectSink = function disconnectSink(callback) {
+    var self = this;
+    if (callback) {
+        this.once('disconnectSink', callback);
+    }
+
+    process.nextTick(function() {
+        self.disconnectSource();
+        self.emit('disconnectSink');   
+    });
+};
+
+TChannelTracer.prototype.send = function send(blob, callback) {
+    if (callback) {
+        this.once('send', callback);
+    }
+
+    if (Buffer.isBuffer(blob)) {
+        blob = blob.toString();
+    } else if (typeof blob === 'object') {
+        blob = JSON.stringify(blob);
+    }
+
+    this.ringpop.channel
+        .request(this.reqOpts)
+        .send(this.reqOpts.endpoint, null, blob, this._remoteCallback.bind(this, 'send'));
+};
+
+TChannelTracer.prototype._remoteCallback = function _remoteCallback(event, err, resp) {
+    // May have to split this to handle tchannel network type errors to
+    // allow self removal. What's the right thing?
+    if (!err && resp && !resp.ok) {
+        err = new Error('ringpop TChannelTracer.' + event + ' received "notOk"');
+    }
+    if (err) {
+        if (typeof err !== 'object') {
+            err = new Error(err); // fallback for string
+        }
+        err.message = 'ringpop TChannelTracer.' + event + ': ' + err.message;
+        err.context = {
+            err: err,
+            message: err.message,
+            local: this.ringpop.whoami(),
+            reqOpts: this.reqOpts,
+        };
+        this.ringpop.logger.warn(err.message, err.context);
+        this.emit(event, err);
+        return;
+    }
+    this.emit(event, null, resp);
+};
+
+TChannelTracer.prototype.matches = function matches(traceEvent, opts) {
+    return (
+        this.traceEvent === traceEvent &&
+        opts.sink.type === 'tchannel' &&
+        _.isEqual(
+            _.pick(this.opts.sink, 'type', 'hostPort', 'endpoint'),
+            _.pick(opts.sink, 'type', 'hostPort', 'endpoint'))
+    );
+};
+
+module.exports = TChannelTracer;

--- a/lib/trace/types.js
+++ b/lib/trace/types.js
@@ -19,22 +19,12 @@
 // THE SOFTWARE.
 'use strict';
 
-var noop = require('./noop.js');
+var LogTracer = require('./log');
+var TChannelTracer = require('./tchannel');
 
-module.exports = {
-    waitForIdentified: function (opts, callback) {
-        callback(null)
-    },
-    quit: noop,
-    close: noop,
-    request: function request(/* options */) {
-        return {
-            send: function(url, head, body, cb) {
-                cb(null, {
-                    ok: true
-                });
-            }
-        };
-    },
-    register: function register() {}
+var tracers = {
+    tchannel: TChannelTracer,
+    log: LogTracer,
 };
+
+module.exports = tracers;

--- a/lib/util.js
+++ b/lib/util.js
@@ -79,6 +79,81 @@ function safeParse(str) {
     }
 }
 
+// lifted from rt--dispatch, and mod'd for here
+var lispOrSnakeCase = /([_-][a-z])/g;
+var camelCase = /([A-Z]+)/g;
+
+var toString = Object.prototype.toString;
+var isArray = Array.isArray;
+
+function isObject(obj) {
+    return toString.apply(obj) === '[object Object]';
+}
+
+function isString(obj) {
+    return typeof obj === 'string';
+}
+
+function replaceKeys(regex, replace, arg) {
+    if (arg === null || arg === undefined) {
+        return arg;
+    } else if (isString(arg)) {
+        return removeUnderscorePrefix(arg.replace(regex, replace), arg);
+    } else if (isArray(arg)) {
+        var newArray = [];
+
+        for (var i = 0; i < arg.length; i++) {
+            var item = arg[i];
+
+            if (isObject(item) || isArray(item)) {
+                newArray.push(replaceKeys(regex, replace, item));
+            } else {
+                newArray.push(item);
+            }
+        }
+
+        return newArray;
+    } else if (isObject(arg)) {
+        var newObj = {};
+        var keys = Object.keys(arg);
+
+        for (var j = 0; j < keys.length; j++) {
+            var key = keys[j];
+            var val = arg[key];
+            var newKey = key.replace(regex, replace);
+
+            newKey = removeUnderscorePrefix(newKey, key);
+
+            if (isObject(val) || isArray(val)) {
+                newObj[newKey] = replaceKeys(regex, replace, val);
+            } else {
+                newObj[newKey] = val;
+            }
+        }
+
+        return newObj;
+    } else {
+        return arg;
+    }
+}
+
+function replaceWithLispCase($1) {
+    return "-" + $1.toLowerCase();
+}
+
+function replaceWithSnakeCase($1) {
+    return "_" + $1.toLowerCase();
+}
+
+function replaceWithCamelCase($1) {
+    return $1.toUpperCase().replace('-', '').replace('_', '');
+}
+
+function removeUnderscorePrefix(newStr, oldStr) {
+    return (newStr.indexOf('_') === 0 && oldStr.indexOf('_') !== 0) ? newStr.substring(1) : newStr;
+}
+
+
 module.exports = {
     captureHost: captureHost,
     getTChannelVersion: getTChannelVersion,
@@ -86,5 +161,8 @@ module.exports = {
     mapUniq: mapUniq,
     numOrDefault: numOrDefault,
     parseArg: parseArg,
-    safeParse: safeParse
+    safeParse: safeParse,
+    toLispCase: replaceKeys.bind(null, camelCase, replaceWithLispCase),
+    toSnakeCase: replaceKeys.bind(null, camelCase, replaceWithSnakeCase),
+    toCamelCase: replaceKeys.bind(null, lispOrSnakeCase, replaceWithCamelCase)
 };

--- a/main.js
+++ b/main.js
@@ -21,18 +21,18 @@ var program = require('commander');
 var RingPop = require('./index');
 var TChannel = require('tchannel');
 
-function main() {
+function main(args) {
     program
         .version(require('./package.json').version)
         .usage('[options]')
         .option('-l, --listen <listen>', 'Host and port on which server listens (also node\'s identity in cluster)')
         .option('-h, --hosts <hosts>', 'Seed file of list of hosts to join')
-        .parse(process.argv);
+        .parse(args);
 
     var listen = program.listen;
-
     if (!listen) {
         console.error('Error: listen arg is required');
+        program.outputHelp();
         process.exit(1);
     }
 
@@ -60,12 +60,9 @@ function main() {
     ringpop.channel.listen(Number(listenParts[1]), listenParts[0]);
 }
 
-if (require.main === module) {
-    main();
-}
-
 function createLogger(name) {
     return {
+        trace: function noop() {},
         debug: function noop() {},
         info: enrich('info', 'log'),
         warn: enrich('warn', 'error'),
@@ -80,3 +77,8 @@ function createLogger(name) {
         };
     }
 }
+
+if (require.main === module) {
+    main(process.argv);
+}
+module.exports = main;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ringpop",
   "description": "Scalable, fault-tolerant application-layer sharding",
   "contributors": [
+    "ben fleis <ben.fleis@gmail.com>",
     "Alex Hauser <ahauser@uber.com>",
     "Rui Hu <ruihu.pvt@gmail.com>",
     "Bob Nugmanov <bob.nugmanov@gmail.com>",
@@ -16,12 +17,13 @@
     "ringpop": "./main.js"
   },
   "scripts": {
-    "test": "npm run jshint && node test/index.js",
-    "test-integration": "node test/integration/index.js",
-    "test-unit": "node test/unit/index.js",
+    "test": "npm run jshint && node test/index.js | faucet",
+    "test-debug": "node debug test/index.js",
+    "test-integration": "node test/integration/index.js | faucet",
+    "test-unit": "node test/unit/index.js | faucet",
     "add-licence": "uber-licence",
     "check-licence": "uber-licence --dry",
-    "cover": "istanbul cover --print detail --report html test/index.js",
+    "cover": "istanbul cover --print detail --report html test/index.js | faucet",
     "jshint": "jshint --verbose *.js lib/**/*.js scripts/*.js server/**/*.js",
     "travis": "npm run cover -s && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)",
     "view-cover": "opn coverage/index.html"
@@ -44,6 +46,7 @@
     "commander": "^2.6.0",
     "coveralls": "^2.11.2",
     "debug-logtron": "^2.1.0",
+    "faucet": "^0.0.1",
     "format-stack": "4.1.0",
     "glob": "^4.3.1",
     "istanbul": "^0.3.5",

--- a/server/index.js
+++ b/server/index.js
@@ -19,16 +19,19 @@
 // THE SOFTWARE.
 'use strict';
 
+
 function RingPopTChannel(ringpop, tchannel) {
-    this.ringpop = ringpop;
-    this.tchannel = tchannel;
+    var self = this;
+    self.ringpop = ringpop;
+    self.tchannel = tchannel;
 
     registerEndpointHandlers(require('./admin'));
     registerEndpointHandlers(require('./protocol'));
+    registerEndpointHandlers(require('./trace'));
 
     // Register stragglers ;)
     var createProxyReqHandler = require('./proxy-req.js');
-    registerEndpoint('/proxy/req', createProxyReqHandler(this.ringpop));
+    registerEndpoint('/proxy/req', createProxyReqHandler(self.ringpop));
 
     var createHealthHandler = require('./health.js');
     registerEndpoint('/health', createHealthHandler());
@@ -50,6 +53,7 @@ function RingPopTChannel(ringpop, tchannel) {
             function onResponse(err, res1, res2) {
                 res.headers.as = 'raw';
                 if (err) {
+                    self.ringpop.logger.warn(err.message, err);
                     res.sendNotOk(null, err.message);
                 } else {
                     res.sendOk(res1, res2);

--- a/server/trace.js
+++ b/server/trace.js
@@ -1,0 +1,66 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var errors = require('../lib/errors');
+var safeParse = require('../lib/util').safeParse;
+var toCamelCase = require('../lib/util').toCamelCase;
+var traceCore = require('../lib/trace/core');
+
+module.exports = {
+    addTrace: {
+        endpoint: '/trace/add',
+        handler: createAddTrace,
+    },
+    removeTrace: {
+        endpoint: '/trace/remove',
+        handler: createRemoveTrace,
+    },
+};
+
+function createAddTrace(ringpop) {
+    return function addTrace(head, body, peerInfo, cb) {
+        _updateTracers(ringpop, 'add', body, cb);
+    };
+}
+
+function createRemoveTrace(ringpop) {
+    return function removeTrace(head, body, peerInfo, cb) {
+        _updateTracers(ringpop, 'remove', body, cb);
+    };
+}
+
+function _updateTracers(ringpop, fnStr, optsStr, cb) {
+    var opts = toCamelCase(safeParse(optsStr));
+    var config = traceCore.resolveEventConfig(ringpop, opts.event);
+    if (!config) {
+        var err = errors.InvalidOptionError({ option: 'event', reason: 'it is unknown'});
+        ringpop.logger.warn('ringpop: unknown Trace Event specified', {
+            local: ringpop.whoami(),
+            err: err
+        });
+        cb(err);
+        return;
+    } else {
+        ringpop.tracers[fnStr](config, opts, cb);
+        return;
+    }
+}

--- a/test/lib/test-ringpop-cluster.js
+++ b/test/lib/test-ringpop-cluster.js
@@ -57,7 +57,7 @@ function bootstrapClusterOf(opts, onBootstrap) {
 
     cluster.forEach(function each(ringpop, i) {
         var parts = ringpop.hostPort.split(':');
-        ringpop.channel.on('listening', function listened() {
+        ringpop.__channel.on('listening', function listened() {
             ringpop.channel.removeListener('listening', listened);
 
             var cb = Array.isArray(onBootstrap) ?
@@ -66,7 +66,7 @@ function bootstrapClusterOf(opts, onBootstrap) {
                 bootstrapFile: bootstrapHosts
             }, cb);
         });
-        ringpop.channel.listen(Number(parts[1]), parts[0]);
+        ringpop.__channel.listen(Number(parts[1]), parts[0]);
     });
 
     return cluster;

--- a/test/trace-test.js
+++ b/test/trace-test.js
@@ -1,0 +1,138 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+
+var test = require('tape');
+var Timer = require('time-mock');
+
+var core = require('../lib/trace/core');
+var TracerStore = require('../lib/trace/store');
+
+var timer = Timer(1000);
+// workaround timer id 0 by setting a throwaway, increments to 1
+timer.setTimeout(function() {}, 0);
+
+var timers = {
+    setTimeout: timer.setTimeout,
+    clearTimeout: timer.clearTimeout,
+    now: timer.now,
+};
+
+test('trace adds/removes work and are idempotent', function t(assert) {
+    assert.plan(13);
+
+    var ringpop = new RingpopMock();
+    var store = new TracerStore(ringpop);
+
+    var config = core.resolveEventConfig(ringpop, 'membership.checksum.update');
+    assert.ok(config, 'event resolves');
+    assert.equal(config.sourceEmitter, ringpop.membership, 'config has right membership emitter');
+    var opts = {expiresIn: 50, sink: {type: 'log'}};
+
+    // remove from nothing, then add, and again. should end with one tracer
+    store.remove(config, opts, function onRemove(err, tracer) {
+        assert.false(err, 'no error, idempotent remove');
+        assert.false(tracer, 'no tracer, idempotent remove');
+    });
+
+    var theTracer = store.add(config, opts, function onAdd(err, tracerOptsStr) {
+        assert.false(err, 'no error, add good');
+        assert.true(tracerOptsStr, 'tracer added');
+    });
+    assert.true(theTracer, 'tracer added, double checking');
+
+    store.add(config, opts, function onAdd(err, tracerOptsStr) {
+        assert.false(err, 'no error, idempotent add');
+        assert.true(tracerOptsStr, 'tracer already added');
+    });
+
+    // remove twice, checking both times
+    store.remove(config, opts, function onRemove(err, tracerOptsStr) {
+        assert.false(err, 'no error, idempotent remove');
+        assert.true(tracerOptsStr, 'tracer removed');
+    });
+
+    store.remove(config, opts, function onRemove(err, tracerOptsStr) {
+        assert.false(err, 'no error, idempotent remove');
+        assert.false(tracerOptsStr, 'tracer already removed');
+    });
+});
+
+test('trace events get traced', function t(assert) {
+    var ringpop = new RingpopMock();
+    var store = new TracerStore(ringpop);
+    var config = core.resolveEventConfig(ringpop, 'membership.checksum.update');
+    var opts = {expiresIn: 50, sink: {type: 'log'}};
+    var tracer = store.add(config, opts);
+
+    assert.plan(5);
+    tracer.on('connectSink', function onTracer() {
+        // now test events on this thing
+        assert.equal(ringpop.journal.length, 0, 'journal starts empty');
+        ringpop.membership.emit('checksumUpdate', 'foo');
+        assert.equal(ringpop.journal.length, 1, 'journal has 1 entry');
+        assert.equal(ringpop.journal[0], 'foo', 'journal added foo');
+
+        ringpop.membership.emit('checksumUpdate', 'bar');
+        assert.equal(ringpop.journal.length, 2, 'journal has 2 entries');
+        assert.equal(ringpop.journal[1], 'bar', 'journal added bar');
+    });
+});
+
+test('trace events can renew, and expire', function t(assert) {
+    var ringpop = new RingpopMock();
+    var store = new TracerStore(ringpop, { timers: timers });
+    var config = core.resolveEventConfig(ringpop, 'membership.checksum.update');
+    var opts = {expiresIn: 50, sink: {type: 'log'}};
+    store.add(config, opts);
+
+    assert.plan(3);
+
+    // nextTick okay since log "connects" instantly
+    process.nextTick(function onTracer() {
+        ringpop.membership.emit('checksumUpdate', 'foo');
+        assert.equal(ringpop.journal.length, 1, 'trace added correctly');
+
+        timer.advance(25);
+        store.add(config, opts);
+
+        timer.advance(49);
+        ringpop.membership.emit('checksumUpdate', 'bar');
+        assert.equal(ringpop.journal.length, 2, 'trace readd survived timeout');
+
+        timer.advance(1);
+        ringpop.membership.emit('checksumUpdate', 'dropped');
+        assert.equal(ringpop.journal.length, 2, 'timer dropped trace @timeout');
+    });
+});
+
+// dumbest of mocks for our trace element
+function RingpopMock() {
+    var journal = [];
+    this.journal = journal;
+    this.logger = {
+        info: function(_, data) { journal.push(data); },
+        warn: function(_, data) { journal.push(data); },
+    };
+    this.membership = new EventEmitter();
+}


### PR DESCRIPTION
to tchannel or the given logger object.

event tracers allow a live ringpop system to dynamically foward internal
events to arbitrary events, creating space for ephemeral live event
analysis and diagnostics in running clusters.

see https://github.com/uber/ringpop/issues/139

This diff is *incomplete* -- tests are not added yet, and there are several open XXX questions for @jwolski (or others, wink wink @raynos) to consider addressing.