### PR TITLE
Make better sense out of the organization of the test suite

### DIFF
--- a/test/unit/dissemination-test.js
+++ b/test/unit/dissemination-test.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 'use strict';
 
-var testRingpop = require('./lib/test-ringpop');
+var testRingpop = require('../lib/test-ringpop');
 
 testRingpop('full sync includes all members', function t(deps, assert) {
     var membership = deps.membership;

--- a/test/unit/hashring_test.js
+++ b/test/unit/hashring_test.js
@@ -17,8 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-var HashRing = require('../lib/ring');
-var RBTree = require('../lib/rbtree').RBTree;
+var HashRing = require('../../lib/ring');
+var RBTree = require('../../lib/rbtree').RBTree;
 
 var test = require('tape');
 

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -18,12 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 var _ = require('underscore');
-var AdminMember = require('../server/admin/member.js');
-var createJoinHandler = require('../server/protocol/join.js');
-var mock = require('./mock');
-var Ringpop = require('../index.js');
+var AdminMember = require('../../server/admin/member.js');
+var createJoinHandler = require('../../server/protocol/join.js');
+var mock = require('../mock');
+var Ringpop = require('../../index.js');
 var test = require('tape');
-var testRingpop = require('./lib/test-ringpop.js');
+var testRingpop = require('../lib/test-ringpop.js');
 
 var createAdminJoinHandler = AdminMember.memberJoin.handler;
 var createAdminLeaveHandler = AdminMember.memberLeave.handler;

--- a/test/unit/join-response-merge-test.js
+++ b/test/unit/join-response-merge-test.js
@@ -19,9 +19,9 @@
 // THE SOFTWARE.
 'use strict';
 
-var Member = require('../lib/membership/member.js');
-var mergeJoinResponses = require('../lib/swim/join-response-merge.js');
-var testRingpop = require('./lib/test-ringpop.js');
+var Member = require('../../lib/membership/member.js');
+var mergeJoinResponses = require('../../lib/swim/join-response-merge.js');
+var testRingpop = require('../lib/test-ringpop.js');
 
 testRingpop('no responses results in empty array', function t(deps, assert) {
     var result = mergeJoinResponses(deps.ringpop, deps.ringpop, null);

--- a/test/unit/join-sender-test.js
+++ b/test/unit/join-sender-test.js
@@ -19,8 +19,8 @@
 // THE SOFTWARE.
 'use strict';
 
-var createJoiner = require('../lib/swim/join-sender.js').createJoiner;
-var Ringpop = require('../index.js');
+var createJoiner = require('../../lib/swim/join-sender.js').createJoiner;
+var Ringpop = require('../../index.js');
 var test = require('tape');
 
 function assertThrows(assert, thrower, assertions) {

--- a/test/unit/membership-changeset-merge-test.js
+++ b/test/unit/membership-changeset-merge-test.js
@@ -19,8 +19,8 @@
 // THE SOFTWARE.
 'use strict';
 
-var mergeMembershipChangesets = require('../lib/membership/merge.js');
-var testRingpop = require('./lib/test-ringpop.js');
+var mergeMembershipChangesets = require('../../lib/membership/merge.js');
+var testRingpop = require('../lib/test-ringpop.js');
 
 testRingpop('merges incarnation numbers', function t(deps, assert) {
     var changesets = [firstChangeset(), secondChangeset()];

--- a/test/unit/membership-iterator-test.js
+++ b/test/unit/membership-iterator-test.js
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-var testRingpop = require('./lib/test-ringpop.js');
+var testRingpop = require('../lib/test-ringpop.js');
 
 testRingpop('iterates over two members correctly', function t(deps, assert) {
     var membership = deps.membership;

--- a/test/unit/membership-set-listener-test.js
+++ b/test/unit/membership-set-listener-test.js
@@ -19,8 +19,8 @@
 // THE SOFTWARE.
 'use strict';
 
-var createMembershipSetListener = require('../lib/membership-set-listener.js');
-var testRingpop = require('./lib/test-ringpop.js');
+var createMembershipSetListener = require('../../lib/membership-set-listener.js');
+var testRingpop = require('../lib/test-ringpop.js');
 
 testRingpop('starts suspicion period for suspect', function t(deps, assert) {
     var ringpop = deps.ringpop;

--- a/test/unit/membership-update-rollup-test.js
+++ b/test/unit/membership-update-rollup-test.js
@@ -19,10 +19,10 @@
 // THE SOFTWARE.
 'use strict';
 
-var MembershipUpdateRollup = require('../lib/membership/rollup.js');
-var Ringpop = require('../index.js');
+var MembershipUpdateRollup = require('../../lib/membership/rollup.js');
+var Ringpop = require('../../index.js');
 var test = require('tape');
-var testRingpop = require('./lib/test-ringpop.js');
+var testRingpop = require('../lib/test-ringpop.js');
 
 var localMemberUpdate = {
     address: '127.0.0.1:3000',

--- a/test/unit/proxy_req_test.js
+++ b/test/unit/proxy_req_test.js
@@ -23,10 +23,10 @@
 var _ = require('underscore');
 var test = require('tape');
 
-var allocRingpop = require('./lib/alloc-ringpop.js');
-var bootstrap = require('./lib/bootstrap.js');
-var mocks = require('./mock');
-var Ringpop = require('../index.js');
+var allocRingpop = require('../lib/alloc-ringpop.js');
+var bootstrap = require('../lib/bootstrap.js');
+var mocks = require('../mock');
+var Ringpop = require('../../index.js');
 
 test('proxyReq() proxies the request', function t(assert) {
     var left = allocRingpop('left');

--- a/test/unit/rbiterator_test.js
+++ b/test/unit/rbiterator_test.js
@@ -17,8 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-var RBTree = require('../lib/rbtree').RBTree;
-var RBIterator = require('../lib/rbtree').RBIterator;
+var RBTree = require('../../lib/rbtree').RBTree;
+var RBIterator = require('../../lib/rbtree').RBIterator;
 var test = require('tape');
 
 test('construct a new RBIterator', function t(assert) {

--- a/test/unit/rbtree_test.js
+++ b/test/unit/rbtree_test.js
@@ -17,8 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-var RBTree = require('../lib/rbtree').RBTree;
-var RingNode = require('../lib/rbtree').RingNode;
+var RBTree = require('../../lib/rbtree').RBTree;
+var RingNode = require('../../lib/rbtree').RingNode;
 var test = require('tape');
 
 test('construct a new RBTree', function t(assert) {

--- a/test/unit/request_proxy_test.js
+++ b/test/unit/request_proxy_test.js
@@ -17,10 +17,10 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-var allocRequest = require('./lib/alloc-request.js');
-var mocks = require('./mock');
-var RequestProxy = require('../lib/request-proxy/index.js');
-var Ringpop = require('../index.js');
+var allocRequest = require('../lib/alloc-request.js');
+var mocks = require('../mock');
+var RequestProxy = require('../../lib/request-proxy/index.js');
+var Ringpop = require('../../index.js');
 var test = require('tape');
 
 function createRingpop() {

--- a/test/unit/ring-test.js
+++ b/test/unit/ring-test.js
@@ -20,7 +20,7 @@
 'use strict';
 
 var _ = require('underscore');
-var HashRing = require('../lib/ring.js');
+var HashRing = require('../../lib/ring.js');
 var test = require('tape');
 
 function createServers(size) {

--- a/test/unit/ringnode_test.js
+++ b/test/unit/ringnode_test.js
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-var RingNode = require('../lib/rbtree').RingNode;
+var RingNode = require('../../lib/rbtree').RingNode;
 var test = require('tape');
 
 test('construct a new red node with supplied values', function t(assert) {

--- a/test/unit/ringpop_alloc_error_test.js
+++ b/test/unit/ringpop_alloc_error_test.js
@@ -22,7 +22,7 @@
 
 var test = require('tape');
 
-var Ringpop = require('../index.js');
+var Ringpop = require('../../index.js');
 
 test('ringpop without app throws', function t(assert) {
     assert.throws(function throwIt() {

--- a/test/unit/swim_test.js
+++ b/test/unit/swim_test.js
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-var Member = require('../lib/membership/member.js');
-var testRingpop = require('./lib/test-ringpop.js');
+var Member = require('../../lib/membership/member.js');
+var testRingpop = require('../lib/test-ringpop.js');
 
 testRingpop('starting and stopping gossip sets timer / unsets timers', function t(deps, assert) {
     var gossip = deps.gossip;

--- a/test/unit/trace-test.js
+++ b/test/unit/trace-test.js
@@ -25,8 +25,8 @@ var EventEmitter = require('events').EventEmitter;
 var test = require('tape');
 var Timer = require('time-mock');
 
-var core = require('../lib/trace/core');
-var TracerStore = require('../lib/trace/store');
+var core = require('../../lib/trace/core');
+var TracerStore = require('../../lib/trace/store');
 
 var timer = Timer(1000);
 // workaround timer id 0 by setting a throwaway, increments to 1


### PR DESCRIPTION
The disorganization had gone unaddressed for far too long. This PR at least puts all straggler tests under the units folder.

@uber/ringpop 