### PR TITLE
Allow body limit to be specified for large object payloads

### DIFF
--- a/lib/request-proxy/index.js
+++ b/lib/request-proxy/index.js
@@ -85,7 +85,10 @@ proto.proxyReq = function proxyReq(opts) {
     var timeout = opts.timeout ?
         opts.timeout : this.ringpop.proxyReqTimeout;
 
-    body(req, res, { cache: true }, onBody);
+    body(req, res, {
+        cache: true,
+        limit: opts.bodyLimit
+    }, onBody);
 
     function onBody(err, rawBody) {
         if (err) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "after": "^0.8.1",
     "async": "^0.9.0",
     "benchmark": "^1.0.0",
+    "buffer-equal": "0.0.1",
     "cli-color": "^0.3.2",
     "commander": "^2.6.0",
     "coveralls": "^2.11.2",

--- a/test/lib/alloc-cluster.js
+++ b/test/lib/alloc-cluster.js
@@ -44,9 +44,9 @@ function allocCluster(options, onReady) {
     var two = allocRingpop('two', options);
     var three = allocRingpop('three', options);
 
-    one.on('request', createHandler('one'));
-    two.on('request', createHandler('two'));
-    three.on('request', createHandler('three'));
+    one.on('request', createHandler('one', options));
+    two.on('request', createHandler('two', options));
+    three.on('request', createHandler('three', options));
 
     bootstrap([one, two, three], onReady);
 
@@ -87,7 +87,8 @@ function allocCluster(options, onReady) {
             timeout: opts.timeout,
             retrySchedule: opts.retrySchedule,
             endpoint: opts.endpoint,
-            maxRetries: opts.maxRetries
+            maxRetries: opts.maxRetries,
+            bodyLimit: opts.bodyLimit
         });
         if (handle) {
             cluster[host].emit('request', req, res);
@@ -102,10 +103,12 @@ function allocCluster(options, onReady) {
     }
 }
 
-function createServerHandler(name) {
+function createServerHandler(name, opts) {
     return function serverHandle(req, res) {
         if (req.headers['content-type'] === 'application/json') {
-            jsonBody(req, onBody);
+            jsonBody(req, null, {
+                limit: opts.bodyLimit
+            }, onBody);
         } else {
             onBody(null, undefined);
         }


### PR DESCRIPTION
Cherry-pick 'the body module' fix applied to Ringpop v9 to master.

@jwyuan 