### PR TITLE
Client can make use of subChannel passed into constructor

### DIFF
--- a/client.js
+++ b/client.js
@@ -22,11 +22,16 @@
 var safeParse = require('./lib/util.js').safeParse;
 var TChannel = require('tchannel');
 
-function RingpopClient() {
-    this.tchannel = new TChannel();
-    this.subChannel = this.tchannel.makeSubChannel({
-        serviceName: 'ringpop'
-    });
+function RingpopClient(subChannel) {
+    this.subChannel = subChannel;
+    this.isChannelOwner = false;
+    if (!this.subChannel) {
+        this.tchannel = new TChannel();
+        this.subChannel = this.tchannel.makeSubChannel({
+            serviceName: 'ringpop'
+        });
+        this.isChannelOwner = true;
+    }
 }
 
 RingpopClient.prototype.adminConfigGet = function adminConfigGet(host, body, callback) {
@@ -50,7 +55,9 @@ RingpopClient.prototype.adminGossipTick= function adminGossipTick(host, callback
 };
 
 RingpopClient.prototype.destroy = function destroy(callback) {
-    this.tchannel.close(callback);
+    if (this.isChannelOwner) {
+        this.tchannel.close(callback);
+    }
 };
 
 /* jshint maxparams: 5 */

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ var MembershipUpdateRollup = require('./lib/membership/rollup.js');
 var nulls = require('./lib/nulls');
 var rawHead = require('./lib/request-proxy/util.js').rawHead;
 var RequestProxy = require('./lib/request-proxy/index.js');
+var RingpopClient = require('./client.js');
 var RingpopServer = require('./server');
 var safeParse = require('./lib/util').safeParse;
 var sendJoin = require('./lib/swim/join-sender.js').joinCluster;
@@ -218,6 +219,7 @@ RingPop.prototype.destroy = function destroy() {
 };
 
 RingPop.prototype.setupChannel = function setupChannel() {
+    this.client = new RingpopClient(this.channel);
     this.server = new RingpopServer(this, this.channel);
 };
 


### PR DESCRIPTION
More incidental cleanup. Take note that this is branched off of `renamed-ringpop-tchannel` branch and not master. The new damping subprotocol PR will make use of RingpopClient to fanout its damp score requests.

@uber/ringpop 