### PR TITLE
Get rid of the dreadful pingMemberNow; make tick() part of gossip

### DIFF
--- a/lib/swim/gossip.js
+++ b/lib/swim/gossip.js
@@ -18,7 +18,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 'use strict';
+
 var metrics = require('metrics');
+var sendPing = require('./ping-sender.js');
+var sendPingReq = require('./ping-req-sender.js');
 
 function Gossip(options) {
     this.ringpop = options.ringpop;
@@ -61,7 +64,7 @@ Gossip.prototype.run = function run() {
     this.protocolPeriodTimer = setTimeout(function onGossipTimer() {
         var pingStartTime = Date.now();
 
-        self.ringpop.pingMemberNow(function onMemberPinged() {
+        self.tick(function onMemberPinged() {
             self.lastProtocolPeriod = Date.now();
             self.numProtocolPeriods++;
             self.ringpop.stat('timing', 'protocol.frequency', startTime);
@@ -122,6 +125,65 @@ Gossip.prototype.stop = function stop() {
 
     this.ringpop.logger.debug('stopped gossip protocol', {
         local: this.ringpop.whoami()
+    });
+};
+
+Gossip.prototype.tick = function tick(callback) {
+    callback = callback || function() {};
+
+    if (this.ringpop.isPinging) {
+        this.ringpop.logger.warn('aborting ping because one is in progress');
+        return callback();
+    }
+
+    if (!this.ringpop.isReady) {
+        this.ringpop.logger.warn('ping started before ring initialized');
+        return callback();
+    }
+
+    var member = this.ringpop.memberIterator.next();
+
+    if (! member) {
+        this.ringpop.logger.warn('no usable nodes at protocol period');
+        return callback();
+    }
+
+    var self = this;
+    this.isPinging = true;
+    var start = new Date();
+    sendPing({
+        ringpop: self.ringpop,
+        target: member
+    }, function(isOk, body) {
+        self.ringpop.stat('timing', 'ping', start);
+        if (isOk) {
+            self.ringpop.isPinging = false;
+            self.ringpop.membership.update(body.changes);
+            return callback();
+        }
+
+        if (self.ringpop.destroyed) {
+            return callback(new Error('destroyed whilst pinging'));
+        }
+
+        var pingReqStartTime = new Date();
+        // TODO The pinged member's status could have changed to
+        // faulty by the time we received and processed the ping
+        // response. There are no ill effects to membership state
+        // by sending a ping-req to the faulty member (and processing
+        // the response), though it does delay the protocol period
+        // unnecessarily. We may want to bypass the ping-req here
+        // if the member's status is faulty.
+        sendPingReq({
+            ringpop: self.ringpop,
+            unreachableMember: member,
+            pingReqSize: self.ringpop.pingReqSize
+        }, function onPingReq() {
+            self.ringpop.stat('timing', 'ping-req', pingReqStartTime);
+            self.ringpop.isPinging = false;
+
+            callback.apply(null, Array.prototype.splice.call(arguments, 0));
+        });
     });
 };
 

--- a/server/admin/gossip.js
+++ b/server/admin/gossip.js
@@ -35,7 +35,7 @@ function createGossipStopHandler(ringpop) {
 
 function createGossipTickHandler(ringpop) {
     return function handleGossipTick(arg1, arg2, hostInfo, callback) {
-        ringpop.pingMemberNow(function onPing(err) {
+        ringpop.gossip.tick(function onPing(err) {
             if (err) {
                 callback(err);
                 return;


### PR DESCRIPTION
This pingMemberNow has been bothering me since the dawn of time. I had to take the plunge and get rid of it. Minor refactoring. Just moved some code around, leading to a more intuitive Gossip interface.

@uber/ringpop 