### PR TITLE
Add make-* stats

### DIFF
--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -151,19 +151,23 @@ Membership.prototype.isPingable = function isPingable(member) {
 };
 
 Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber) {
+    this.ringpop.stat('increment', 'make-alive');
     return this._makeUpdate(address, incarnationNumber, Member.Status.alive,
         address === this.ringpop.whoami());
 };
 
 Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber) {
+    this.ringpop.stat('increment', 'make-faulty');
     return this._makeUpdate(address, incarnationNumber, Member.Status.faulty);
 };
 
 Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber) {
+    this.ringpop.stat('increment', 'make-leave');
     return this._makeUpdate(address, incarnationNumber, Member.Status.leave);
 };
 
 Membership.prototype.makeSuspect = function makeSuspect(address, incarnationNumber) {
+    this.ringpop.stat('increment', 'make-suspect');
     return this._makeUpdate(address, incarnationNumber, Member.Status.suspect);
 };
 


### PR DESCRIPTION
Ringpop does not currently emit stats when a node explicitly changes the status of a member. This new stat is complementary to the `membership-update.*` stats that Ringpop emits when it observes an update that has been gossiped and applied.

@benfleis @danielheller @Raynos @CorgiMan 