### PR TITLE
Add membership update types

### DIFF
--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -381,12 +381,11 @@ Membership.prototype._updateMember = function _updateMember(update, isLocal) {
     var updates = this.update(update, isLocal);
 
     if (updates.length > 0) {
-        var logData = {};
-        logData.local = this.ringpop.whoami();
-        logData[update.status] = update.address;
-        logData.updateId = update.id;
         this.ringpop.logger.debug('ringpop member declares other member ' +
-            update.status, logData);
+            update.status, {
+                local: this.ringpop.whoami(),
+                update: updates[0]
+        });
     }
 
     return updates;

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -25,8 +25,11 @@ var farmhash = require('farmhash');
 var Member = require('./member.js');
 var mergeMembershipChangesets = require('./merge.js');
 var timers = require('timers');
+var update = require('./update.js');
 var util = require('util');
-var uuid = require('node-uuid');
+
+var LeaveUpdate = update.LeaveUpdate;
+var Update = update.Update;
 
 function Membership(opts) {
     this.ringpop = opts.ringpop; // assumed to be present
@@ -175,23 +178,27 @@ Membership.prototype.isPingable = function isPingable(member) {
 
 Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber) {
     this.ringpop.stat('increment', 'make-alive');
-    return this._makeUpdate(address, incarnationNumber, Member.Status.alive,
-        address === this.ringpop.whoami());
+    var isLocal = address === this.ringpop.whoami();
+    return this._updateMember(new Update(address, incarnationNumber,
+        Member.Status.alive, this.localMember), isLocal);
 };
 
 Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber) {
     this.ringpop.stat('increment', 'make-faulty');
-    return this._makeUpdate(address, incarnationNumber, Member.Status.faulty);
+    return this._updateMember(new Update(address, incarnationNumber,
+        Member.Status.faulty, this.localMember));
 };
 
 Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber) {
     this.ringpop.stat('increment', 'make-leave');
-    return this._makeUpdate(address, incarnationNumber, Member.Status.leave);
+    return this._updateMember(new LeaveUpdate(address, incarnationNumber,
+        this.localMember));
 };
 
 Membership.prototype.makeSuspect = function makeSuspect(address, incarnationNumber) {
     this.ringpop.stat('increment', 'make-suspect');
-    return this._makeUpdate(address, incarnationNumber, Member.Status.suspect);
+    return this._updateMember(new Update(address, incarnationNumber,
+        Member.Status.suspect, this.localMember));
 };
 
 // Sets stashed updates. set() is different from update() in that it bypasses
@@ -370,30 +377,16 @@ Membership.prototype._decayMembersDampScore = function _decayMembersDampScore() 
     }
 };
 
-Membership.prototype._makeUpdate = function _makeUpate(address,
-        incarnationNumber, status, isLocal) {
-    var localMember = this.localMember || {
-        address: address,
-        incarnationNumber: incarnationNumber
-    };
-
-    var updateId = uuid.v4();
-    var updates = this.update({
-        id: updateId,
-        source: localMember.address,
-        sourceIncarnationNumber: localMember.incarnationNumber,
-        address: address,
-        status: status,
-        incarnationNumber: incarnationNumber,
-        timestamp: Date.now()
-    }, isLocal);
+Membership.prototype._updateMember = function _updateMember(update, isLocal) {
+    var updates = this.update(update, isLocal);
 
     if (updates.length > 0) {
         var logData = {};
         logData.local = this.ringpop.whoami();
-        logData[status] = address;
-        logData.updateId = updateId;
-        this.ringpop.logger.debug('ringpop member declares other member ' + status, logData);
+        logData[update.status] = update.address;
+        logData.updateId = update.id;
+        this.ringpop.logger.debug('ringpop member declares other member ' +
+            update.status, logData);
     }
 
     return updates;

--- a/lib/membership/update.js
+++ b/lib/membership/update.js
@@ -1,0 +1,54 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var Member = require('./member.js');
+var uuid = require('node-uuid');
+var util = require('util');
+
+function BaseUpdate(address, incarnationNumber, status) {
+    this.address = address;
+    this.incarnationNumber = incarnationNumber;
+    this.status = status;
+}
+
+function Update(address, incarnationNumber, status, localMember) {
+    Update.super_.call(this, address, incarnationNumber, status);
+
+    localMember = localMember || {};
+    this.id = uuid.v4();
+    this.source = localMember.address;
+    this.sourceIncarnationNumber = localMember.incarnationNumber;
+    this.timestamp = Date.now();
+}
+
+util.inherits(Update, BaseUpdate);
+
+function LeaveUpdate(address, incarnationNumber, localMember) {
+    LeaveUpdate.super_.call(this, address, incarnationNumber, Member.Status.leave,
+        localMember);
+}
+
+util.inherits(LeaveUpdate, Update);
+
+module.exports = {
+    LeaveUpdate: LeaveUpdate,
+    Update: Update
+};

--- a/lib/membership/update.js
+++ b/lib/membership/update.js
@@ -23,23 +23,16 @@ var Member = require('./member.js');
 var uuid = require('node-uuid');
 var util = require('util');
 
-function BaseUpdate(address, incarnationNumber, status) {
+function Update(address, incarnationNumber, status, localMember) {
     this.address = address;
     this.incarnationNumber = incarnationNumber;
     this.status = status;
-}
-
-function Update(address, incarnationNumber, status, localMember) {
-    Update.super_.call(this, address, incarnationNumber, status);
-
-    localMember = localMember || {};
     this.id = uuid.v4();
+    localMember = localMember || {};
     this.source = localMember.address;
     this.sourceIncarnationNumber = localMember.incarnationNumber;
     this.timestamp = Date.now();
 }
-
-util.inherits(Update, BaseUpdate);
 
 function LeaveUpdate(address, incarnationNumber, localMember) {
     LeaveUpdate.super_.call(this, address, incarnationNumber, Member.Status.leave,


### PR DESCRIPTION
This concretely defines Update types. Why this is need will make more sense in a PR still to come. In general, I think it's much better to explicitly define the shape of the updates that are transmitted as part of the gossip protocol.

@uber/ringpop 