### PR TITLE
Add Member::getId

### DIFF
--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -111,6 +111,10 @@ Member.prototype.evaluateUpdate = function evaluateUpdate(update) {
     return true;
 };
 
+Member.prototype.getId = function getId() {
+    return this.address;
+};
+
 Member.prototype.getStats = function getStats() {
     return {
         address: this.address,

--- a/test/unit/member_test.js
+++ b/test/unit/member_test.js
@@ -199,3 +199,11 @@ testRingpop('never decays below min', function t(deps, assert) {
     assert.true(member2.dampScore === config.get('dampScoringMin'),
         'damp score decayed to min');
 });
+
+testRingpop('member ID is its address', function t(deps, assert) {
+    var address = '127.0.0.1:3000';
+    var member = new Member(deps.ringpop, {
+        address: address
+    });
+    assert.equals(member.getId(), address, 'ID is address');
+});


### PR DESCRIPTION
Beginning work on next phase of flap damping. There'll be some small PRs for continuing improvement to codebase, but that are fairly unrelated to the task at hand. Here's the first. A helper function on the Member prototype to abstract away a Member's ID. This comes about as a result of indexing outstanding damp subprotocola by a Member's ID. I want to prevent anymore assumptions about what the ID is for obvious reasons.

Since this is so trivial, I'll likely self-merge.

@danielheller @CorgiMan @benfleis @thanodnl @mbrysa 