### PR TITLE
WIP Membership-only leave w/ ttl

### DIFF
--- a/index.js
+++ b/index.js
@@ -665,6 +665,13 @@ RingPop.prototype.handleOrProxyAll =
         }
     };
 
+// Valid opts for this function are those that are compatible with the
+// LeaveUpdate class defined in lib/membership/update.js.
+RingPop.prototype.leave = function leave(opts) {
+    this.membership.makeLeave(this.whoami(),
+        this.membership.getIncarnationNumber(), opts);
+};
+
 // This function is defined for testing purposes only.
 RingPop.prototype.allowJoins = function allowJoins() {
     this.isDenyingJoins = false;

--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -20,6 +20,7 @@
 'use strict';
 
 var EventEmitter = require('events').EventEmitter;
+var PiggybackData = require('./piggyback_data.js');
 var util = require('util');
 
 var LOG_10 = Math.log(10);
@@ -28,7 +29,7 @@ function Dissemination(ringpop) {
     this.ringpop = ringpop;
     this.ringpop.on('ringChanged', this.onRingChanged.bind(this));
 
-    this.changes = {};
+    this.piggybackData = new PiggybackData(this);
     this.maxPiggybackCount = Dissemination.Defaults.maxPiggybackCount;
     this.piggybackFactor = Dissemination.Defaults.piggybackFactor;
 }
@@ -55,7 +56,7 @@ Dissemination.prototype.adjustMaxPiggybackCount = function adjustMaxPiggybackCou
 };
 
 Dissemination.prototype.clearChanges = function clearChanges() {
-    this.changes = [];
+    this.piggybackData.clear();
 };
 
 Dissemination.prototype.fullSync = function fullSync() {
@@ -65,6 +66,7 @@ Dissemination.prototype.fullSync = function fullSync() {
         var member = this.ringpop.membership.members[i];
 
         changes.push({
+            id: require('node-uuid').v4(),
             source: this.ringpop.whoami(),
             address: member.address,
             status: member.status,
@@ -123,56 +125,28 @@ Dissemination.prototype.onRingChanged = function onRingChanged() {
 };
 
 Dissemination.prototype.recordChange = function recordChange(change) {
-    this.changes[change.address] = change;
+    this.piggybackData.recordChange(change);
 };
 
 Dissemination.prototype.resetMaxPiggybackCount = function resetMaxPiggybackCount() {
     this.maxPiggybackCount = Dissemination.Defaults.maxPiggybackCount;
 };
 
-Dissemination.prototype._issueAs = function _issueAs(filterChange, mapChanges) {
-    var changesToDisseminate = [];
+Dissemination.prototype._issueAs = function issueAs(filterChange, mapChanges) {
+    var self = this;
+    var disseminate = [];
 
-    var changedNodes = Object.keys(this.changes);
-
-    for (var i = 0; i < changedNodes.length; i++) {
-        var address = changedNodes[i];
-        var change = this.changes[address];
-
-        // TODO We're bumping the piggyback count even though
-        // we don't know whether the change successfully made
-        // it over to the other side. This can result in undesired
-        // full-syncs.
-        if (typeof change.piggybackCount === 'undefined') {
-            change.piggybackCount = 0;
+    this.piggybackData.issue(function onData(data) {
+        if (typeof filterChange === 'function' && filterChange(data)) {
+            self.ringpop.stat('increment', 'filtered-change');
+            return;
         }
 
-        if (typeof filterChange === 'function' && filterChange(change)) {
-            this.ringpop.stat('increment', 'filtered-change');
-            continue;
-        }
+        disseminate.push(data);
+    });
 
-        change.piggybackCount += 1;
-
-        if (change.piggybackCount > this.maxPiggybackCount) {
-            delete this.changes[address];
-            continue;
-        }
-
-        // TODO Include change timestamp
-        changesToDisseminate.push({
-            id: change.id,
-            source: change.source,
-            sourceIncarnationNumber: change.sourceIncarnationNumber,
-            address: change.address,
-            status: change.status,
-            incarnationNumber: change.incarnationNumber
-        });
-    }
-
-    this.ringpop.stat('gauge', 'changes.disseminate', changesToDisseminate.length);
-
-    return mapChanges(changesToDisseminate);
+    this.ringpop.stat('gauge', 'changes.disseminate', disseminate.length);
+    return mapChanges(disseminate);
 };
 
 Dissemination.Defaults = {

--- a/lib/gossip/piggyback_data.js
+++ b/lib/gossip/piggyback_data.js
@@ -1,0 +1,71 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+function PiggybackData(dissemination) {
+    this.dissemination = dissemination;
+    this.membershipChanges = {}; // indexed by address
+    this.counts = {}; // indexed by id
+}
+
+PiggybackData.prototype.clear = function clear() {
+    this.membershipChanges = {};
+    this.counts = {};
+};
+
+PiggybackData.prototype.issue = function issue(yieldTo) {
+    // Yield changes until they exceed maximum piggyback count.
+    // When they do, mark them for deletion after yielding all
+    // possible changes.
+    var purgeable = [];
+    var addresses = Object.keys(this.membershipChanges);
+    for (var i = 0; i < addresses.length; i++) {
+        var change = this.membershipChanges[addresses[i]];
+        var count = this.counts[change.id];
+
+        if (count > this.dissemination.maxPiggybackCount) {
+            purgeable.push(change);
+            continue;
+        }
+
+        yieldTo(change);
+        this.counts[change.id]++;
+    }
+
+    this._purgeChanges(purgeable);
+};
+
+PiggybackData.prototype.recordChange = function recordChange(change) {
+    this.membershipChanges[change.address] = change;
+    this.counts[change.id] = 0;
+};
+
+PiggybackData.prototype._deleteChange = function _deleteChange(change) {
+    delete this.membershipChanges[change.address];
+    delete this.counts[change.id];
+};
+
+PiggybackData.prototype._purgeChanges = function _purgeChanges(changes) {
+    for (var i = 0; i < changes.length; i++) {
+        this._deleteChange(changes[i]);
+    }
+};
+
+module.exports = PiggybackData;

--- a/lib/membership/events.js
+++ b/lib/membership/events.js
@@ -27,6 +27,15 @@ function LocalMemberLeaveEvent(member, oldStatus) {
 
 LocalMemberLeaveEvent.Name = 'localMemberLeave';
 
+function LocalMemberAliveEvent(member, oldStatus) {
+    this.name = LocalMemberAliveEvent.Name;
+    this.member = member;
+    this.oldStatus = oldStatus;
+}
+
+LocalMemberAliveEvent.Name = 'localMemberAlive';
+
 module.exports = {
+    LocalMemberAliveEvent: LocalMemberAliveEvent,
     LocalMemberLeaveEvent: LocalMemberLeaveEvent
 };

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -41,6 +41,8 @@ function Membership(opts) {
     this.checksum = null;
     this.stashedUpdates = [];
     this.decayTimer = null;
+    this.expirationTimer = null;
+    this.updatesWithTtl = {}; // indexed by address
 }
 
 util.inherits(Membership, EventEmitter);
@@ -189,10 +191,10 @@ Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber
         Member.Status.faulty, this.localMember));
 };
 
-Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber) {
+Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber, opts) {
     this.ringpop.stat('increment', 'make-leave');
     return this._updateMember(new LeaveUpdate(address, incarnationNumber,
-        this.localMember));
+        this.localMember, opts));
 };
 
 Membership.prototype.makeSuspect = function makeSuspect(address, incarnationNumber) {
@@ -315,6 +317,13 @@ Membership.prototype.update = function update(changes, isLocal) {
             });
         }
 
+        if (typeof update.ttl === 'undefined' &&
+            self.updatesWithTtl[update.address]) {
+            delete self.updatesWithTtl[update.address];
+        } else if (update.ttl > 0) {
+            self.updatesWithTtl[update.address] = update;
+        }
+
         updates.push(update);
     }
 };
@@ -345,10 +354,34 @@ Membership.prototype.startDampScoreDecayer = function startDampScoreDecayer() {
     }
 };
 
+Membership.prototype.startExpirationTimer = function startExpirationTimer() {
+    var self = this;
+
+    if (this.expirationTimer) {
+        return;
+    }
+
+    schedule();
+
+    function schedule() {
+        self.expirationTimer = self.setTimeout(function onTimeout() {
+            self._onExpirationInterval();
+            schedule(); // loop until stopped or disabled
+        }, 1000);
+    }
+};
+
 Membership.prototype.stopDampScoreDecayer = function stopDampScoreDecayer() {
     if (this.decayTimer) {
         clearTimeout(this.decayTimer);
         this.decayTimer = null;
+    }
+};
+
+Membership.prototype.stopExpirationTimer = function stopExpirationTimer() {
+    if (this.expirationTimer) {
+        clearTimeout(this.expirationTimer);
+        this.expirationTimer = null;
     }
 };
 
@@ -378,6 +411,24 @@ Membership.prototype._decayMembersDampScore = function _decayMembersDampScore() 
     }
 };
 
+Membership.prototype._onExpirationInterval = function _onExpirationInterval() {
+    var addresses = Object.keys(this.updatesWithTtl);
+    for (var i = 0; i < addresses.length; i++) {
+        var address = addresses[i];
+        var update = this.updatesWithTtl[address];
+        if (Date.now() - update.timestamp >= update.ttl) {
+            switch (update.status) {
+                case Member.Status.leave:
+                    if (update.address === this.ringpop.whoami()) {
+                        this.makeAlive(update.address, Date.now());
+                    }
+            }
+
+            delete this.updatesWithTtl[address];
+        }
+    }
+};
+
 Membership.prototype._updateMember = function _updateMember(update, isLocal) {
     var updates = this.update(update, isLocal);
 
@@ -402,11 +453,13 @@ module.exports = function initMembership(ringpop) {
     });
     membership.on('memberSuppressLimitExceeded', onExceeded);
     membership.startDampScoreDecayer();
+    membership.startExpirationTimer();
     ringpop.on('destroyed', onDestroyed);
     return membership;
 
     function onDestroyed() {
         membership.stopDampScoreDecayer();
+        membership.stopExpirationTimer();
     }
 
     function onExceeded(/*member*/) {

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -21,6 +21,7 @@
 
 var _ = require('underscore');
 var EventEmitter = require('events').EventEmitter;
+var LocalMemberAliveEvent = require('./events.js').LocalMemberAliveEvent;
 var LocalMemberLeaveEvent = require('./events.js').LocalMemberLeaveEvent;
 var numOrDefault = require('../util.js').numOrDefault;
 var util = require('util');
@@ -89,8 +90,11 @@ Member.prototype.evaluateUpdate = function evaluateUpdate(update) {
 
         if (this.address === this.ringpop.whoami()) {
             if (this.status === Member.Status.leave) {
-                var event = new LocalMemberLeaveEvent(this, oldStatus);
-                this.ringpop.membership.emit('event', event);
+                this.ringpop.membership.emit('event',
+                    new LocalMemberLeaveEvent(this, oldStatus));
+            } else if (this.status === Member.Status.alive) {
+                this.ringpop.membership.emit('event',
+                    new LocalMemberAliveEvent(this, oldStatus));
             }
         }
     }

--- a/lib/membership/update.js
+++ b/lib/membership/update.js
@@ -41,9 +41,12 @@ function Update(address, incarnationNumber, status, localMember) {
 
 util.inherits(Update, BaseUpdate);
 
-function LeaveUpdate(address, incarnationNumber, localMember) {
+function LeaveUpdate(address, incarnationNumber, localMember, opts) {
     LeaveUpdate.super_.call(this, address, incarnationNumber, Member.Status.leave,
         localMember);
+
+    this.membershipOnly = opts.membershipOnly;
+    this.ttl = opts.ttl;
 }
 
 util.inherits(LeaveUpdate, Update);

--- a/lib/on_membership_event.js
+++ b/lib/on_membership_event.js
@@ -32,6 +32,12 @@ function createChecksumComputedHandler(ringpop) {
 function createEventHandler(ringpop) {
     return function onEvent(event) {
         switch (event.name) {
+            case MembershipEvents.LocalMemberAliveEvent.Name:
+                if (event.oldStatus === Member.Status.leave) {
+                    ringpop.gossip.start();
+                    ringpop.suspicion.reenable();
+                }
+                break;
             case MembershipEvents.LocalMemberLeaveEvent.Name:
                 ringpop.gossip.stop();
                 ringpop.suspicion.stopAll();

--- a/lib/ring/index.js
+++ b/lib/ring/index.js
@@ -17,6 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+'use strict';
+
 var EventEmitter = require('events').EventEmitter;
 var farmhash = require('farmhash');
 var util = require('util');

--- a/server/admin/member.js
+++ b/server/admin/member.js
@@ -20,6 +20,7 @@
 'use strict';
 
 var errors = require('../../lib/errors.js');
+var safeParse = require('../../lib/util.js').safeParse;
 var sendJoin = require('../../lib/gossip/join-sender.js').joinCluster;
 var TypedError = require('error/typed');
 
@@ -86,9 +87,11 @@ function createLeaveHandler(ringpop) {
             return;
         }
 
-        // TODO Explicitly infect other members (like admin join)?
-        ringpop.membership.makeLeave(ringpop.whoami(),
-            ringpop.membership.localMember.incarnationNumber);
+        var body = safeParse(arg2.toString());
+        ringpop.leave({
+            membershipOnly: body.membershipOnly,
+            ttl: body.ttl
+        });
 
         process.nextTick(function() {
             callback(null, null, 'ok');


### PR DESCRIPTION
This PR supports a membership-only leave with a specifiable TTL on the leave operation. @Raynos asked about this on Friday. I've also taken a few liberties to clean up some piggyback code so that arbitrary options like `membershipOnly` can be disseminated. 

This code isn't ready for review. It's got no tests and there's still a fair bit of cleanup, but I've tested it locally and it does the right thing. I feel it's in a good enough place to let other people have at it in a test/stage environment.

Here's how you'd use it. Either invoke directly on the ringpop instance:

```
ringpop.leave({
  membershipOnly: true,
  ttl: 30000
});
```

or through its admin API which would look something like:

```
tcurl -p 192.168.1.10:3000 ringpop /admin/member/leave -3 '{"membershipOnly": false, "ttl": 30000}'
```

@uber/ringpop 
