### PR TITLE
emit destroying message right before ringpop is destroyed

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,7 +178,13 @@ function RingPop(options) {
 require('util').inherits(RingPop, EventEmitter);
 
 RingPop.prototype.destroy = function destroy() {
+    if (this.destroyed) {
+        return;
+    }
+
     this.destroyed = true;
+    this.emit('destroying');
+
     this.gossip.stop();
     this.suspicion.stopAll();
     this.membershipUpdateRollup.destroy();

--- a/index.js
+++ b/index.js
@@ -182,7 +182,6 @@ RingPop.prototype.destroy = function destroy() {
         return;
     }
 
-    this.destroyed = true;
     this.emit('destroying');
 
     this.gossip.stop();
@@ -215,6 +214,7 @@ RingPop.prototype.destroy = function destroy() {
         this.channel.topChannel.close();
     }
 
+    this.destroyed = true;
     this.emit('destroyed');
 };
 


### PR DESCRIPTION
r @jwolski @benfleis 

This is necessary for whoever needs to use channel to clean up before it is destroyed.