### PR TITLE
Join blacklist to prevent unintended hosts from joining cluster

### DIFF
--- a/config.js
+++ b/config.js
@@ -19,14 +19,16 @@
 // THE SOFTWARE.
 'use strict';
 
+var _ = require('underscore');
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
 // This Config class is meant to be a central store
 // for configurable parameters in Ringpop. Parameters
 // are meant to be initialized in the constructor.
-function Config(seedConfig) {
+function Config(ringpop, seedConfig) {
     seedConfig = seedConfig || {};
+    this.ringpop = ringpop;
     this.store = {};
     this._seed(seedConfig);
 }
@@ -38,6 +40,7 @@ Config.prototype.get = function get(key) {
 };
 
 Config.prototype.set = function set(key, value) {
+    // TODO Use same validation in _seed() here.
     var oldValue = this.store[key];
     this.store[key] = value;
     this.emit('set', key, value, oldValue);
@@ -61,10 +64,26 @@ Config.prototype._seed = function _seed(seed) {
     seedOrDefault('dampScoringReuseLimit', 2500);
     seedOrDefault('dampScoringSuppressDuration', 60 * 60 * 1000); // 1 hr in ms
     seedOrDefault('dampScoringSuppressLimit', 5000);
+    seedOrDefault('joinBlacklist', [], function validator(vals) {
+        return _.all(vals, function all(val) {
+            return val instanceof RegExp;
+        });
+    }, 'expected to be array of RegExp objects');
 
-    function seedOrDefault(name, defaultVal) {
+    function seedOrDefault(name, defaultVal, validator, reason) {
         var seedVal = seed[name];
         if (typeof seedVal === 'undefined') {
+            self.set(name, defaultVal);
+        } else if (typeof validator === 'function' && !validator(seedVal)) {
+            if (self.ringpop) {
+                self.ringpop.logger.warn('ringpop using default value for config after' +
+                        ' being passed invalid seed value', {
+                    config: name,
+                    seedVal: seedVal,
+                    defaultVal: defaultVal,
+                    reason: reason
+                });
+            }
             self.set(name, defaultVal);
         } else {
             self.set(name, seedVal);

--- a/config.js
+++ b/config.js
@@ -64,7 +64,7 @@ Config.prototype._seed = function _seed(seed) {
     seedOrDefault('dampScoringReuseLimit', 2500);
     seedOrDefault('dampScoringSuppressDuration', 60 * 60 * 1000); // 1 hr in ms
     seedOrDefault('dampScoringSuppressLimit', 5000);
-    seedOrDefault('joinBlacklist', [], function validator(vals) {
+    seedOrDefault('memberBlacklist', [], function validator(vals) {
         return _.all(vals, function all(val) {
             return val instanceof RegExp;
         });

--- a/config.js
+++ b/config.js
@@ -69,6 +69,7 @@ Config.prototype._seed = function _seed(seed) {
             return val instanceof RegExp;
         });
     }, 'expected to be array of RegExp objects');
+    seedOrDefault('maxJoinAttempts', 50, numValidator);
 
     function seedOrDefault(name, defaultVal, validator, reason) {
         var seedVal = seed[name];
@@ -90,5 +91,9 @@ Config.prototype._seed = function _seed(seed) {
         }
     }
 };
+
+function numValidator(maybeNum) {
+    return typeof maybeNum === 'number' && !isNaN(maybeNum);
+}
 
 module.exports = Config;

--- a/lib/swim/join-sender.js
+++ b/lib/swim/join-sender.js
@@ -63,7 +63,6 @@ var JOIN_TIMEOUT = 1000;
 //   provisioned cluster
 //   - Trying forever is futile
 var MAX_JOIN_DURATION = 120000;
-var MAX_JOIN_ATTEMPTS = 50;
 var PARALLELISM_FACTOR = 2;
 
 function isSingleNodeCluster(ringpop) {
@@ -112,11 +111,6 @@ function JoinCluster(opts) {
     // to a certain time limit.
     this.maxJoinDuration = numOrDefault(opts.maxJoinDuration,
         MAX_JOIN_DURATION);
-
-    // We want to abort the joining process if we have failed
-    // a certain number of times.
-    this.maxJoinAttempts = numOrDefault(opts.maxJoinAttempts,
-        MAX_JOIN_ATTEMPTS);
 
     // We do not want to retry joining as hard as we can. We
     // want to have some fixed backoff applied before we try
@@ -226,6 +220,7 @@ JoinCluster.prototype.join = function join(callback) {
     var numFailed = 0;
     var startTime = Date.now();
     var calledBack = false;
+    var maxJoinAttempts = this.ringpop.config.get('maxJoinAttempts');
 
     function onJoin(err, nodes) {
         if (calledBack) {
@@ -275,11 +270,11 @@ JoinCluster.prototype.join = function join(callback) {
 
             calledBack = true;
             callback(null, nodesJoined);
-        } else if (numFailed >= self.maxJoinAttempts) {
+        } else if (numFailed >= maxJoinAttempts) {
             self.ringpop.logger.warn('ringpop max join attempts exceeded', {
                 local: self.ringpop.whoami(),
                 joinAttempts: numFailed,
-                maxJoinAttempts: self.maxJoinAttempts,
+                maxJoinAttempts: maxJoinAttempts,
                 numJoined: numJoined,
                 numFailed: numFailed,
                 startTime: startTime
@@ -288,7 +283,7 @@ JoinCluster.prototype.join = function join(callback) {
             calledBack = true;
             callback(JoinAttemptsExceededError({
                 joinAttempts: numFailed,
-                maxJoinAttempts: self.maxJoinAttempts
+                maxJoinAttempts: maxJoinAttempts
             }));
             return;
         } else {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "add-licence": "uber-licence",
     "check-licence": "uber-licence --dry",
     "cover": "istanbul cover --print detail --report html test/index.js",
-    "jshint": "jshint --verbose *.js lib/*.js lib/request-proxy/*.js lib/swim/*.js scripts/*.js",
+    "jshint": "jshint --verbose *.js lib/**/*.js scripts/*.js server/**/*.js",
     "travis": "npm run cover -s && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)",
     "view-cover": "opn coverage/index.html"
   },

--- a/server/protocol/join.js
+++ b/server/protocol/join.js
@@ -69,7 +69,7 @@ function validateJoinerAddress(ringpop, joiner, callback) {
     }
 
     var blacklist = ringpop.config.get('memberBlacklist');
-    if (Array.isArray(blacklist) && anyBlacklisted()) {
+    if (anyBlacklisted()) {
         callback(BlacklistedError({
             joiner: joiner,
             blacklist: blacklist
@@ -80,7 +80,8 @@ function validateJoinerAddress(ringpop, joiner, callback) {
     return true;
 
     function anyBlacklisted() {
-        return _.any(blacklist, function any(pattern) {
+        return Array.isArray(blacklist) && blacklist.some(
+                function some(pattern) {
             return pattern.test(joiner);
         });
     }

--- a/server/protocol/join.js
+++ b/server/protocol/join.js
@@ -23,6 +23,14 @@ var _ = require('underscore');
 var safeParse = require('../../lib/util').safeParse;
 var TypedError = require('error/typed');
 
+var BlacklistedError = TypedError({
+    type: 'ringpop.invalid-join.blacklist',
+    message: '{joiner} tried joining a cluster, but its host is part of the' +
+        ' blacklist: {blacklist}',
+    blacklist: null,
+    joiner: null
+});
+
 var DenyJoinError = TypedError({
     type: 'ringpop.deny-join',
     message: 'Node is currently configured to deny joins'
@@ -34,14 +42,6 @@ var InvalidJoinAppError = TypedError({
         ' ({expected}) did not match the actual app ({actual}).',
     expected: null,
     actual: null
-});
-
-var InvalidJoinBlacklistError = TypedError({
-    type: 'ringpop.invalid-join.blacklist',
-    message: '{joiner} tried joining a cluster, but its host is part of the' +
-        ' blacklist: {blacklist}',
-    blacklist: null,
-    joiner: null
 });
 
 var InvalidJoinSourceError = TypedError({
@@ -68,9 +68,9 @@ function validateJoinerAddress(ringpop, joiner, callback) {
         return false;
     }
 
-    var blacklist = ringpop.config.get('joinBlacklist');
+    var blacklist = ringpop.config.get('memberBlacklist');
     if (Array.isArray(blacklist) && anyBlacklisted()) {
-        callback(InvalidJoinBlacklistError({
+        callback(BlacklistedError({
             joiner: joiner,
             blacklist: blacklist
         }));

--- a/server/protocol/join.js
+++ b/server/protocol/join.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 'use strict';
 
-var _ = require('underscore');
 var safeParse = require('../../lib/util').safeParse;
 var TypedError = require('error/typed');
 

--- a/test/integration/join-test.js
+++ b/test/integration/join-test.js
@@ -154,7 +154,7 @@ testRingpopCluster({
     tap: function tap(cluster) {
         // This'll make Node 0's join fail faster
         cluster[0].config.set('maxJoinAttempts', 1);
-        cluster[1].config.set('joinBlacklist', [/127.0.0.1:10000/]);
+        cluster[1].config.set('memberBlacklist', [/127.0.0.1:10000/]);
     }
 }, 'join blacklist', function t(bootRes, cluster, assert) {
     assert.notok(cluster[0].isReady, 'node one is not ready');

--- a/test/unit/config_test.js
+++ b/test/unit/config_test.js
@@ -59,7 +59,7 @@ test('seeds known config', function t(assert) {
     seed[knownKey] = knownVal;
     seed[unknownKey] = unknownVal;
 
-    var config = new Config(seed);
+    var config = new Config(null, seed);
 
     assert.equals(knownVal, config.get(knownKey), 'known config is seeded');
     assert.equals(undefined, config.get(unknownKey),
@@ -72,5 +72,21 @@ test('no seed is OK', function t(assert) {
         /* jshint nonew: false */
         new Config(null);
     });
+    assert.end();
+});
+
+test('validates joinBlacklist seed', function t(assert) {
+    var config = new Config(null, {
+        'joinBlacklist': ['127.0.0.1:3000']
+    });
+    assert.deepEquals([], config.get('joinBlacklist'),
+        'uses default blacklist');
+
+    var regexList = [/127.0.0.1:*/];
+    config = new Config(null, {
+        'joinBlacklist': regexList
+    });
+    assert.deepEquals(regexList, config.get('joinBlacklist'),
+        'uses seed blacklist');
     assert.end();
 });

--- a/test/unit/config_test.js
+++ b/test/unit/config_test.js
@@ -90,3 +90,12 @@ test('validates joinBlacklist seed', function t(assert) {
         'uses seed blacklist');
     assert.end();
 });
+
+test('validates num', function t(assert) {
+    var config = new Config(null, {
+        'maxJoinAttempts': 'notanum'
+    });
+    assert.equals(50, config.get('maxJoinAttempts'),
+        'uses default');
+    assert.end();
+});

--- a/test/unit/config_test.js
+++ b/test/unit/config_test.js
@@ -75,18 +75,18 @@ test('no seed is OK', function t(assert) {
     assert.end();
 });
 
-test('validates joinBlacklist seed', function t(assert) {
+test('validates memberBlacklist seed', function t(assert) {
     var config = new Config(null, {
-        'joinBlacklist': ['127.0.0.1:3000']
+        'memberBlacklist': ['127.0.0.1:3000']
     });
-    assert.deepEquals([], config.get('joinBlacklist'),
+    assert.deepEquals([], config.get('memberBlacklist'),
         'uses default blacklist');
 
     var regexList = [/127.0.0.1:*/];
     config = new Config(null, {
-        'joinBlacklist': regexList
+        'memberBlacklist': regexList
     });
-    assert.deepEquals(regexList, config.get('joinBlacklist'),
+    assert.deepEquals(regexList, config.get('memberBlacklist'),
         'uses seed blacklist');
     assert.end();
 });

--- a/test/unit/server/protocol/join_test.js
+++ b/test/unit/server/protocol/join_test.js
@@ -27,7 +27,7 @@ test('join fails with blacklist error', function t(assert) {
     var ringpop = new Ringpop({
         app: 'ringpop',
         hostPort: '127.0.0.1:3000',
-        joinBlacklist: [/127.0.0.1:*/]
+        memberBlacklist: [/127.0.0.1:*/]
     });
     var handleProtocolJoin = createProtocolJoinHandler(ringpop);
     handleProtocolJoin(null, JSON.stringify({

--- a/test/unit/server/protocol/join_test.js
+++ b/test/unit/server/protocol/join_test.js
@@ -17,14 +17,28 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
-// You might ask, what belongs in this unit test directory? The answer:
-// anything test that strictly depends one and only one module. It does
-// not test the interactions of many modules nor does it require you
-// to stand up and bootstrap a single node or multi-node Ringpop cluster.
 'use strict';
 
-require('./config_test.js');
-require('./member_test.js');
-require('./membership_test.js');
-require('./server/protocol/join_test.js');
+var createProtocolJoinHandler = require('../../../../server/protocol/join.js');
+var Ringpop = require('../../../../index.js');
+var test = require('tape');
+
+test('join fails with blacklist error', function t(assert) {
+    var ringpop = new Ringpop({
+        app: 'ringpop',
+        hostPort: '127.0.0.1:3000',
+        joinBlacklist: [/127.0.0.1:*/]
+    });
+    var handleProtocolJoin = createProtocolJoinHandler(ringpop);
+    handleProtocolJoin(null, JSON.stringify({
+        app: 'ringpop',
+        source: '127.0.0.1:3001',
+        incarnationNumber: 1
+    }), null, function onHandled(err) {
+        assert.ok(err, 'an error occurred');
+        assert.equals(err.type, 'ringpop.invalid-join.blacklist',
+            'blacklist error occurred');
+        assert.end();
+        ringpop.destroy();
+    });
+});


### PR DESCRIPTION
This is the start of a formal member blacklist. This prevents joins from 'unintended' members which are specifiable by a `memberBlacklist` config. Apps can choose arbitrary regexs for the blacklist.

Oh, and yes, this'll need to be back-ported, if services that desire this functionality cannot upgrade to 10.x.x.

@CorgiMan @danielheller @markyen @benfleis 