### PR TITLE
Renamed legacy name RingPopTChannel to RingpopServer

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,6 @@ var Config = require('./config.js');
 var createEventForwarder = require('./lib/event-forwarder.js');
 var createMembershipSetListener = require('./lib/membership-set-listener.js');
 var createMembershipUpdateListener = require('./lib/membership-update-listener.js');
-var createServer = require('./server');
 var Dissemination = require('./lib/dissemination.js');
 var errors = require('./lib/errors.js');
 var getTChannelVersion = require('./lib/util.js').getTChannelVersion;
@@ -60,6 +59,7 @@ var MembershipUpdateRollup = require('./lib/membership/rollup.js');
 var nulls = require('./lib/nulls');
 var rawHead = require('./lib/request-proxy/util.js').rawHead;
 var RequestProxy = require('./lib/request-proxy/index.js');
+var RingpopServer = require('./server');
 var safeParse = require('./lib/util').safeParse;
 var sendJoin = require('./lib/swim/join-sender.js').joinCluster;
 var TracerStore = require('./lib/trace/store.js');
@@ -218,7 +218,7 @@ RingPop.prototype.destroy = function destroy() {
 };
 
 RingPop.prototype.setupChannel = function setupChannel() {
-    createServer(this, this.channel);
+    this.server = new RingpopServer(this, this.channel);
 };
 
 /*

--- a/server/index.js
+++ b/server/index.js
@@ -20,7 +20,7 @@
 'use strict';
 
 
-function RingPopTChannel(ringpop, tchannel) {
+function RingpopServer(ringpop, tchannel) {
     var self = this;
     self.ringpop = ringpop;
     self.tchannel = tchannel;
@@ -63,8 +63,4 @@ function RingPopTChannel(ringpop, tchannel) {
     }
 }
 
-function createServer(ringpop, tchannel) {
-    return new RingPopTChannel(ringpop, tchannel);
-}
-
-module.exports = createServer;
+module.exports = RingpopServer;


### PR DESCRIPTION
More incidental cleanup from damp subprotocol work.

@uber/ringpop 