### PR TITLE
allow 2-node clusters to split and rejoin

### DIFF
--- a/lib/swim/ping-req-sender.js
+++ b/lib/swim/ping-req-sender.js
@@ -38,11 +38,6 @@ var BadPingReqRespBodyError = TypedError({
     body: null
 });
 
-var NoMembersError = TypedError({
-    type: 'ringpop.ping-req.no-members',
-    message: 'No selectable ping-req members'
-});
-
 var PingReqInconclusiveError = TypedError({
     type: 'ringpop.ping-req.inconclusive',
     message: 'Ping-req is inconclusive'
@@ -158,16 +153,22 @@ module.exports = function sendPingReq(opts, callback) {
     ringpop.stat('increment', 'ping-req.send');
 
     var pingReqMembers = randomMembers();
+    var addrs = pingReqAddrs(pingReqMembers);
+    var errors = [];
+
     ringpop.stat('timing', 'ping-req.other-members', pingReqMembers.length);
 
+    // allow 2-node cluster to work by short cutting directly to suspect
     if (pingReqMembers.length === 0) {
-        callback(NoMembersError());
+        ringpop.membership.makeSuspect(
+            unreachableMember.address,
+            unreachableMember.incarnationNumber);
+
+        callback(null, { pingReqAddrs: addrs, pingReqErrs: errors });
         return;
     }
 
-    var addrs = pingReqAddrs(pingReqMembers);
     var calledBack = false;
-    var errors = [];
     var startTime = Date.now();
     var unreachableMemberInfo = {
         address: unreachableMember.address,

--- a/test/integration/swim-test.js
+++ b/test/integration/swim-test.js
@@ -146,8 +146,9 @@ testRingpopCluster({
         unreachableMember: unreachableMember,
         pingReqSize: pingReqSize
     }, function onPingReq(err, res) {
-        assert.ok(err, 'error occurred');
-        assert.equals(err.type, 'ringpop.ping-req.no-members', 'No members error');
+        assert.ifErr(err, 'no error occurred');
+        assertNumBadStatuses(assert, res, 0);
+        assertSuspect(assert, ringpop, unreachableMember.address);
         assert.end();
     });
 });


### PR DESCRIPTION
addresses: https://github.com/uber/ringpop-node/issues/167

Allow a 2-node cluster to split and generate proper suspect mark events, etc.,
and subsequent rejoins. Current code short circuits suspect logic, and will
never mark faulty or generate new checksum.

Since there is a test demonstrating that 2-node ping fail generates an error,
not sure if this is the correct/desired approach.