### PR TITLE
Flap damp scoring

### DIFF
--- a/config.js
+++ b/config.js
@@ -40,8 +40,8 @@ Config.prototype.get = function get(key) {
 Config.prototype.set = function set(key, value) {
     var oldValue = this.store[key];
     this.store[key] = value;
-    this.emit('changed', key, value, oldValue);
-    this.emit('changed.' + key, value, oldValue);
+    this.emit('set', key, value, oldValue);
+    this.emit('set.' + key, value, oldValue);
 };
 
 Config.prototype._seed = function _seed(seed) {

--- a/config.js
+++ b/config.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var util = require('util');
+
+// This Config class is meant to be a central store
+// for configurable parameters in Ringpop. Parameters
+// are meant to be initialized in the constructor.
+function Config(seedConfig) {
+    seedConfig = seedConfig || {};
+    this.store = {};
+    this._seed(seedConfig);
+}
+
+util.inherits(Config, EventEmitter);
+
+Config.prototype.get = function get(key) {
+    return this.store[key];
+};
+
+Config.prototype.set = function set(key, value) {
+    var oldValue = this.store[key];
+    this.store[key] = value;
+    this.emit('changed', key, value, oldValue);
+    this.emit('changed.' + key, value, oldValue);
+};
+
+Config.prototype._seed = function _seed(seed) {
+    var self = this;
+
+    // All config names should be camel-cased.
+    seedOrDefault('TEST_KEY', 100); // never remove, tests and lives depend on it
+    seedOrDefault('dampScoringEnabled', true);
+    seedOrDefault('dampScoringDecayEnabled', true);
+    seedOrDefault('dampScoringDecayInternval', 1000);
+    seedOrDefault('dampScoringHalfLife', 60);
+    // TODO Initial should never be below min nor above max
+    seedOrDefault('dampScoringInitial', 0);
+    seedOrDefault('dampScoringMax', 10000);
+    seedOrDefault('dampScoringMin', 0);
+    seedOrDefault('dampScoringPenalty', 500);
+    seedOrDefault('dampScoringReuseLimit', 2500);
+    seedOrDefault('dampScoringSuppressDuration', 60 * 60 * 1000); // 1 hr in ms
+    seedOrDefault('dampScoringSuppressLimit', 5000);
+
+    function seedOrDefault(name, defaultVal) {
+        var seedVal = seed[name];
+        if (typeof seedVal === 'undefined') {
+            self.set(name, defaultVal);
+        } else {
+            self.set(name, seedVal);
+        }
+    }
+};
+
+module.exports = Config;

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -24,15 +24,20 @@ var EventEmitter = require('events').EventEmitter;
 var farmhash = require('farmhash');
 var Member = require('./member.js');
 var mergeMembershipChangesets = require('./merge.js');
+var timers = require('timers');
 var util = require('util');
 var uuid = require('node-uuid');
 
-function Membership(ringpop) {
-    this.ringpop = ringpop;
+function Membership(opts) {
+    this.ringpop = opts.ringpop; // assumed to be present
+    this.setTimeout = opts.setTimeout || timers.setTimeout;
+    this.clearTimeout = opts.clearTimeout || timers.clearTimeout;
+
     this.members = [];
     this.membersByAddress = {};
     this.checksum = null;
     this.stashedUpdates = [];
+    this.decayTimer = null;
 }
 
 util.inherits(Membership, EventEmitter);
@@ -191,9 +196,7 @@ Membership.prototype.set = function set() {
 
     for (var i = 0; i < updates.length; i++) {
         var update = updates[i];
-
-        var member = new Member(this.ringpop, update);
-
+        var member = this._createMember(update);
         this.members.push(member);
         this.membersByAddress[member.address] = member;
     }
@@ -238,7 +241,7 @@ Membership.prototype.update = function update(changes, isLocal) {
         var member = this.findMemberByAddress(change.address);
 
         if (!member) {
-            member = new Member(this.ringpop, change);
+            member = this._createMember(change);
 
             // localMember is carried around as a convenience.
             if (member.address === this.ringpop.whoami()) {
@@ -285,8 +288,59 @@ Membership.prototype.shuffle = function shuffle() {
     this.members = _.shuffle(this.members);
 };
 
+Membership.prototype.startDampScoreDecayer = function startDampScoreDecayer() {
+    var self = this;
+
+    if (this.decayTimer) {
+        return;
+    }
+
+    schedule();
+
+    function schedule() {
+        var config = self.ringpop.config; // for convenience
+        if (!config.get('dampScoringDecayEnabled')) {
+            return;
+        }
+
+        self.decayTimer = self.setTimeout(function onTimeout() {
+            self._decayMembersDampScore();
+            schedule(); // loop until stopped or disabled
+        }, config.get('dampScoringDecayInterval'));
+    }
+};
+
+Membership.prototype.stopDampScoreDecayer = function stopDampScoreDecayer() {
+    if (this.decayTimer) {
+        clearTimeout(this.decayTimer);
+        this.decayTimer = null;
+    }
+};
+
 Membership.prototype.toString = function toString() {
     return JSON.stringify(_.pluck(this.members, 'address'));
+};
+
+Membership.prototype._createMember = function _createMember(update) {
+    var self = this;
+
+    var member = new Member(this.ringpop, update);
+    member.on('suppressLimitExceeded', onExceeded);
+    return member;
+
+    function onExceeded() {
+        self.emit('memberSuppressLimitExceeded', member);
+    }
+};
+
+Membership.prototype._decayMembersDampScore = function _decayMembersDampScore() {
+    // TODO Slightly inefficient. We don't need to run through the entire
+    // membership list decaying damp scores. We really only need to decay
+    // the scores of members that have not had their scores reset to 0.
+    // Consider a more efficient decay mechanism.
+    for (var i = 0; i < this.members.length; i++) {
+        this.members[i].decayDampScore();
+    }
 };
 
 Membership.prototype._makeUpdate = function _makeUpate(address,
@@ -318,4 +372,23 @@ Membership.prototype._makeUpdate = function _makeUpate(address,
     return updates;
 };
 
-module.exports = Membership;
+module.exports = function initMembership(ringpop) {
+    // It would be more correct to start Membership's background decayer once
+    // we know that a member has been penalized for a flap. But it's
+    // OK to start prematurely.
+    var membership = new Membership({
+        ringpop: ringpop
+    });
+    membership.on('memberSuppressLimitExceeded', onExceeded);
+    membership.startDampScoreDecayer();
+    ringpop.on('destroyed', onDestroyed);
+    return membership;
+
+    function onDestroyed() {
+        membership.stopDampScoreDecayer();
+    }
+
+    function onExceeded(/*member*/) {
+        // TODO Initiate flap damping subprotocol
+    }
+};

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -113,7 +113,8 @@ Member.prototype.getStats = function getStats() {
     return {
         address: this.address,
         status: this.status,
-        incarnationNumber: this.incarnationNumber
+        incarnationNumber: this.incarnationNumber,
+        dampScore: this.dampScore
     };
 };
 

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -28,9 +28,38 @@ function Member(ringpop, update) {
     this.address = update.address;
     this.status = update.status;
     this.incarnationNumber = update.incarnationNumber;
+    this.dampScore = update.dampScore || ringpop.config.get('dampScoringInitial');
+    this.dampedTimestamp = update.dampedTimestamp;
+
+    this.lastUpdateTimestamp = null;
+    this.lastUpdateDampScore = this.dampScore;
+    this.Date = Date;
 }
 
 util.inherits(Member, EventEmitter);
+
+Member.prototype.decayDampScore = function decayDampScore() {
+    var config = this.ringpop.config; // for convenience
+
+    if (this.dampScore === null || typeof this.dampScore === 'undefined') {
+        this.dampScore = config.get('dampScoringInitial');
+        return;
+    }
+
+    // Apply exponential decay of damp score, formally:
+    // score(t2) = score(t1) * e^(-(t2-t1) * ln2 / halfLife)
+    var timeSince = (this.Date.now() - this.lastUpdateTimestamp) / 1000; // in seconds
+    var decay = Math.pow(Math.E, -1 * timeSince * Math.LN2 /
+        config.get('dampScoringHalfLife'));
+
+    // - Round to nearest whole. Scoring doesn't need any finer precision.
+    // - Keep within lower bound.
+    var oldDampScore = this.dampScore;
+    this.dampScore = Math.max(Math.round(this.lastUpdateDampScore * decay),
+        config.get('dampScoringMin'));
+
+    this.emit('dampScoreDecayed', this.dampScore, oldDampScore);
+};
 
 // This function is named with the word "evaluate" because it is not
 // guaranteed that the update will be applied. Naming it "update()"
@@ -44,7 +73,7 @@ Member.prototype.evaluateUpdate = function evaluateUpdate(update) {
         // Override intended update. Assert aliveness!
         update = _.defaults({
             status: Member.Status.alive,
-            incarnationNumber: Date.now()
+            incarnationNumber: this.Date.now()
         }, update);
     } else if (!this._isOtherOverride(update)) {
         return;
@@ -59,7 +88,23 @@ Member.prototype.evaluateUpdate = function evaluateUpdate(update) {
         this.incarnationNumber = update.incarnationNumber;
     }
 
+    // For damping. Also, you are not allowed to penalize yourself.
+    if (this.ringpop.config.get('dampScoringEnabled') &&
+            update.address !== this.ringpop.whoami()) {
+        // So far, this is very liberal treatment of a flap. Any update
+        // will be penalized. The scoring levers will control persistent
+        // flaps. We'll eventually get _real_ good at identifying flaps
+        // and apply penalties more strictly.
+        this._applyUpdatePenalty();
+        this.lastUpdateDampScore = this.dampScore;
+    }
+
     this.emit('updated', update);
+
+    // lastUpdateTimestamp must be updated after the penalty is applied
+    // because decaying the damp score uses the last timestamp to calculate
+    // the rate of decay.
+    this.lastUpdateTimestamp = this.Date.now();
 
     return true;
 };
@@ -70,6 +115,28 @@ Member.prototype.getStats = function getStats() {
         status: this.status,
         incarnationNumber: this.incarnationNumber
     };
+};
+
+Member.prototype._applyUpdatePenalty = function _applyUpdatePenalty() {
+    var config = this.ringpop.config; // var defined for convenience
+
+    this.decayDampScore();
+
+    // Keep within upper bound
+    this.dampScore = Math.min(this.dampScore + config.get('dampScoringPenalty'),
+        config.get('dampScoringMax'));
+
+    var suppressLimit = config.get('dampScoringSuppressLimit');
+    if (this.dampScore > suppressLimit) {
+        this.emit('suppressLimitExceeded');
+
+        this.ringpop.logger.info('ringpop member damp score exceeded suppress limit', {
+            local: this.ringpop.whoami(),
+            member: this.address,
+            dampScore: this.dampScore,
+            suppressLimit: suppressLimit
+        });
+    }
 };
 
 Member.prototype._isLocalOverride = function _isLocalOverride(update) {

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -21,6 +21,7 @@
 
 var _ = require('underscore');
 var EventEmitter = require('events').EventEmitter;
+var numOrDefault = require('../util.js').numOrDefault;
 var util = require('util');
 
 function Member(ringpop, update) {
@@ -28,7 +29,8 @@ function Member(ringpop, update) {
     this.address = update.address;
     this.status = update.status;
     this.incarnationNumber = update.incarnationNumber;
-    this.dampScore = update.dampScore || ringpop.config.get('dampScoringInitial');
+    this.dampScore = numOrDefault(update.dampScore,
+        ringpop.config.get('dampScoringInitial'));
     this.dampedTimestamp = update.dampedTimestamp;
 
     this.lastUpdateTimestamp = null;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "test": "npm run jshint && node test/index.js",
     "test-integration": "node test/integration/index.js",
+    "test-unit": "node test/unit/index.js",
     "add-licence": "uber-licence",
     "check-licence": "uber-licence --dry",
     "cover": "istanbul cover --print detail --report html test/index.js",

--- a/scripts/tick-cluster.js
+++ b/scripts/tick-cluster.js
@@ -23,7 +23,6 @@
 
 var childProc = require('child_process');
 var color = require('cli-color');
-var farmhash = require('farmhash').hash32;
 var generateHosts = require('./generate-hosts');
 var program = require('commander');
 var TChannel = require('tchannel');
@@ -127,12 +126,12 @@ function statsAll() {
             if (err) {
                 console.log(color.red('err: ' + err.message + ' [' + host + ']'));
             } else {
-                var membership = JSON.stringify(safeParse(arg3).membership.members);
-                
-                var csum = farmhash(membership);
+                var membership = safeParse(arg3).membership;
+                var csum = membership.checksum;
+
                 if (csums[csum] === undefined) {
                     csums[csum] = [];
-                    memberships[csum] = membership;
+                    memberships[csum] = JSON.stringify(membership.members);
                 }
 
                 var port = host.replace(localIP + ':', '');

--- a/test/lib/test-ringpop.js
+++ b/test/lib/test-ringpop.js
@@ -39,7 +39,10 @@ function testRingpop(opts, name, test) {
 
         ringpop.membership.makeAlive(ringpop.whoami(), Date.now());
 
+        // These are made top-level dependencies as a mere
+        // convenience to users of the test suite.
         var deps = {
+            config: ringpop.config,
             dissemination: ringpop.dissemination,
             gossip: ringpop.gossip,
             iterator: ringpop.memberIterator,

--- a/test/unit/config_test.js
+++ b/test/unit/config_test.js
@@ -1,0 +1,80 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var Config = require('../../config.js');
+var test = require('tape');
+
+test('set and get interactions', function t(assert) {
+    var config = new Config();
+
+    var configKey = 'testconfig';
+    var expectedVal = 100;
+    config.set(configKey, expectedVal);
+
+    assert.equals(expectedVal, config.get(configKey), 'set and get works');
+    assert.end();
+});
+
+test('changed events', function t(assert) {
+    assert.plan(2);
+
+    var config = new Config();
+    config.on('changed', onConfigChanged);
+    var configKey = 'somekey';
+    config.on('changed.' + configKey, onConfigKeyChanged);
+    var configVal = 'someval';
+    config.set(configKey, configVal); // this triggers change events *fingers crossed*
+
+    assert.end();
+
+    function onConfigChanged() {
+        assert.pass('changed');
+    }
+
+    function onConfigKeyChanged() {
+        assert.pass('key changed');
+    }
+});
+
+test('seeds known config', function t(assert) {
+    var knownKey = 'TEST_KEY';
+    var knownVal = 200;
+    var unknownKey = 'unknown';
+    var unknownVal = 100;
+    var seed = {};
+    seed[knownKey] = knownVal;
+    seed[unknownKey] = unknownVal;
+
+    var config = new Config(seed);
+
+    assert.equals(knownVal, config.get(knownKey), 'known config is seeded');
+    assert.equals(undefined, config.get(unknownKey),
+        'unknown config is not seeded');
+    assert.end();
+});
+
+test('no seed is OK', function t(assert) {
+    assert.doesNotThrow(function it() {
+        /* jshint nonew: false */
+        new Config(null);
+    });
+    assert.end();
+});

--- a/test/unit/config_test.js
+++ b/test/unit/config_test.js
@@ -37,21 +37,17 @@ test('changed events', function t(assert) {
     assert.plan(2);
 
     var config = new Config();
-    config.on('changed', onConfigChanged);
+    config.on('set', function onSet() {
+        assert.pass('set');
+    });
     var configKey = 'somekey';
-    config.on('changed.' + configKey, onConfigKeyChanged);
+    config.on('set.' + configKey, function onKeySet() {
+        assert.pass('key set');
+    });
     var configVal = 'someval';
     config.set(configKey, configVal); // this triggers change events *fingers crossed*
 
     assert.end();
-
-    function onConfigChanged() {
-        assert.pass('changed');
-    }
-
-    function onConfigKeyChanged() {
-        assert.pass('key changed');
-    }
 });
 
 test('seeds known config', function t(assert) {

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// You might ask, what belongs in this unit test directory? The answer:
+// anything test that strictly depends one and only one module. It does
+// not test the interactions of many modules nor does it require you
+// to stand up and bootstrap a single node or multi-node Ringpop cluster.
+'use strict';
+
+require('./config_test.js');
+require('./member_test.js');
+require('./membership_test.js');

--- a/test/unit/member_test.js
+++ b/test/unit/member_test.js
@@ -1,0 +1,201 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var Member = require('../../lib/membership/member.js');
+var testRingpop = require('../lib/test-ringpop.js');
+
+function addSecondMember(membership, address) {
+    membership.update([{
+        address: address,
+        status: Member.Status.alive,
+        incarnationNumber: 1
+    }]);
+
+    return membership.findMemberByAddress(address);
+}
+
+testRingpop('damp score intialized', function t(deps, assert) {
+    var config = deps.config;
+    var membership = deps.membership;
+    var member2 = addSecondMember(membership, '127.0.0.1:3001');
+    assert.equals(member2.dampScore, config.get('dampScoringInitial'),
+        'damp score is initialized');
+});
+
+testRingpop('penalized for update', function t(deps, assert) {
+    var membership = deps.membership;
+    var member2 = addSecondMember(membership, '127.0.0.1:3001');
+    member2.evaluateUpdate({
+        status: Member.Status.suspect,
+        incarnationNumber: Date.now() + 1
+    });
+    var config = deps.config;
+    assert.notEqual(member2.dampScore, config.get('dampScoringInitial'),
+        'damp score adjusted');
+});
+
+testRingpop('flaps until exceeds suppress limit', function t(deps, assert) {
+    assert.plan(2);
+
+    var config= deps.config;
+    config.set('dampScoringMax', 1000);
+    config.set('dampScoringSuppressLimit', 500);
+    config.set('dampScoringPenalty', 251); // 2 updates is all it'll take
+
+    var membership = deps.membership;
+    var member2 = addSecondMember(membership, '127.0.0.1:3001');
+    member2.on('suppressLimitExceeded', onExceeded);
+    member2.evaluateUpdate({
+        status: Member.Status.suspect,
+        incarnationNumber: Date.now() + 1
+    });
+    member2.evaluateUpdate({
+        status: Member.Status.faulty,
+        incarnationNumber: Date.now() + 2
+    });
+    assert.true(member2.dampScore > config.get('dampScoringSuppressLimit'),
+        'damp score exceeds suppress limit');
+
+    function onExceeded() {
+        assert.pass('suppress limit exceeded');
+    }
+});
+
+testRingpop('damp score never exceeds max', function t(deps, assert) {
+    var config= deps.config;
+    config.set('dampScoringMax', 1000);
+    // Penalty of this size will reach max after one update
+    config.set('dampScoringPenalty', 5000);
+
+    var membership = deps.membership;
+    var member2 = addSecondMember(membership, '127.0.0.1:3001');
+    member2.evaluateUpdate({
+        status: Member.Status.suspect,
+        incarnationNumber: Date.now() + 1
+    });
+    assert.true(member2.dampScore === config.get('dampScoringMax'),
+        'damp score equals max');
+});
+
+testRingpop('penalized in penalty increments', function t(deps, assert) {
+    var config= deps.config;
+    config.set('dampScoringMax', 1000);
+    config.set('dampScoringPenalty', 100);
+
+    var membership = deps.membership;
+    var member2 = addSecondMember(membership, '127.0.0.1:3001');
+
+    // First penalty
+    member2.evaluateUpdate({
+        status: Member.Status.suspect,
+        incarnationNumber: Date.now() + 1
+    });
+    assert.true(member2.dampScore === config.get('dampScoringPenalty'),
+        'damp score is penalty');
+
+    // Second
+    member2.evaluateUpdate({
+        status: Member.Status.suspect,
+        incarnationNumber: Date.now() + 2
+    });
+    assert.true(member2.dampScore === config.get('dampScoringPenalty') * 2,
+        'damp score is multiple of penalty');
+
+    // Third
+    member2.evaluateUpdate({
+        status: Member.Status.suspect,
+        incarnationNumber: Date.now() + 3
+    });
+    assert.true(member2.dampScore === config.get('dampScoringPenalty') * 3,
+        'damp score is multiple of penalty');
+});
+
+function decayBy(member, term) {
+    // Decay rate is based on time since last update. Make it seem
+    // as though time has advanced.
+    member.Date = {
+        now: function now() {
+            return Date.now() + term
+        }
+    };
+    member.decayDampScore();
+}
+
+testRingpop('decays by some arbitrary amount', function t(deps, assert) {
+    var membership = deps.membership;
+    var member2 = addSecondMember(membership, '127.0.0.1:3001');
+    member2.evaluateUpdate({
+        status: Member.Status.suspect,
+        incarnationNumber: Date.now() + 1
+    });
+
+    var origDampScore = member2.dampScore;
+    // Granularity of decay is in seconds. Set term to 1 greater.
+    decayBy(member2, 1000 + 1);
+    assert.true(member2.dampScore < origDampScore,
+        'damp score has decayed');
+});
+
+testRingpop('decayed by half', function t(deps, assert) {
+    var membership = deps.membership;
+    var member2 = addSecondMember(membership, '127.0.0.1:3001');
+    member2.evaluateUpdate({
+        status: Member.Status.suspect,
+        incarnationNumber: Date.now() + 1
+    });
+
+    var origDampScore = member2.dampScore;
+    var config = deps.config;
+    // * 1000 because half-life is in seconds
+    decayBy(member2, config.get('dampScoringHalfLife') * 1000);
+    assert.true(origDampScore / 2, 'damp score has decayed by half');
+});
+
+testRingpop('never decays below min', function t(deps, assert) {
+    var config = deps.config;
+    config.set('dampScoringInitial', 0);
+    config.set('dampScoringPenalty', 100);
+    config.set('dampScoringMin', 100);
+    config.set('dampScoringMax', 1000);
+
+    var membership = deps.membership;
+    var member2 = addSecondMember(membership, '127.0.0.1:3001');
+    member2.evaluateUpdate({
+        status: Member.Status.suspect,
+        incarnationNumber: Date.now() + 1
+    });
+
+    // Penalize until max reached
+    var i = 1;
+    while (member2.dampScore < config.get('dampScoringMax')) {
+        member2.evaluateUpdate({
+            status: Member.Status.suspect,
+            incarnationNumber: Date.now() + i
+        });
+        i++;
+    }
+
+    // After 4 half-lives decay should have dropped below min (given
+    // damp scoring config params set above)
+    decayBy(member2, config.get('dampScoringHalfLife') * 1000 * 4);
+    assert.true(member2.dampScore === config.get('dampScoringMin'),
+        'damp score decayed to min');
+});


### PR DESCRIPTION
This is the first of several PRs to come for flap damping. The first is damp scoring. A member in the membership list will be penalized for every update that is applied. When the damp score exceeds the configured damp suppress limit, an event will be emitted. Later, this event will initiate the damping subprotocol. (That's the next PR to come). The damp scores for all members decay exponentially, its periodicity governed by another configurable parameter. 

I left a few cheeky comments and added a few bells/whistles (like the separate Config object) to this PR to accompany the scoring. Don't mind them too much.

The test coverage is fairly reasonable.

Oh, and also... tick-cluster needed a bit of fixing. A member's damp score is now part of the returned stats. The way tick-cluster previously computed checksums for membership was too restrictive.

There's actually no net gain in terms of functionality in this PR. It's simply a mechanism to start scoring members and learning about scoring, in general.

@danielheller @benfleis @CorgiMan 