### PR TITLE
Remove listener after evaluating update to prevent leaking listeners

### DIFF
--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -289,6 +289,7 @@ Membership.prototype.update = function update(changes, isLocal) {
         // One-time subscription for batching applied updates
         member.once('updated', onMemberUpdated);
         member.evaluateUpdate(change);
+        member.removeListener('updated', onMemberUpdated);
     }
 
     if (updates.length > 0) {

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -286,7 +286,11 @@ Membership.prototype.update = function update(changes, isLocal) {
             continue;
         }
 
-        // One-time subscription for batching applied updates
+        // One-time subscription for batching applied updates. Make
+        // sure to unsubscribe immediately after evaluating the update.
+        // Events are expected to be emitted synchronously and are not
+        // guaranteed if the update is determined to be invalid or
+        // redundant.
         member.once('updated', onMemberUpdated);
         member.evaluateUpdate(change);
         member.removeListener('updated', onMemberUpdated);

--- a/test/unit/member_test.js
+++ b/test/unit/member_test.js
@@ -207,3 +207,32 @@ testRingpop('member ID is its address', function t(deps, assert) {
     });
     assert.equals(member.getId(), address, 'ID is address');
 });
+
+testRingpop('update happens synchronously or not at all', function t(deps, assert) {
+    var address = '127.0.0.1:3001';
+    var incarnationNumber = Date.now();
+    var member = new Member(deps.ringpop, {
+        address: address,
+        incarnationNumber: incarnationNumber,
+        status: Member.Status.alive
+    });
+    var emitted = false;
+    member.on('updated', function onUpdated() {
+        emitted = true;
+    });
+    makeUpdate();
+    assert.true(emitted, 'event is emitted');
+
+    // Reset and try the same (redundant) update again
+    emitted = false;
+    makeUpdate();
+    assert.false(emitted, 'event is not emitted');
+
+    function makeUpdate() {
+        member.evaluateUpdate({
+            address: address,
+            status: Member.Status.suspect,
+            incarnationNumber: incarnationNumber + 1
+        });
+    }
+});


### PR DESCRIPTION
This bug'll cause leaky listeners and unnecessary CPU churn when redundant updates are processed.

@uber/ringpop 