### PR TITLE
Damping subprotocol

### DIFF
--- a/client.js
+++ b/client.js
@@ -85,8 +85,8 @@ RingpopClient.prototype.protocolPingReq = function protocolPingReq(opts, body, c
     this._request(opts, '/protocol/ping-req', null, body, callback);
 };
 
-RingpopClient.prototype.protocolDampReq = function protocolDampReq(host, body, callback) {
-    this._request(host, '/protocol/damp-req', null, body, callback);
+RingpopClient.prototype.protocolDampReq = function protocolDampReq(opts, body, callback) {
+    this._request(opts, '/protocol/damp-req', null, body, callback);
 };
 
 RingpopClient.prototype.destroy = function destroy(callback) {

--- a/client.js
+++ b/client.js
@@ -85,6 +85,10 @@ RingpopClient.prototype.protocolPingReq = function protocolPingReq(opts, body, c
     this._request(opts, '/protocol/ping-req', null, body, callback);
 };
 
+RingpopClient.prototype.protocolDampReq = function protocolDampReq(host, body, callback) {
+    this._request(host, '/protocol/damp-req', null, body, callback);
+};
+
 RingpopClient.prototype.destroy = function destroy(callback) {
     if (this.isChannelOwner) {
         this.tchannel.close(callback);

--- a/config.js
+++ b/config.js
@@ -68,10 +68,11 @@ Config.prototype._seed = function _seed(seed) {
 
     // Logger configs
     seedOrDefault('defaultLogLevel', LoggingLevels.info);
-    seedOrDefault('dampingLogLevel', LoggingLevels.debug);
+    seedOrDefault('dampingLogLevel', LoggingLevels.error);
     seedOrDefault('disseminationLogLevel', LoggingLevels.error);
-    seedOrDefault('gossipLogLevel', LoggingLevels.off);
+    seedOrDefault('gossipLogLevel', LoggingLevels.error);
     seedOrDefault('joinLogLevel', LoggingLevels.warn);
+    seedOrDefault('membershipLogLevel', LoggingLevels.error);
     seedOrDefault('suspicionLogLevel', LoggingLevels.error);
 
     // Gossip configs
@@ -83,6 +84,7 @@ Config.prototype._seed = function _seed(seed) {
     seedOrDefault('dampedMemberExpirationInterval', 60000);
     seedOrDefault('dampReqNVal', 6);
     seedOrDefault('dampReqRVal', 3);
+    seedOrDefault('dampReqTimeout', 1000);
     seedOrDefault('dampScoringEnabled', true);
     seedOrDefault('dampScoringDecayEnabled', true);
     seedOrDefault('dampScoringDecayInterval', 1000);

--- a/config.js
+++ b/config.js
@@ -88,7 +88,7 @@ Config.prototype._seed = function _seed(seed) {
     seedOrDefault('dampScoringEnabled', true);
     seedOrDefault('dampScoringDecayEnabled', true);
     seedOrDefault('dampScoringDecayInterval', 1000);
-    seedOrDefault('dampScoringHalfLife', 60);
+    seedOrDefault('dampScoringHalfLife', 60 * 5); // 5 minutes in seconds
     // TODO Initial should never be below min nor above max
     seedOrDefault('dampScoringInitial', 0);
     seedOrDefault('dampScoringMax', 10000);

--- a/config.js
+++ b/config.js
@@ -66,7 +66,7 @@ Config.prototype._seed = function _seed(seed) {
     // All config names should be camel-cased.
     seedOrDefault('TEST_KEY', 100, numValidator); // never remove, tests and lives depend on it
 
-    // Logger configs
+    // Logger configs; should be at least error by default.
     seedOrDefault('defaultLogLevel', LoggingLevels.info);
     seedOrDefault('dampingLogLevel', LoggingLevels.error);
     seedOrDefault('disseminationLogLevel', LoggingLevels.error);

--- a/config.js
+++ b/config.js
@@ -68,15 +68,21 @@ Config.prototype._seed = function _seed(seed) {
 
     // Logger configs
     seedOrDefault('defaultLogLevel', LoggingLevels.info);
-    seedOrDefault('dampingLogLevel', LoggingLevels.warn);
+    seedOrDefault('dampingLogLevel', LoggingLevels.debug);
+    seedOrDefault('disseminationLogLevel', LoggingLevels.error);
     seedOrDefault('gossipLogLevel', LoggingLevels.off);
     seedOrDefault('joinLogLevel', LoggingLevels.warn);
-    seedOrDefault('disseminationLogLevel', LoggingLevels.off);
+    seedOrDefault('suspicionLogLevel', LoggingLevels.error);
 
     // Gossip configs
     seedOrDefault('autoGossip', true);
 
     seedOrDefault('isCrossPlatform', false);
+    seedOrDefault('dampedErrorLoggingEnabled', false);
+    seedOrDefault('dampedMaxPercentage', 10);
+    seedOrDefault('dampedMemberExpirationInterval', 60000);
+    seedOrDefault('dampReqNVal', 6);
+    seedOrDefault('dampReqRVal', 3);
     seedOrDefault('dampScoringEnabled', true);
     seedOrDefault('dampScoringDecayEnabled', true);
     seedOrDefault('dampScoringDecayInterval', 1000);
@@ -89,6 +95,7 @@ Config.prototype._seed = function _seed(seed) {
     seedOrDefault('dampScoringReuseLimit', 2500);
     seedOrDefault('dampScoringSuppressDuration', 60 * 60 * 1000); // 1 hr in ms
     seedOrDefault('dampScoringSuppressLimit', 5000);
+    seedOrDefault('dampTimerInterval', 60 * 1000); // 1min in ms
 
     // Joiner config
     seedOrDefault('joinDelayMin', 100, numValidator); // ms

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ var Gossip = require('./lib/gossip');
 var Suspicion = require('./lib/gossip/suspicion');
 
 var Config = require('./config.js');
+var Damper = require('./lib/gossip/damper.js');
 var Dissemination = require('./lib/gossip/dissemination.js');
 var errors = require('./lib/errors.js');
 var getTChannelVersion = require('./lib/util.js').getTChannelVersion;
@@ -156,6 +157,9 @@ function RingPop(options) {
     this.gossip = new Gossip({
         ringpop: this,
         minProtocolPeriod: options.minProtocolPeriod
+    });
+    this.damper = new Damper({
+        ringpop: this
     });
     this.suspicion = new Suspicion({
         ringpop: this,

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -210,7 +210,7 @@ Damper.prototype.expireDampedMembers = function expireDampedMembers() {
     var keys = Object.keys(this.dampedMembers);
     for (var i = 0; i < keys.length; i++) {
         var key = keys[i];
-        var memberDamping = this.dampedMembers[keys[i]];
+        var memberDamping = this.dampedMembers[key];
         var dampedDuration = this.Date.now() - memberDamping.timestamp;
         if (dampedDuration >= suppressDuration) {
             delete this.dampedMembers[key];

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -155,6 +155,10 @@ Damper.prototype.addFlapper = function addFlapper(flapper) {
         Object.keys(this.flappers).length);
 
     if (this._getFlapperCount() === 1) {
+        this.logger.debug('ringpop damper starting damp timer; a flapper has been added', {
+            local: this.ringpop.whoami(),
+            flapper: flapper.address
+        });
         this._startDampTimer();
     }
 
@@ -188,6 +192,10 @@ Damper.prototype.dampMember = function dampMember(addr)  {
     this.addDampedMember(member.address);
 
     if (!this.isExpirationTimerEnabled) {
+        this.logger.debug('ringpop damper starting expiration timer; a member has been damped', {
+            local: this.ringpop.whoami(),
+            member: member.address
+        });
         this._startExpirationTimer();
     }
 
@@ -224,6 +232,9 @@ Damper.prototype.expireDampedMembers = function expireDampedMembers() {
 
     // If there are no more damped members, stop trying to expire them.
     if (Object.keys(this.dampedMembers).length === 0) {
+        this.logger.debug('ringpop damper stopping expiration timer; no damped members left', {
+            local: this.ringpop.whoami()
+        });
         this._stopExpirationTimer();
     }
 
@@ -349,9 +360,10 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
 Damper.prototype.removeFlapper = function removeFlapper(flapper) {
     var address = flapper.address || flapper;
     if (!this.flappers[address]) {
-        this.logger.debug('ringpop flapper has not been added to the damper', {
+        this.logger.debug('ringpop damper did not remove flapper; it was not added. it may be damped.', {
             local: this.ringpop.whoami(),
-            flapper: address
+            flapper: address,
+            isDamped: !!this.dampedMembers[address]
         });
         return false;
     }
@@ -366,6 +378,9 @@ Damper.prototype.removeFlapper = function removeFlapper(flapper) {
         Object.keys(this.flappers).length);
 
     if (this._getFlapperCount() === 0) {
+        this.logger.debug('ringpop damper stopping damp timer; no flappers left', {
+            local: this.ringpop.whoami()
+        });
         this._stopDampTimer();
     }
 
@@ -380,7 +395,10 @@ Damper.prototype._fanoutDampReqs = function _fanoutDampReqs(flapperAddrs, dampRe
     for (var i = 0; i < dampReqMembers.length; i++) {
         var dampReqAddr = dampReqMembers[i].address;
         this.ringpop.stat('increment', 'damp-req.send');
-        this.ringpop.client.protocolDampReq(dampReqAddr, request,
+        this.ringpop.client.protocolDampReq({
+            host: dampReqAddr,
+            timeout: this.ringpop.config.get('dampReqTimeout')
+        }, request,
             createDampReqHandler(dampReqAddr));
     }
 
@@ -391,7 +409,11 @@ Damper.prototype._fanoutDampReqs = function _fanoutDampReqs(flapperAddrs, dampRe
     // Accumulate responses until rVal is satisfied or is impossible to satisfy because
     // too many error responses.
     function createDampReqHandler(addr) {
+        var start = Date.now();
         return function onDampReq(err, res) {
+            var timing = Date.now() - start;
+            self.ringpop.stat('timing', 'protocol.damp-req', timing);
+
             // Prevents double-callback
             if (typeof callback !== 'function') return;
 
@@ -407,6 +429,7 @@ Damper.prototype._fanoutDampReqs = function _fanoutDampReqs(flapperAddrs, dampRe
                 // Enrich the result with the addr of the damp
                 // req member for reporting purposes.
                 res.dampReqAddr = addr;
+                res.timing = timing;
                 results.push(res);
             }
 
@@ -459,6 +482,9 @@ Damper.prototype._startDampTimer = function _startDampTimer() {
         // in the event that a Ringpop cluster is significantly degraded. Fanning-out
         // damp-req requests may only make matters worse.
         self.dampTimer = self.timers.setTimeout(function onTimeout() {
+            self.logger.debug('ringpop damper damp timer tick', {
+                local: self.ringpop.whoami()
+            });
             self.initiateSubprotocol(function onSubprotocol() {
                 // It may be the case that the damp timer is stopped while in the
                 // middle of a subprotocol. Make sure we don't schedule another
@@ -488,6 +514,9 @@ Damper.prototype._startExpirationTimer = function _startExpirationTimer() {
     function schedule() {
         self.expirationTimer =
             self.timers.setTimeout(function onTimeout() {
+                self.logger.debug('ringpop damper expiration timer tick', {
+                    local: self.ringpop.whoami()
+                });
                 self.expireDampedMembers();
                 if (self.isExpirationTimerEnabled) schedule();
         }, self.ringpop.config.get('dampedMemberExpirationInterval'));

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -221,7 +221,7 @@ Damper.prototype.expireDampedMembers = function expireDampedMembers() {
         return undampedMembers;
     }
 
-    this.emit('event', new events.DampedMemberExpirationEvent(undampedMembers));
+    this.emit('dampedMemberExpiration', new events.DampedMemberExpirationEvent(undampedMembers));
     this.logger.info('ringpop damper undamped members', {
         local: this.ringpop.whoami(),
         suppressDuration: suppressDuration,
@@ -279,7 +279,7 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
         local: this.ringpop.whoami(),
         flappers: flapperAddrs
     });
-    this.emit('event', new events.DamperStartedEvent());
+    this.emit('started', new events.DamperStartedEvent());
 
     // Select members to receive the damp-req.
     var nVal = config.get('dampReqNVal');
@@ -299,7 +299,7 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
             nVal: nVal,
             numDampReqMembers: dampReqMembers.length
         });
-        this.emit('event', new events.DampReqUnsatisfiedEvent());
+        this.emit('dampReqUnsatisfied', new events.DampReqUnsatisfiedEvent());
         callback();
         return;
     }
@@ -314,7 +314,7 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
                 dampReqMembers: dampReqMemberAddrs,
                 errors: err
             });
-            self.emit('event', new events.DampReqFailedEvent(err));
+            self.emit('dampReqFailed', new events.DampReqFailedEvent(err));
             callback();
             return;
         }
@@ -337,7 +337,7 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
                 dampReqMembers: dampReqMemberAddrs,
                 results: res
             });
-            self.emit('event', new events.DampingInconclusiveEvent());
+            self.emit('dampingInconclusive', new events.DampingInconclusiveEvent());
             callback();
             return;
         }
@@ -353,7 +353,7 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
             membersToDamp: membersToDamp,
             results: res
         });
-        self.emit('event', new events.DampedEvent());
+        self.emit('damped', new events.DampedEvent());
         callback();
     }
 };
@@ -580,7 +580,7 @@ Damper.prototype._validateDampedClusterLimits = function _validateDampedClusterL
         dampedMax: dampedMax,
         dampedMembers: dampedMemberAddrs
     });
-    this.emit('event', new events.DampedLimitExceededEvent());
+    this.emit('dampedLimitExceeded', new events.DampedLimitExceededEvent());
     return false;
 };
 

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -53,13 +53,14 @@ function Damper(opts) {
     // removes them.
     this.dampedMembers = {}; // indexed by address
 
-    this.isDampTimerEnabled = false;
     // This damp timer runs only when there are flappy members
     // add to the flappers collection above.
+    this.isDampTimerEnabled = false;
     this.dampTimer = null;
 
     // The expiration timer runs only when there are damped members
     // in the dampedMembers collection above.
+    this.isExpirationTimerEnabled = false;
     this.expirationTimer = null;
 }
 
@@ -161,7 +162,6 @@ Damper.prototype.addFlapper = function addFlapper(flapper) {
 };
 
 Damper.prototype.dampMember = function dampMember(addr)  {
-    var self = this;
     var member = this.ringpop.membership.findMemberByAddress(addr);
 
     if (!member) {
@@ -187,22 +187,11 @@ Damper.prototype.dampMember = function dampMember(addr)  {
     this.removeFlapper(member.address);
     this.addDampedMember(member.address);
 
-    if (!this.expirationTimer) {
-        scheduleExpiration();
-        this.logger.info('ringpop started damped member expiration timer', {
-            local: this.ringpop.whoami()
-        });
+    if (!this.isExpirationTimerEnabled) {
+        this._startExpirationTimer();
     }
 
     return true;
-
-    function scheduleExpiration() {
-        self.expirationTimer =
-            self.timers.setTimeout(function onTimeout() {
-                self.expireDampedMembers();
-                scheduleExpiration();
-        }, self.ringpop.config.get('dampedMemberExpirationInterval'));
-    }
 };
 
 Damper.prototype.expireDampedMembers = function expireDampedMembers() {
@@ -480,6 +469,31 @@ Damper.prototype._startDampTimer = function _startDampTimer() {
     }
 };
 
+Damper.prototype._startExpirationTimer = function _startExpirationTimer() {
+    var self = this;
+
+    if (this.isExpirationTimerEnabled) {
+        this.logger.debug('ringpop damper expiration timer already started', {
+            local: this.ringpop.whoami()
+        });
+        return;
+    }
+
+    this.isExpirationTimerEnabled = true;
+    schedule();
+    this.logger.debug('ringpop damper expiration timer started', {
+        local: this.ringpop.whoami()
+    });
+
+    function schedule() {
+        self.expirationTimer =
+            self.timers.setTimeout(function onTimeout() {
+                self.expireDampedMembers();
+                if (self.isExpirationTimerEnabled) schedule();
+        }, self.ringpop.config.get('dampedMemberExpirationInterval'));
+    }
+};
+
 Damper.prototype._stopDampTimer = function _stopDampTimer() {
     if (!this.isDampTimerEnabled) {
         this.logger.debug('ringpop damper already stopped damp timer', {
@@ -497,7 +511,7 @@ Damper.prototype._stopDampTimer = function _stopDampTimer() {
 };
 
 Damper.prototype._stopExpirationTimer = function _stopExpirationTimer() {
-    if (!this.expirationTimer) {
+    if (!this.isExpirationTimerEnabled) {
         this.logger.debug('ringpop damper expiration timer already stopped', {
             local: this.ringpop.whoami()
         });
@@ -506,6 +520,7 @@ Damper.prototype._stopExpirationTimer = function _stopExpirationTimer() {
 
     this.timers.clearTimeout(this.expirationTimer);
     this.expirationTimer = null;
+    this.isExpirationTimerEnabled = false;
     this.logger.info('ringpop damper stopped expiration timer', {
         local: this.ringpop.whoami()
     });

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -23,6 +23,7 @@ var DampReqRequest = require('../../request_response.js').DampReqRequest;
 var EventEmitter = require('events').EventEmitter;
 var events = require('./events.js');
 var globalTimers = require('timers');
+var LoggingLevels = require('../logging/levels.js');
 var TypedError = require('error/typed');
 var util = require('util');
 
@@ -317,11 +318,16 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
             return;
         }
 
-        self.logger.debug('ringpop damper received all damp-req responses', {
-            local: self.ringpop.whoami(),
-            flappers: flapperAddrs,
-            responses: JSON.stringify(res)
-        });
+        // This log-level check is here to prevent stringification of responses
+        // in cases where level is set above debug.
+        if (self.logger.canLogAt(LoggingLevels.debug)) {
+            self.logger.debug('ringpop damper received all damp-req responses', {
+                local: self.ringpop.whoami(),
+                flappers: flapperAddrs,
+                responses: JSON.stringify(res)
+            });
+        }
+
         var membersToDamp = Damper.getMembersToDamp(res, rVal, config);
         if (membersToDamp.length === 0) {
             self.ringpop.stat('increment', 'damper.damp-req.inconclusive');

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -182,6 +182,15 @@ Damper.prototype.dampMember = function dampMember(addr)  {
         return false;
     }
 
+    if (!this._validateDampedClusterLimits()) {
+        this.logger.warn('ringpop damper reached maximum allowable damped members; will not damp member', {
+            local: this.ringpop.whoami(),
+            dampedMembers: Object.keys(this.dampedMembers),
+            member: addr
+        });
+        return;
+    }
+
     this.ringpop.membership.makeDamped(member.address);
 
     // Don't start anymore damping subprotocols for a member
@@ -270,6 +279,10 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
 
     // TODO Stop damp timer when cluster has reached damped limits
     if (!this._validateDampedClusterLimits()) {
+        this.logger.warn('ringpop damper reached maximum allowable damped members; will not initiate subprotocol', {
+            local: this.ringpop.whoami(),
+            dampedMembers: Object.keys(this.dampedMembers)
+        });
         callback();
         return;
     }
@@ -361,7 +374,7 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
 Damper.prototype.removeFlapper = function removeFlapper(flapper) {
     var address = flapper.address || flapper;
     if (!this.flappers[address]) {
-        this.logger.debug('ringpop damper did not remove flapper; it was not added. it may be damped.', {
+        this.logger.debug('ringpop damper did not remove flapper; it may be damped.', {
             local: this.ringpop.whoami(),
             flapper: address,
             isDamped: !!this.dampedMembers[address]
@@ -574,12 +587,6 @@ Damper.prototype._validateDampedClusterLimits = function _validateDampedClusterL
         return true;
     }
 
-    this.logger.warn('ringpop damper reached maximum allowable damped members', {
-        local: this.ringpop.whoami(),
-        dampedCurrent: dampedCurrent,
-        dampedMax: dampedMax,
-        dampedMembers: dampedMemberAddrs
-    });
     this.emit('dampedLimitExceeded', new events.DampedLimitExceededEvent());
     return false;
 };

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -258,6 +258,14 @@ Damper.prototype.hasStarted = function hasStarted() {
     return !!this.dampTimer;
 };
 
+// This function starts what is called "the damp-req subprotocol," which is a
+// fancy name for fanning-out damp-req requests to a random collection of other
+// members. The damp-req asks for the damp scores of members that were previously
+// added to the internal flappers collection of this Damper module.
+//
+// initiateSubprotocol() is called periodically by the background damp timer when
+// "flappers" have been added. If no flappers exist or all flappers have been removed,
+// then the damp timer will be canceled and the subprotocol will not be initiated.
 Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
     var self = this;
     var config = this.ringpop.config;
@@ -268,11 +276,6 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
         return;
     }
 
-    // You may think that a check to verify that flappers actually
-    // exist before firing off the fanout is necessary. I know I did.
-    // But in fact, the subprotocol will only ever be initiated when
-    // there are known flappers. Otherwise the damp timer would never
-    // have been scheduled.
     var flapperAddrs = this._getFlapperAddrs();
     this.logger.info('ringpop damper started', {
         local: this.ringpop.whoami(),
@@ -303,9 +306,9 @@ Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
         return;
     }
 
-    this._fanoutDampReqs(flapperAddrs, dampReqMembers, rVal, onDampReqs);
+    this._fanoutDampReqs(flapperAddrs, dampReqMembers, rVal, onFanout);
 
-    function onDampReqs(err, res) {
+    function onFanout(err, res) {
         if (err) {
             self.ringpop.stat('increment', 'damper.damp-req.error');
             self.logger.warn('ringpop damper errored out', {

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -412,9 +412,9 @@ Damper.prototype._fanoutDampReqs = function _fanoutDampReqs(flapperAddrs, dampRe
     // Accumulate responses until rVal is satisfied or is impossible to satisfy because
     // too many error responses.
     function createDampReqHandler(addr) {
-        var start = Date.now();
+        var start = self.Date.now();
         return function onDampReq(err, res) {
-            var timing = Date.now() - start;
+            var timing = self.Date.now() - start;
             self.ringpop.stat('timing', 'protocol.damp-req', timing);
 
             // Prevents double-callback

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -1,0 +1,530 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var DampReqRequest = require('../../request_response.js').DampReqRequest;
+var EventEmitter = require('events').EventEmitter;
+var events = require('./events.js');
+var globalTimers = require('timers');
+var TypedError = require('error/typed');
+var util = require('util');
+
+var UnattainableRValError = TypedError({
+    type: 'ringpop.damping.unattainable-rval',
+    message: 'Unable to attain damp-req r-val',
+    rVal: null,
+    errors: null
+});
+
+function Damper(opts) {
+    this.ringpop = opts.ringpop;
+    this.timers = opts.timers || globalTimers;
+    this.Date = opts.Date || Date;
+    this.logger = this.ringpop.loggerFactory.getLogger('damping');
+
+    // Flappers are members with damping potential. They have
+    // exceeded the suppression limit and are considered as members
+    // that may need damping. They are no longer considered flappy
+    // when their damp score falls under the reuse limit.
+    this.flappers = {}; // indexed by address (id)
+
+    // TODO This is only temporary collection of damped members
+    // since we're not actually damping them (marking the
+    // member's status to damped) at this point. Damped members
+    // are removed from this collection when the expiration timer
+    // removes them.
+    this.dampedMembers = {}; // indexed by address
+
+    this.isDampTimerEnabled = false;
+    // This damp timer runs only when there are flappy members
+    // add to the flappers collection above.
+    this.dampTimer = null;
+
+    // The expiration timer runs only when there are damped members
+    // in the dampedMembers collection above.
+    this.expirationTimer = null;
+}
+
+util.inherits(Damper, EventEmitter);
+
+function groupDampScoresByFlapper(allResponses) {
+    var dampScoresByFlapper = {};
+
+    for (var i = 0; i < allResponses.length; i++) {
+        var dampReqResponse = allResponses[i];
+
+        var responseScores = dampReqResponse.scores;
+        if (!Array.isArray(responseScores)) continue;
+
+        for (var j = 0; j < responseScores.length; j++) {
+            var responseScore = responseScores[j];
+
+            var member = responseScore.member;
+            dampScoresByFlapper[member] = dampScoresByFlapper[member] || [];
+            dampScoresByFlapper[member].push(responseScore);
+        }
+    }
+
+    return dampScoresByFlapper;
+}
+
+function findFlappersToDamp(dampScoresByFlapper, rVal, suppressLimit) {
+    // Evaluate the damp scores collected from the fan-out. For each flapper
+    // find whether all scores exceed the suppress limit. If so, the flapper
+    // should be damped.
+    var membersToDamp = [];
+
+    var flapperAddrs = Object.keys(dampScoresByFlapper);
+    for (var i = 0; i < flapperAddrs.length; i++) {
+        var flapperAddr = flapperAddrs[i];
+
+        var flapperScores = dampScoresByFlapper[flapperAddr];
+        if (flapperScores.length >= rVal &&
+                haveAllScoresExceededLimit(flapperScores)) {
+            membersToDamp.push(flapperAddr);
+        }
+    }
+
+    return membersToDamp;
+
+    function haveAllScoresExceededLimit(scores) {
+        return scores.every(function each(score) {
+            return score.dampScore >= suppressLimit;
+        });
+    }
+}
+
+// This function definition is pulled up and attached to the constructor
+// so that its output can be easily unit tested.
+Damper.getMembersToDamp = function getMembersToDamp(allResponses, rVal, config) {
+    var dampScoresByFlapper = groupDampScoresByFlapper(allResponses);
+    var suppressLimit = config.get('dampScoringSuppressLimit');
+    return findFlappersToDamp(dampScoresByFlapper, rVal, suppressLimit);
+};
+
+Damper.prototype.addDampedMember = function addDampedMember(memberAddr) {
+    this.dampedMembers[memberAddr] = {
+        timestamp: this.Date.now()
+    };
+};
+
+Damper.prototype.addFlapper = function addFlapper(flapper) {
+    if (this.dampedMembers[flapper.address]) {
+        this.logger.debug('ringpop damper already damped member', {
+            local: this.ringpop.whoami()
+        });
+        return false;
+    }
+
+    if (this.flappers[flapper.address]) {
+        this.logger.debug('ringpop damper already added flapper', {
+            local: this.ringpop.whoami()
+        });
+        return false;
+    }
+
+    // TODO Limit number of flappers?
+    // TODO Expire flappers?
+
+    this.flappers[flapper.address] = flapper;
+    this.logger.debug('ringpop damper added flapper', {
+        local: this.ringpop.whoami(),
+        flapper: flapper.address
+    });
+    this.ringpop.stat('increment', 'damper.flapper.added');
+    this.ringpop.stat('gauge', 'damper.flappers',
+        Object.keys(this.flappers).length);
+
+    if (this._getFlapperCount() === 1) {
+        this._startDampTimer();
+    }
+
+    return true;
+};
+
+Damper.prototype.dampMember = function dampMember(addr)  {
+    var self = this;
+    var member = this.ringpop.membership.findMemberByAddress(addr);
+
+    if (!member) {
+        this.logger.warn('ringpop damper cannot damp member; member does not exist', {
+            local: this.ringpop.whoami(),
+            member: addr
+        });
+        return false;
+    }
+
+    if (!this.hasFlapper(member)) {
+        this.logger.warn('ringpop damper cannot damp member; member is not flappy', {
+            local: this.ringpop.whoami(),
+            member: addr
+        });
+        return false;
+    }
+
+    this.ringpop.membership.makeDamped(member.address);
+
+    // Don't start anymore damping subprotocols for a member
+    // that is already damped.
+    this.removeFlapper(member.address);
+    this.addDampedMember(member.address);
+
+    if (!this.expirationTimer) {
+        scheduleExpiration();
+        this.logger.info('ringpop started damped member expiration timer', {
+            local: this.ringpop.whoami()
+        });
+    }
+
+    return true;
+
+    function scheduleExpiration() {
+        self.expirationTimer =
+            self.timers.setTimeout(function onTimeout() {
+                self.expireDampedMembers();
+                scheduleExpiration();
+        }, self.ringpop.config.get('dampedMemberExpirationInterval'));
+    }
+};
+
+Damper.prototype.expireDampedMembers = function expireDampedMembers() {
+    var undampedMembers = [];
+    var suppressDuration = this.ringpop.config.get('dampScoringSuppressDuration');
+    var keys = Object.keys(this.dampedMembers);
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        var memberDamping = this.dampedMembers[keys[i]];
+        var dampedDuration = this.Date.now() - memberDamping.timestamp;
+        if (dampedDuration >= suppressDuration) {
+            delete this.dampedMembers[key];
+            undampedMembers.push({
+                member: key,
+                timeDamped: dampedDuration
+            });
+        }
+    }
+
+    if (undampedMembers.length === 0) {
+        return undampedMembers;
+    }
+
+    this.emit('event', new events.DampedMemberExpirationEvent(undampedMembers));
+    this.logger.info('ringpop damper undamped members', {
+        local: this.ringpop.whoami(),
+        suppressDuration: suppressDuration,
+        undampedMembers: undampedMembers
+    });
+
+    // If there are no more damped members, stop trying to expire them.
+    if (Object.keys(this.dampedMembers).length === 0) {
+        this._stopExpirationTimer();
+    }
+
+    return undampedMembers;
+};
+
+Damper.prototype.destroy = function destroy() {
+    this._stopDampTimer();
+    this._stopExpirationTimer();
+};
+
+Damper.prototype.isDamped = function isDamped(flapper) {
+    return !!this.dampedMembers[flapper.address];
+};
+
+Damper.prototype.hasFlapper = function hasFlapper(flapper) {
+    return !!this.flappers[flapper.address];
+};
+
+Damper.prototype.hasStarted = function hasStarted() {
+    return !!this.dampTimer;
+};
+
+Damper.prototype.initiateSubprotocol = function initiateSubprotocol(callback) {
+    var self = this;
+    var config = this.ringpop.config;
+
+    // TODO Stop damp timer when cluster has reached damped limits
+    if (!this._validateDampedClusterLimits()) {
+        callback();
+        return;
+    }
+
+    // You may think that a check to verify that flappers actually
+    // exist before firing off the fanout is necessary. I know I did.
+    // But in fact, the subprotocol will only ever be initiated when
+    // there are known flappers. Otherwise the damp timer would never
+    // have been scheduled.
+    var flapperAddrs = this._getFlapperAddrs();
+    this.logger.info('ringpop damper started', {
+        local: this.ringpop.whoami(),
+        flappers: flapperAddrs
+    });
+    this.emit('event', new events.DamperStartedEvent());
+
+    // Select members to receive the damp-req.
+    var nVal = config.get('dampReqNVal');
+    var dampReqMembers = this.ringpop.membership.getRandomPingableMembers(
+        nVal, flapperAddrs);
+    var dampReqMemberAddrs = dampReqMembers.map(function map(member) {
+        return member.address;
+    });
+
+    // Make sure rVal is satisfiable to begin with.
+    var rVal = Math.min(config.get('dampReqRVal'), dampReqMembers.length);
+    if (rVal === 0) {
+        this.logger.warn('ringpop damper skipped subprotocol; there are not enough selectable damp req members', {
+            local: this.ringpop.whoami(),
+            flappers: flapperAddrs,
+            rVal: rVal,
+            nVal: nVal,
+            numDampReqMembers: dampReqMembers.length
+        });
+        this.emit('event', new events.DampReqUnsatisfiedEvent());
+        callback();
+        return;
+    }
+
+    this._fanoutDampReqs(flapperAddrs, dampReqMembers, rVal, onDampReqs);
+
+    function onDampReqs(err, res) {
+        if (err) {
+            self.ringpop.stat('increment', 'damper.damp-req.error');
+            self.logger.warn('ringpop damper errored out', {
+                local: self.ringpop.whoami(),
+                dampReqMembers: dampReqMemberAddrs,
+                errors: err
+            });
+            self.emit('event', new events.DampReqFailedEvent(err));
+            callback();
+            return;
+        }
+
+        self.logger.debug('ringpop damper received all damp-req responses', {
+            local: self.ringpop.whoami(),
+            flappers: flapperAddrs,
+            responses: JSON.stringify(res)
+        });
+        var membersToDamp = Damper.getMembersToDamp(res, rVal, config);
+        if (membersToDamp.length === 0) {
+            self.ringpop.stat('increment', 'damper.damp-req.inconclusive');
+            self.logger.warn('ringpop damper inconclusive', {
+                local: self.ringpop.whoami(),
+                dampReqMembers: dampReqMemberAddrs,
+                results: res
+            });
+            self.emit('event', new events.DampingInconclusiveEvent());
+            callback();
+            return;
+        }
+
+        for (var i = 0; i < membersToDamp.length; i++) {
+            self.dampMember(membersToDamp[i]);
+        }
+
+        self.ringpop.stat('increment', 'damper.damp-req.damped');
+        self.logger.warn('ringpop damped members', {
+            local: self.ringpop.whoami(),
+            dampReqMembers: dampReqMemberAddrs,
+            membersToDamp: membersToDamp,
+            results: res
+        });
+        self.emit('event', new events.DampedEvent());
+        callback();
+    }
+};
+
+Damper.prototype.removeFlapper = function removeFlapper(flapper) {
+    var address = flapper.address || flapper;
+    if (!this.flappers[address]) {
+        this.logger.debug('ringpop flapper has not been added to the damper', {
+            local: this.ringpop.whoami(),
+            flapper: address
+        });
+        return false;
+    }
+
+    delete this.flappers[address];
+    this.logger.debug('ringpop damper removed flapper', {
+        local: this.ringpop.whoami(),
+        flapper: address
+    });
+    this.ringpop.stat('increment', 'damper.flapper.removed');
+    this.ringpop.stat('gauge', 'damper.flappers',
+        Object.keys(this.flappers).length);
+
+    if (this._getFlapperCount() === 0) {
+        this._stopDampTimer();
+    }
+
+    return true;
+};
+
+Damper.prototype._fanoutDampReqs = function _fanoutDampReqs(flapperAddrs, dampReqMembers, rVal, callback) {
+    var self = this;
+
+    // Send out the damp-req to each member selected.
+    var request = new DampReqRequest(this.ringpop, flapperAddrs);
+    for (var i = 0; i < dampReqMembers.length; i++) {
+        var dampReqAddr = dampReqMembers[i].address;
+        this.ringpop.stat('increment', 'damp-req.send');
+        this.ringpop.client.protocolDampReq(dampReqAddr, request,
+            createDampReqHandler(dampReqAddr));
+    }
+
+    var numPendingReqs = dampReqMembers.length;
+    var errors = [];
+    var results = [];
+
+    // Accumulate responses until rVal is satisfied or is impossible to satisfy because
+    // too many error responses.
+    function createDampReqHandler(addr) {
+        return function onDampReq(err, res) {
+            // Prevents double-callback
+            if (typeof callback !== 'function') return;
+
+            numPendingReqs--;
+
+            if (err) {
+                errors.push(err);
+            } else {
+                if (Array.isArray(res.changes)) {
+                    self.ringpop.membership.update(res.changes);
+                }
+
+                // Enrich the result with the addr of the damp
+                // req member for reporting purposes.
+                res.dampReqAddr = addr;
+                results.push(res);
+            }
+
+            // The first rVal requests will be reported.
+            if (results.length >= rVal) {
+                callback(null, results);
+                callback = null;
+                return;
+            }
+
+            if (numPendingReqs < rVal - results.length) {
+                callback(UnattainableRValError({
+                    flappers: flapperAddrs,
+                    rVal: rVal,
+                    errors: errors
+                }));
+                callback = null;
+                return;
+            }
+        };
+    }
+};
+
+Damper.prototype._getFlapperAddrs = function _getFlapperAddrs() {
+    return Object.keys(this.flappers);
+};
+
+Damper.prototype._getFlapperCount = function _getFlapperCount() {
+    return Object.keys(this.flappers).length;
+};
+
+Damper.prototype._startDampTimer = function _startDampTimer() {
+    var self = this;
+
+    if (this.isDampTimerEnabled) {
+        this.logger.debug('ringpop damp timer already started', {
+            local: this.ringpop.whoami()
+        });
+        return;
+    }
+
+    this.isDampTimerEnabled = true;
+    schedule();
+    this.logger.debug('ringpop damper started damp timer', {
+        local: this.ringpop.whoami()
+    });
+
+    function schedule() {
+        // TODO We may want to apply some backoff mechanism to the dampTimerInteval
+        // in the event that a Ringpop cluster is significantly degraded. Fanning-out
+        // damp-req requests may only make matters worse.
+        self.dampTimer = self.timers.setTimeout(function onTimeout() {
+            self.initiateSubprotocol(function onSubprotocol() {
+                // It may be the case that the damp timer is stopped while in the
+                // middle of a subprotocol. Make sure we don't schedule another
+                // run if that happens.
+                if (self.isDampTimerEnabled) schedule();
+            });
+        }, self.ringpop.config.get('dampTimerInterval'));
+    }
+};
+
+Damper.prototype._stopDampTimer = function _stopDampTimer() {
+    if (!this.isDampTimerEnabled) {
+        this.logger.debug('ringpop damper already stopped damp timer', {
+            local: this.ringpop.whoami()
+        });
+        return;
+    }
+
+    this.timers.clearTimeout(this.dampTimer);
+    this.dampTimer = null;
+    this.isDampTimerEnabled = false;
+    this.logger.debug('ringpop damper stopped damp timer', {
+        local: this.ringpop.whoami()
+    });
+};
+
+Damper.prototype._stopExpirationTimer = function _stopExpirationTimer() {
+    if (!this.expirationTimer) {
+        this.logger.debug('ringpop damper expiration timer already stopped', {
+            local: this.ringpop.whoami()
+        });
+        return;
+    }
+
+    this.timers.clearTimeout(this.expirationTimer);
+    this.expirationTimer = null;
+    this.logger.info('ringpop damper stopped expiration timer', {
+        local: this.ringpop.whoami()
+    });
+};
+
+Damper.prototype._validateDampedClusterLimits = function _validateDampedClusterLimits() {
+    // Determine if the portion of damped members in the cluster exceeds
+    // the maximum limit.
+    var dampedMemberAddrs = Object.keys(this.dampedMembers);
+    var dampedCount = dampedMemberAddrs.length;
+    var dampedCurrent = dampedCount * 100 /
+        this.ringpop.membership.getMemberCount();
+    var dampedMax = this.ringpop.config.get('dampedMaxPercentage');
+    if (dampedCurrent < dampedMax) {
+        return true;
+    }
+
+    this.logger.warn('ringpop damper reached maximum allowable damped members', {
+        local: this.ringpop.whoami(),
+        dampedCurrent: dampedCurrent,
+        dampedMax: dampedMax,
+        dampedMembers: dampedMemberAddrs
+    });
+    this.emit('event', new events.DampedLimitExceededEvent());
+    return false;
+};
+
+module.exports = Damper;

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -418,7 +418,9 @@ Damper.prototype._fanoutDampReqs = function _fanoutDampReqs(flapperAddrs, dampRe
             self.ringpop.stat('timing', 'protocol.damp-req', timing);
 
             // Prevents double-callback
-            if (typeof callback !== 'function') return;
+            if (typeof callback !== 'function') {
+                return;
+            }
 
             numPendingReqs--;
 

--- a/lib/gossip/damper.js
+++ b/lib/gossip/damper.js
@@ -55,12 +55,10 @@ function Damper(opts) {
 
     // This damp timer runs only when there are flappy members
     // add to the flappers collection above.
-    this.isDampTimerEnabled = false;
     this.dampTimer = null;
 
     // The expiration timer runs only when there are damped members
     // in the dampedMembers collection above.
-    this.isExpirationTimerEnabled = false;
     this.expirationTimer = null;
 }
 
@@ -191,7 +189,7 @@ Damper.prototype.dampMember = function dampMember(addr)  {
     this.removeFlapper(member.address);
     this.addDampedMember(member.address);
 
-    if (!this.isExpirationTimerEnabled) {
+    if (!this._isExpirationTimerEnabled()) {
         this.logger.debug('ringpop damper starting expiration timer; a member has been damped', {
             local: this.ringpop.whoami(),
             member: member.address
@@ -466,17 +464,24 @@ Damper.prototype._getFlapperCount = function _getFlapperCount() {
     return Object.keys(this.flappers).length;
 };
 
+Damper.prototype._isDampTimerEnabled = function _isDampTimerEnabled() {
+    return !!this.dampTimer;
+};
+
+Damper.prototype._isExpirationTimerEnabled = function _isExpirationTimerEnabled() {
+    return !!this.expirationTimer;
+};
+
 Damper.prototype._startDampTimer = function _startDampTimer() {
     var self = this;
 
-    if (this.isDampTimerEnabled) {
+    if (this._isDampTimerEnabled()) {
         this.logger.debug('ringpop damp timer already started', {
             local: this.ringpop.whoami()
         });
         return;
     }
 
-    this.isDampTimerEnabled = true;
     schedule();
     this.logger.debug('ringpop damper started damp timer', {
         local: this.ringpop.whoami()
@@ -494,7 +499,7 @@ Damper.prototype._startDampTimer = function _startDampTimer() {
                 // It may be the case that the damp timer is stopped while in the
                 // middle of a subprotocol. Make sure we don't schedule another
                 // run if that happens.
-                if (self.isDampTimerEnabled) schedule();
+                if (self._isDampTimerEnabled()) schedule();
             });
         }, self.ringpop.config.get('dampTimerInterval'));
     }
@@ -503,14 +508,13 @@ Damper.prototype._startDampTimer = function _startDampTimer() {
 Damper.prototype._startExpirationTimer = function _startExpirationTimer() {
     var self = this;
 
-    if (this.isExpirationTimerEnabled) {
+    if (this._isExpirationTimerEnabled()) {
         this.logger.debug('ringpop damper expiration timer already started', {
             local: this.ringpop.whoami()
         });
         return;
     }
 
-    this.isExpirationTimerEnabled = true;
     schedule();
     this.logger.debug('ringpop damper expiration timer started', {
         local: this.ringpop.whoami()
@@ -523,13 +527,13 @@ Damper.prototype._startExpirationTimer = function _startExpirationTimer() {
                     local: self.ringpop.whoami()
                 });
                 self.expireDampedMembers();
-                if (self.isExpirationTimerEnabled) schedule();
+                if (self._isExpirationTimerEnabled()) schedule();
         }, self.ringpop.config.get('dampedMemberExpirationInterval'));
     }
 };
 
 Damper.prototype._stopDampTimer = function _stopDampTimer() {
-    if (!this.isDampTimerEnabled) {
+    if (!this._isDampTimerEnabled()) {
         this.logger.debug('ringpop damper already stopped damp timer', {
             local: this.ringpop.whoami()
         });
@@ -538,14 +542,13 @@ Damper.prototype._stopDampTimer = function _stopDampTimer() {
 
     this.timers.clearTimeout(this.dampTimer);
     this.dampTimer = null;
-    this.isDampTimerEnabled = false;
     this.logger.debug('ringpop damper stopped damp timer', {
         local: this.ringpop.whoami()
     });
 };
 
 Damper.prototype._stopExpirationTimer = function _stopExpirationTimer() {
-    if (!this.isExpirationTimerEnabled) {
+    if (!this._isExpirationTimerEnabled()) {
         this.logger.debug('ringpop damper expiration timer already stopped', {
             local: this.ringpop.whoami()
         });
@@ -554,7 +557,6 @@ Damper.prototype._stopExpirationTimer = function _stopExpirationTimer() {
 
     this.timers.clearTimeout(this.expirationTimer);
     this.expirationTimer = null;
-    this.isExpirationTimerEnabled = false;
     this.logger.info('ringpop damper stopped expiration timer', {
         local: this.ringpop.whoami()
     });

--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -28,6 +28,7 @@ var LOG_10 = Math.log(10);
 function Dissemination(ringpop) {
     this.ringpop = ringpop;
     this.ringpop.on('ringChanged', this.onRingChanged.bind(this));
+    this.logger = this.ringpop.loggerFactory.getLogger('dissemination');
 
     this.changes = {};
     this.maxPiggybackCount = Dissemination.Defaults.maxPiggybackCount;
@@ -45,7 +46,7 @@ Dissemination.prototype.adjustMaxPiggybackCount = function adjustMaxPiggybackCou
     if (this.maxPiggybackCount !== newPiggybackCount) {
         this.maxPiggybackCount = newPiggybackCount;
         this.ringpop.stat('gauge', 'max-piggyback', this.maxPiggybackCount);
-        this.ringpop.logger.debug('adjusted max piggyback count', {
+        this.logger.debug('ringpop dissemination adjusted max piggyback count', {
             newPiggybackCount: this.maxPiggybackCount,
             oldPiggybackCount: prevPiggybackCount,
             piggybackFactor: this.piggybackFactor,
@@ -57,7 +58,7 @@ Dissemination.prototype.adjustMaxPiggybackCount = function adjustMaxPiggybackCou
 };
 
 Dissemination.prototype.clearChanges = function clearChanges() {
-    this.changes = [];
+    this.changes = {};
 };
 
 Dissemination.prototype.fullSync = function fullSync() {
@@ -75,6 +76,10 @@ Dissemination.prototype.fullSync = function fullSync() {
     }
 
     return changes;
+};
+
+Dissemination.prototype.isEmpty = function isEmpty() {
+    return Object.keys(this.changes).length === 0;
 };
 
 Dissemination.prototype.issueAsSender = function issueAsSender() {
@@ -105,7 +110,7 @@ Dissemination.prototype.issueAsReceiver = function issueAsReceiver(senderAddr, s
             return changes;
         } else if (self.ringpop.membership.checksum !== senderChecksum) {
             self.ringpop.stat('increment', 'full-sync');
-            self.ringpop.logger.info('full sync', {
+            self.logger.info('ringpop dissemination issued full sync', {
                 local: self.ringpop.whoami(),
                 localChecksum: self.ringpop.membership.checksum,
                 dest: senderAddr,

--- a/lib/gossip/events.js
+++ b/lib/gossip/events.js
@@ -23,6 +23,43 @@ function ChangesExhaustedEvent() {
     this.name = this.constructor.name;
 }
 
+function DampReqFailedEvent(err) {
+    this.name = this.constructor.name;
+    this.err = err;
+}
+
+function DampReqUnsatisfiedEvent() {
+    this.name = this.constructor.name;
+}
+
+function DampedEvent() {
+    this.name = this.constructor.name;
+}
+
+function DampedMemberExpirationEvent(undampedMembers) {
+    this.name = this.constructor.name;
+    this.undampedMembers = undampedMembers;
+}
+
+function DamperStartedEvent() {
+    this.name = this.constructor.name;
+}
+
+function DampedLimitExceededEvent() {
+    this.name = this.constructor.name;
+}
+
+function DampingInconclusiveEvent() {
+    this.name = this.constructor.name;
+}
+
 module.exports = {
-    ChangesExhaustedEvent: ChangesExhaustedEvent
+    ChangesExhaustedEvent: ChangesExhaustedEvent,
+    DampReqFailedEvent: DampReqFailedEvent,
+    DampReqUnsatisfiedEvent: DampReqUnsatisfiedEvent,
+    DampedEvent: DampedEvent,
+    DampedLimitExceededEvent: DampedLimitExceededEvent,
+    DampedMemberExpirationEvent: DampedMemberExpirationEvent,
+    DamperStartedEvent: DamperStartedEvent,
+    DampingInconclusiveEvent: DampingInconclusiveEvent
 };

--- a/lib/gossip/index.js
+++ b/lib/gossip/index.js
@@ -27,6 +27,7 @@ function Gossip(options) {
     this.ringpop = options.ringpop;
     this.minProtocolPeriod = options.minProtocolPeriod ||
         Gossip.Defaults.minProtocolPeriod;
+    this.logger = this.ringpop.loggerFactory.getLogger('gossip');
 
     this.isPinging = false;
     this.isStopped = true;
@@ -75,7 +76,7 @@ Gossip.prototype.run = function run() {
             self.protocolTiming.update(Date.now() - pingStartTime); // This keeps the protocol rate in check
 
             if (self.isStopped) {
-                self.ringpop.logger.debug('stopped recurring gossip loop', {
+                self.logger.debug('ringpop gossip stopped recurring gossip loop', {
                     local: self.ringpop.whoami()
                 });
                 return;
@@ -88,7 +89,7 @@ Gossip.prototype.run = function run() {
 
 Gossip.prototype.start = function start() {
     if (!this.isStopped) {
-        this.ringpop.logger.debug('gossip has already started', {
+        this.logger.debug('ringpop gossip has already started', {
             local: this.ringpop.whoami()
         });
         return;
@@ -99,7 +100,7 @@ Gossip.prototype.start = function start() {
     this.startProtocolRateTimer();
     this.isStopped = false;
 
-    this.ringpop.logger.debug('started gossip protocol', {
+    this.logger.debug('ringpop started gossip protocol', {
         local: this.ringpop.whoami()
     });
 };
@@ -113,7 +114,7 @@ Gossip.prototype.startProtocolRateTimer = function startProtocolRateTimer() {
 
 Gossip.prototype.stop = function stop() {
     if (this.isStopped) {
-        this.ringpop.logger.warn('gossip is already stopped', {
+        this.logger.warn('ringpop gossip is already stopped', {
             local: this.ringpop.whoami()
         });
         return;
@@ -127,7 +128,7 @@ Gossip.prototype.stop = function stop() {
 
     this.isStopped = true;
 
-    this.ringpop.logger.debug('stopped gossip protocol', {
+    this.logger.debug('ringpop stopped gossip protocol', {
         local: this.ringpop.whoami()
     });
 };
@@ -136,19 +137,19 @@ Gossip.prototype.tick = function tick(callback) {
     callback = callback || function() {};
 
     if (this.isPinging) {
-        this.ringpop.logger.warn('aborting ping because one is in progress');
+        this.logger.warn('ringpop gossip aborting ping because one is in progress');
         return callback();
     }
 
     if (!this.ringpop.isReady) {
-        this.ringpop.logger.warn('ping started before ring initialized');
+        this.logger.warn('ringpop gossip ping started before ring initialized');
         return callback();
     }
 
     var member = this.ringpop.memberIterator.next();
 
     if (! member) {
-        this.ringpop.logger.warn('no usable nodes at protocol period');
+        this.logger.warn('ringpop gossip no usable nodes at protocol period');
         return callback();
     }
 

--- a/lib/gossip/suspicion.js
+++ b/lib/gossip/suspicion.js
@@ -23,6 +23,7 @@ function Suspicion(options) {
     this.ringpop = options.ringpop;
     this.period = options.suspicionTimeout ||
         Suspicion.Defaults.suspicionTimeout;
+    this.logger = this.ringpop.loggerFactory.getLogger('suspicion');
 
     this.isStoppedAll = null;
     this.timers = {};
@@ -30,7 +31,7 @@ function Suspicion(options) {
 
 Suspicion.prototype.reenable = function reenable() {
     if (this.isStoppedAll !== true) {
-        this.ringpop.logger.warn('cannot reenable suspicion protocol because it was never disabled', {
+        this.logger.debug('ringpop cannot reenable suspicion protocol because it was never disabled', {
             local: this.ringpop.whoami()
         });
         return;
@@ -38,21 +39,21 @@ Suspicion.prototype.reenable = function reenable() {
 
     this.isStoppedAll = null;
 
-    this.ringpop.logger.debug('reenabled suspicion protocol', {
+    this.logger.debug('reenabled suspicion protocol', {
         local: this.ringpop.whoami()
     });
 };
 
 Suspicion.prototype.start = function start(member) {
     if (this.isStoppedAll === true) {
-        this.ringpop.logger.debug('cannot start a suspect period because suspicion has not been reenabled', {
+        this.logger.debug('cannot start a suspect period because suspicion has not been reenabled', {
             local: this.ringpop.whoami()
         });
         return;
     }
 
     if (member.address === this.ringpop.whoami()) {
-        this.ringpop.logger.debug('cannot start a suspect period for the local member', {
+        this.logger.debug('cannot start a suspect period for the local member', {
             local: this.ringpop.whoami(),
             suspect: member.address
         });
@@ -69,7 +70,7 @@ Suspicion.prototype.start = function start(member) {
             member.incarnationNumber);
     }, self.period);
 
-    this.ringpop.logger.debug('started suspect period', {
+    this.logger.debug('started suspect period', {
         local: this.ringpop.whoami(),
         suspect: member.address
     });
@@ -79,7 +80,7 @@ Suspicion.prototype.stop = function stop(member) {
     clearTimeout(this.timers[member.address]);
     delete this.timers[member.address];
 
-    this.ringpop.logger.debug('stopped members suspect timer', {
+    this.logger.debug('stopped members suspect timer', {
         local: this.ringpop.whoami(),
         suspect: member.address
     });
@@ -91,7 +92,7 @@ Suspicion.prototype.stopAll = function stopAll() {
     var timerKeys = Object.keys(this.timers);
 
     if (timerKeys.length === 0) {
-        this.ringpop.logger.debug('stopped no suspect timers', {
+        this.logger.debug('stopped no suspect timers', {
             local: this.ringpop.whoami()
         });
         return;
@@ -102,7 +103,7 @@ Suspicion.prototype.stopAll = function stopAll() {
         delete this.timers[timerKey];
     }, this);
 
-    this.ringpop.logger.debug('stopped all suspect timers', {
+    this.logger.debug('stopped all suspect timers', {
         local: this.ringpop.whoami(),
         numTimers: timerKeys.length
     });

--- a/lib/logging/logger_factory.js
+++ b/lib/logging/logger_factory.js
@@ -44,8 +44,12 @@ LoggerFactory.prototype.getLogger = function getLogger(name) {
             this.loggers[name] = new ModuleLogger(this.ringpop,
                 'joinLogLevel');
             break;
+        case 'suspicion':
+            this.loggers[name] = new ModuleLogger(this.ringpop,
+                'suspicionLogLevel');
+            break;
         case 'dissemination':
-            this.loggers[name] = new ModuleLogger(this.ringpop, 
+            this.loggers[name] = new ModuleLogger(this.ringpop,
                 'disseminationLogLevel');
             break;
         default:

--- a/lib/logging/logger_factory.js
+++ b/lib/logging/logger_factory.js
@@ -23,7 +23,19 @@ var ModuleLogger = require('./module_logger.js');
 
 function LoggerFactory(opts) {
     this.ringpop = opts.ringpop;
+    this.defaultLogger = new ModuleLogger(this.ringpop, 'defaultLogLevel');
     this.loggers = {}; // indexed by name
+    // TODO This mapping should eventually go away. It seems that log
+    // level names by convention (logger name + "LogLevel") is the way
+    // to go.
+    this.loggerNamesToLevels = {
+        damping: 'dampingLogLevel',
+        dissemination: 'disseminationLogLevel',
+        gossip: 'gossipLogLevel',
+        join: 'joinLogLevel',
+        membership: 'membershipLogLevel',
+        suspicion: 'suspicionLogLevel',
+    };
 }
 
 LoggerFactory.prototype.getLogger = function getLogger(name) {
@@ -31,33 +43,13 @@ LoggerFactory.prototype.getLogger = function getLogger(name) {
         return this.loggers[name];
     }
 
-    switch (name) {
-        case 'damping':
-            this.loggers[name] = new ModuleLogger(this.ringpop,
-                'dampingLogLevel');
-            break;
-        case 'gossip':
-            this.loggers[name] = new ModuleLogger(this.ringpop,
-                'gossipLogLevel');
-            break;
-        case 'join':
-            this.loggers[name] = new ModuleLogger(this.ringpop,
-                'joinLogLevel');
-            break;
-        case 'suspicion':
-            this.loggers[name] = new ModuleLogger(this.ringpop,
-                'suspicionLogLevel');
-            break;
-        case 'dissemination':
-            this.loggers[name] = new ModuleLogger(this.ringpop,
-                'disseminationLogLevel');
-            break;
-        default:
-            this.loggers[name] = new ModuleLogger(this.ringpop,
-                'defaultLogLevel');
-    }
-
-    return this.loggers[name];
+    return this._createLogger(name);
 };
+
+LoggerFactory.prototype._createLogger = function _createLogger(name) {
+    var level = this.loggerNamesToLevels[name] || 'defaultLogLevel';
+    this.loggers[name] = new ModuleLogger(this.ringpop, level);
+    return this.loggers[name];
+}
 
 module.exports = LoggerFactory;

--- a/lib/logging/module_logger.js
+++ b/lib/logging/module_logger.js
@@ -47,6 +47,15 @@ ModuleLogger.prototype.trace = function trace(msg, meta) {
     this._log('trace', msg, meta);
 };
 
+// This function answers the question, "can I log at the desired log level
+// given the level configured for this logger?"
+ModuleLogger.prototype.canLogAt = function canLogAt(desiredLevel) {
+    var configLevel = this.ringpop.config.get(this.configName);
+    var configInt = Levels.convertStrToInt(configLevel);
+    var desiredInt = Levels.convertStrToInt(desiredLevel);
+    return configLevel !== Levels.off && configInt <= desiredInt;
+};
+
 ModuleLogger.prototype._log = function _log(msgLevel, msg, meta) {
     var configLevel = this.ringpop.config.get(this.configName);
     var configInt = Levels.convertStrToInt(configLevel);

--- a/lib/membership/events.js
+++ b/lib/membership/events.js
@@ -20,13 +20,24 @@
 'use strict';
 
 function LocalMemberLeaveEvent(member, oldStatus) {
-    this.name = LocalMemberLeaveEvent.Name;
+    this.name = this.constructor.name;
     this.member = member;
     this.oldStatus = oldStatus;
 }
 
-LocalMemberLeaveEvent.Name = 'localMemberLeave';
+function ReusableEvent(member, oldDampScore) {
+    this.name = this.constructor.name;
+    this.member = member;
+    this.oldDampScore = oldDampScore;
+}
+
+function SuppressLimitExceededEvent(member) {
+    this.name = this.constructor.name;
+    this.member = member;
+}
 
 module.exports = {
-    LocalMemberLeaveEvent: LocalMemberLeaveEvent
+    LocalMemberLeaveEvent: LocalMemberLeaveEvent,
+    ReusableEvent: ReusableEvent,
+    SuppressLimitExceededEvent: SuppressLimitExceededEvent
 };

--- a/lib/membership/events.js
+++ b/lib/membership/events.js
@@ -25,6 +25,9 @@ function LocalMemberLeaveEvent(member, oldStatus) {
     this.oldStatus = oldStatus;
 }
 
+// A member becomes reusable when the damp score of a previously damped member
+// falls below the reuse limit as specified in config.js by
+// dampScoringReuseLimit.
 function ReusableEvent(member, oldDampScore) {
     this.name = this.constructor.name;
     this.member = member;

--- a/lib/membership/events.js
+++ b/lib/membership/events.js
@@ -28,19 +28,19 @@ function LocalMemberLeaveEvent(member, oldStatus) {
 // A member becomes reusable when the damp score of a previously damped member
 // falls below the reuse limit as specified in config.js by
 // dampScoringReuseLimit.
-function ReusableEvent(member, oldDampScore) {
+function DampingReusableEvent(member, oldDampScore) {
     this.name = this.constructor.name;
     this.member = member;
     this.oldDampScore = oldDampScore;
 }
 
-function SuppressLimitExceededEvent(member) {
+function DampingSuppressLimitExceededEvent(member) {
     this.name = this.constructor.name;
     this.member = member;
 }
 
 module.exports = {
-    LocalMemberLeaveEvent: LocalMemberLeaveEvent,
-    ReusableEvent: ReusableEvent,
-    SuppressLimitExceededEvent: SuppressLimitExceededEvent
+    DampingReusableEvent: DampingReusableEvent,
+    DampingSuppressLimitExceededEvent: DampingSuppressLimitExceededEvent,
+    LocalMemberLeaveEvent: LocalMemberLeaveEvent
 };

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -22,6 +22,7 @@
 var _ = require('underscore');
 var EventEmitter = require('events').EventEmitter;
 var Member = require('./member.js');
+var MemberDampScore = require('./member_damp_score.js');
 var mergeMembershipChangesets = require('./merge.js');
 var timers = require('timers');
 var update = require('./update.js');
@@ -34,6 +35,7 @@ function Membership(opts) {
     this.ringpop = opts.ringpop; // assumed to be present
     this.setTimeout = opts.setTimeout || timers.setTimeout;
     this.clearTimeout = opts.clearTimeout || timers.clearTimeout;
+    this.logger = this.ringpop.loggerFactory.getLogger('membership');
 
     this.members = [];
     this.membersByAddress = {};
@@ -43,6 +45,17 @@ function Membership(opts) {
 }
 
 util.inherits(Membership, EventEmitter);
+
+Membership.prototype.collectDampScores =
+        function collectDampScores(memberAddresses) {
+    var self = this;
+    return memberAddresses.reduce(function reduce(result, address) {
+        var member = self.findMemberByAddress(address);
+        if (!member) return result;
+        result.push(new MemberDampScore(member.address, member.dampScore));
+        return result;
+    }, []);
+};
 
 Membership.prototype.computeChecksum = function computeChecksum() {
     /* The membership checksum is a farmhash of the checksum string computed
@@ -183,6 +196,17 @@ Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber) 
         Member.Status.alive, this.localMember), isLocal);
 };
 
+Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumber*/) {
+    this.ringpop.stat('increment', 'make-damped');
+    var level = this.ringpop.config.get('dampedErrorLoggingEnabled') ? 'error' : 'warn';
+    this.ringpop.logger[level]('ringpop member would have been damped', {
+        local: this.ringpop.whoami(),
+        damped: address
+    });
+    // TODO Apply damped status to member
+    //return this._makeUpdate(address, incarnationNumber, Member.Status.damped);
+};
+
 Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber) {
     this.ringpop.stat('increment', 'make-faulty');
     return this._updateMember(new Update(address, incarnationNumber,
@@ -221,7 +245,7 @@ Membership.prototype.set = function set() {
     var numStashedUpdates = this.stashedUpdates.reduce(reduceUpdates, 0);
 
     if (numStashedUpdates > updates.length) {
-        this.ringpop.logger.debug('ringpop membership set consolidated stashed updates', {
+        this.logger.debug('ringpop membership set consolidated stashed updates', {
             local: this.ringpop.whoami(),
             numStashedUpdates: numStashedUpdates,
             numMergedUpdates: updates.length
@@ -312,7 +336,7 @@ Membership.prototype.update = function update(changes, isLocal) {
 
     function onMemberUpdated(update) {
         if (update.source !== self.ringpop.whoami()) {
-            self.ringpop.logger.debug('ringpop applied remote update', {
+            self.logger.debug('ringpop applied remote update', {
                 local: self.ringpop.whoami(),
                 remote: update.source,
                 updateId: update.id
@@ -361,15 +385,8 @@ Membership.prototype.toString = function toString() {
 };
 
 Membership.prototype._createMember = function _createMember(update) {
-    var self = this;
-
     var member = new Member(this.ringpop, update);
-    member.on('suppressLimitExceeded', onExceeded);
     return member;
-
-    function onExceeded() {
-        self.emit('memberSuppressLimitExceeded', member);
-    }
 };
 
 Membership.prototype._decayMembersDampScore = function _decayMembersDampScore() {
@@ -386,7 +403,7 @@ Membership.prototype._updateMember = function _updateMember(update, isLocal) {
     var updates = this.update(update, isLocal);
 
     if (updates.length > 0) {
-        this.ringpop.logger.debug('ringpop member declares other member ' +
+        this.logger.debug('ringpop member declares other member ' +
             update.status, {
                 local: this.ringpop.whoami(),
                 update: updates[0]
@@ -400,19 +417,7 @@ module.exports = function initMembership(ringpop) {
     // It would be more correct to start Membership's background decayer once
     // we know that a member has been penalized for a flap. But it's
     // OK to start prematurely.
-    var membership = new Membership({
-        ringpop: ringpop
-    });
-    membership.on('memberSuppressLimitExceeded', onExceeded);
+    var membership = new Membership({ ringpop: ringpop });
     membership.startDampScoreDecayer();
-    ringpop.on('destroyed', onDestroyed);
     return membership;
-
-    function onDestroyed() {
-        membership.stopDampScoreDecayer();
-    }
-
-    function onExceeded(/*member*/) {
-        // TODO Initiate flap damping subprotocol
-    }
 };

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -51,8 +51,9 @@ Membership.prototype.collectDampScores =
     var self = this;
     return memberAddresses.reduce(function reduce(result, address) {
         var member = self.findMemberByAddress(address);
-        if (!member) return result;
-        result.push(new MemberDampScore(member.address, member.dampScore));
+        if (member) {
+            result.push(new MemberDampScore(member.address, member.dampScore));
+        }
         return result;
     }, []);
 };

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -73,7 +73,7 @@ Member.prototype.decayDampScore = function decayDampScore() {
             reuseLimit: reuseLimit
         });
         this.ringpop.membership.emit('memberReusable',
-            new events.ReusableEvent(this, oldDampScore));
+            new events.DampingReusableEvent(this, oldDampScore));
     }
 
     this.emit('dampScoreDecayed', this.dampScore, oldDampScore);
@@ -158,7 +158,7 @@ Member.prototype._applyUpdatePenalty = function _applyUpdatePenalty() {
     var suppressLimit = config.get('dampScoringSuppressLimit');
     if (oldDampScore < suppressLimit && this.dampScore >= suppressLimit) {
         this.ringpop.membership.emit('memberSuppressLimitExceeded',
-            new events.SuppressLimitExceededEvent(this));
+            new events.DampingSuppressLimitExceededEvent(this));
         this.dampingLogger.debug('ringpop member damp score exceeded suppress limit', {
             local: this.ringpop.whoami(),
             member: this.address,

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -21,7 +21,7 @@
 
 var _ = require('underscore');
 var EventEmitter = require('events').EventEmitter;
-var LocalMemberLeaveEvent = require('./events.js').LocalMemberLeaveEvent;
+var events = require('./events.js');
 var numOrDefault = require('../util.js').numOrDefault;
 var util = require('util');
 
@@ -63,6 +63,19 @@ Member.prototype.decayDampScore = function decayDampScore() {
     this.dampScore = Math.max(Math.round(this.lastUpdateDampScore * decay),
         config.get('dampScoringMin'));
 
+    var reuseLimit = config.get('dampScoringReuseLimit');
+    if (oldDampScore > reuseLimit && this.dampScore <= reuseLimit) {
+        this.dampingLogger.debug('ringpop member damp score fell below reuse limit', {
+            local: this.ringpop.whoami(),
+            member: this.address,
+            oldDampScore: oldDampScore,
+            dampScore: this.dampScore,
+            reuseLimit: reuseLimit
+        });
+        this.ringpop.membership.emit('memberReusable',
+            new events.ReusableEvent(this, oldDampScore));
+    }
+
     this.emit('dampScoreDecayed', this.dampScore, oldDampScore);
 };
 
@@ -92,8 +105,8 @@ Member.prototype.evaluateUpdate = function evaluateUpdate(update) {
 
         if (this.address === this.ringpop.whoami()) {
             if (this.status === Member.Status.leave) {
-                var event = new LocalMemberLeaveEvent(this, oldStatus);
-                this.ringpop.membership.emit('event', event);
+                this.ringpop.membership.emit('event',
+                    new events.LocalMemberLeaveEvent(this, oldStatus));
             }
         }
     }
@@ -138,16 +151,18 @@ Member.prototype._applyUpdatePenalty = function _applyUpdatePenalty() {
     this.decayDampScore();
 
     // Keep within upper bound
+    var oldDampScore = this.dampScore;
     this.dampScore = Math.min(this.dampScore + config.get('dampScoringPenalty'),
         config.get('dampScoringMax'));
 
     var suppressLimit = config.get('dampScoringSuppressLimit');
-    if (this.dampScore > suppressLimit) {
-        this.emit('suppressLimitExceeded');
-
-        this.dampingLogger.info('ringpop member damp score exceeded suppress limit', {
+    if (oldDampScore < suppressLimit && this.dampScore >= suppressLimit) {
+        this.ringpop.membership.emit('memberSuppressLimitExceeded',
+            new events.SuppressLimitExceededEvent(this));
+        this.dampingLogger.debug('ringpop member damp score exceeded suppress limit', {
             local: this.ringpop.whoami(),
             member: this.address,
+            oldDampScore: oldDampScore,
             dampScore: this.dampScore,
             suppressLimit: suppressLimit
         });

--- a/lib/membership/member_damp_score.js
+++ b/lib/membership/member_damp_score.js
@@ -19,33 +19,9 @@
 // THE SOFTWARE.
 'use strict';
 
-function createDestroyedHandler(ringpop) {
-    return function onDestroyed() {
-        ringpop.lagSampler.stop();
-        ringpop.membership.stopDampScoreDecayer();
-        ringpop.damper.destroy();
-    };
+function MemberDampScore(member, dampScore) {
+    this.member = member;
+    this.dampScore = dampScore;
 }
 
-function createReadyHandler(ringpop) {
-    return function onReady() {
-        if (ringpop.config.get('autoGossip')) {
-            ringpop.gossip.start();
-        }
-
-        if (ringpop.config.get('backpressureEnabled')) {
-            ringpop.lagSampler.start();
-        }
-    };
-}
-
-function register(ringpop) {
-    ringpop.on('destroyed', createDestroyedHandler(ringpop));
-    ringpop.on('ready', createReadyHandler(ringpop));
-}
-
-module.exports = {
-    createDestroyedHandler: createDestroyedHandler,
-    createReadyHandler: createReadyHandler,
-    register: register
-};
+module.exports = MemberDampScore;

--- a/lib/on_membership_event.js
+++ b/lib/on_membership_event.js
@@ -32,13 +32,14 @@ function createChecksumComputedHandler(ringpop) {
 function createEventHandler(ringpop) {
     return function onEvent(event) {
         switch (event.name) {
-            case MembershipEvents.LocalMemberLeaveEvent.Name:
+            case MembershipEvents.LocalMemberLeaveEvent.name:
                 ringpop.gossip.stop();
                 ringpop.suspicion.stopAll();
                 break;
         }
     };
 }
+
 function createSetHandler(ringpop) {
     return function onMembershipSet(updates) {
         var serversToAdd = [];
@@ -62,6 +63,18 @@ function createSetHandler(ringpop) {
         if (serversToAdd.length > 0) {
             ringpop.ring.addRemoveServers(serversToAdd, []);
         }
+    };
+}
+
+function createSuppressLimitExceededHandler(ringpop) {
+    return function onSuppressLimitExceeded(event) {
+        ringpop.damper.addFlapper(event.member);
+    };
+}
+
+function createReusableHandler(ringpop) {
+    return function onReusable(event) {
+        ringpop.damper.removeFlapper(event.member);
     };
 }
 
@@ -134,6 +147,9 @@ function register(ringpop) {
     var membership = ringpop.membership;
     membership.on('checksumComputed', createChecksumComputedHandler(ringpop));
     membership.on('event', createEventHandler(ringpop));
+    membership.on('memberReusable', createReusableHandler(ringpop));
+    membership.on('memberSuppressLimitExceeded',
+        createSuppressLimitExceededHandler(ringpop));
     membership.on('set', createSetHandler(ringpop));
     membership.on('updated', createUpdatedHandler(ringpop));
     membership.on('updated', createUpdatedHandlerForGossip(ringpop));
@@ -143,7 +159,9 @@ function register(ringpop) {
 module.exports = {
     createChecksumComputedHandler: createChecksumComputedHandler,
     createEventHandler: createEventHandler,
+    createReusableHandler: createReusableHandler,
     createSetHandler: createSetHandler,
+    createSuppressLimitExceededHandler: createSuppressLimitExceededHandler,
     createUpdatedHandler: createUpdatedHandler,
     createUpdatedHandlerForGossip: createUpdatedHandlerForGossip,
     createUpdatedHandlerForRing: createUpdatedHandlerForRing,

--- a/main.js
+++ b/main.js
@@ -38,7 +38,6 @@ function main(args) {
     }
 
     var tchannel = new TChannel({
-        logger: createLogger('tchannel'),
     });
 
     var ringpop = new RingPop({
@@ -67,7 +66,7 @@ function main(args) {
 function createLogger(name) {
     return {
         trace: function noop() {},
-        debug: function noop() {},
+        debug: enrich('debug', 'log'),
         info: enrich('info', 'log'),
         warn: enrich('warn', 'error'),
         error: enrich('error', 'error')

--- a/request_response.js
+++ b/request_response.js
@@ -1,0 +1,75 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var util = require('util');
+
+function ProtocolRequest(ringpop) {
+    var localMember = ringpop.membership.localMember || {};
+    this.sourceAddr = localMember.address;
+    this.sourceIncarnationNumber = localMember.incarnationNumber;
+    this.sourceChecksum = ringpop.membership.checksum;
+    this.changes = ringpop.dissemination.issueAsSender();
+}
+
+function ProtocolResponse(ringpop, req) {
+    this.changes = ringpop.dissemination.issueAsReceiver(req.sourceAddr,
+        req.sourceIncarnationNumber, req.sourceChecksum);
+}
+
+function DampReqRequest(ringpop, flappers) {
+    ProtocolRequest.call(this, ringpop);
+    this.flappers = flappers; // An Array of member's addresses (IDs)
+}
+
+util.inherits(DampReqRequest, ProtocolRequest);
+
+function DampReqResponse(ringpop, req, scores) {
+    ProtocolResponse.call(this, ringpop, req);
+    this.scores = scores; // An Array of MemberDampScore
+}
+
+util.inherits(DampReqResponse, ProtocolResponse);
+
+function validateRequest(req, otherProps, callback) {
+    if (!req) {
+        callback(new Error('Bad request: body is required'));
+        return false;
+    }
+
+    var props = ['sourceAddr', 'sourceIncarnationNumber',
+        'sourceChecksum'].concat(otherProps);
+
+    for (var i = 0; i < props.length; i++) {
+        var prop = props[i];
+        if (!req[prop]) {
+            callback(new Error('Bad request: ' + prop + ' is required'));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+module.exports = {
+    DampReqRequest: DampReqRequest,
+    DampReqResponse: DampReqResponse,
+    validateRequest: validateRequest
+};

--- a/server/protocol/damp_req.js
+++ b/server/protocol/damp_req.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var DampReqResponse = require('../../request_response.js').DampReqResponse;
+var safeParse = require('../../lib/util.js').safeParse;
+var TypedError = require('error/typed');
+
+var BadRequestError = TypedError({
+    type: 'overrideme',
+    message: 'Bad request: {reason}',
+    reason: null
+});
+
+module.exports = function createDampReqHandler(ringpop) {
+    return function handleDampReq(arg2, arg3, hostInfo, callback) {
+        ringpop.stat('increment', 'damp-req.recv');
+
+        var body = safeParse(arg3 && arg3.toString());
+        if (!body || !body.flappers) {
+            callback(BadRequestError({
+                type: 'ringpop.server.damp-req.bad-request.flappers-required',
+                reason: 'flappers is required'
+            }));
+            return;
+        }
+
+        var flappers = body.flappers;
+        if (!Array.isArray(flappers)) {
+            callback(BadRequestError({
+                type: 'ringpop.server.damp-req.bad-request.flappers-array',
+                reason: 'flappers must be an array'
+            }));
+            return;
+        }
+
+        var dampScores = ringpop.membership.collectDampScores(flappers);
+        var response = new DampReqResponse(ringpop, body, dampScores);
+        callback(null, null, JSON.stringify(response));
+    };
+};

--- a/server/protocol/index.js
+++ b/server/protocol/index.js
@@ -20,6 +20,10 @@
 'use strict';
 
 module.exports = {
+    dampReq: {
+        endpoint: '/protocol/damp-req',
+        handler: require('./damp_req.js')
+    },
     join: {
         endpoint: '/protocol/join',
         handler: require('./join.js')

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -19,33 +19,29 @@
 // THE SOFTWARE.
 'use strict';
 
-function createDestroyedHandler(ringpop) {
-    return function onDestroyed() {
-        ringpop.lagSampler.stop();
-        ringpop.membership.stopDampScoreDecayer();
-        ringpop.damper.destroy();
-    };
+var Member = require('../lib/membership/member.js');
+
+function member1(ringpop, opts) {
+    opts = opts || {};
+    return new Member(ringpop, {
+        address: opts.address || '127.0.0.1:3001',
+        incarnationNumber: opts.incarnationNumber || Date.now(),
+        status: Member.Status.alive
+    });
 }
 
-function createReadyHandler(ringpop) {
-    return function onReady() {
-        if (ringpop.config.get('autoGossip')) {
-            ringpop.gossip.start();
-        }
-
-        if (ringpop.config.get('backpressureEnabled')) {
-            ringpop.lagSampler.start();
-        }
+function memberGenerator(ringpop) {
+    var basePort = 3001; // assums member with port 3000 is already in membership
+    var counter = 0;
+    return function genMember() {
+        return new Member(ringpop, {
+            address: '127.0.0.1:' + (basePort + counter++),
+            incarnationNumber: Date.now()
+        });
     };
-}
-
-function register(ringpop) {
-    ringpop.on('destroyed', createDestroyedHandler(ringpop));
-    ringpop.on('ready', createReadyHandler(ringpop));
 }
 
 module.exports = {
-    createDestroyedHandler: createDestroyedHandler,
-    createReadyHandler: createReadyHandler,
-    register: register
+    member1: member1,
+    memberGenerator: memberGenerator
 };

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -31,7 +31,7 @@ function member1(ringpop, opts) {
 }
 
 function memberGenerator(ringpop) {
-    var basePort = 3001; // assums member with port 3000 is already in membership
+    var basePort = 3001; // assumes member with port 3000 is already in membership
     var counter = 0;
     return function genMember() {
         return new Member(ringpop, {

--- a/test/lib/test-ringpop.js
+++ b/test/lib/test-ringpop.js
@@ -43,6 +43,7 @@ function testRingpop(opts, name, test) {
         // convenience to users of the test suite.
         var deps = {
             config: ringpop.config,
+            damper: ringpop.damper,
             dissemination: ringpop.dissemination,
             gossip: ringpop.gossip,
             iterator: ringpop.memberIterator,

--- a/test/unit/damper_test.js
+++ b/test/unit/damper_test.js
@@ -91,9 +91,9 @@ testRingpop({
     var targets = setupMembership(deps, nVal + 1);
 
     // Remove member from list when a damp-req is sent to member.
-    stubClient(deps, function protocolDampReq(host, body, callback) {
+    stubClient(deps, function protocolDampReq(opts, body, callback) {
         targets = targets.filter(function filter(member) {
-            return member.address !== host;
+            return member.address !== opts.host;
         });
 
         process.nextTick(function onTick() {

--- a/test/unit/damper_test.js
+++ b/test/unit/damper_test.js
@@ -1,0 +1,355 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var fixtures = require('../fixtures.js');
+var Damper = require('../../lib/gossip/damper.js');
+var DampReqRequest = require('../../request_response.js').DampReqRequest;
+var DampReqResponse = require('../../request_response.js').DampReqResponse;
+var MemberDampScore = require('../../lib/membership/member_damp_score.js');
+var testRingpop = require('../lib/test-ringpop.js');
+var TimeMock = require('time-mock');
+
+var noop = function noop() {};
+
+function setupMembership(deps, numMembers) {
+    numMembers = numMembers || 3;
+
+    var membership = deps.membership;
+    var memberGen = fixtures.memberGenerator(deps.ringpop);
+    var members = [];
+    for (var i = 0; i < numMembers; i++) {
+        var member = memberGen();
+        membership.makeAlive(member.address, member.incarnationNumber);
+        members.push(member);
+    }
+    return members;
+}
+
+function stubClient(deps, protocolDampReq) {
+    deps.ringpop.client = {
+        destroy: noop,
+        protocolDampReq: protocolDampReq
+    };
+}
+
+testRingpop('damped max percentage', function t(deps, assert) {
+    assert.plan(1);
+
+    // Lower allowable damped members to 0%
+    var config = deps.config;
+    config.set('dampedMaxPercentage', 0);
+
+    var damper = deps.damper;
+    damper.on('event', function onEvent(event) {
+        assert.equals(event.name, 'DampedLimitExceededEvent',
+            'damped limit exceeded event');
+    });
+    damper.initiateSubprotocol(noop);
+});
+
+testRingpop('damp-req selection unsatisfied', function t(deps, assert) {
+    assert.plan(1);
+
+    var damper = deps.damper;
+    damper.on('event', function onEvent(event) {
+        if (event.name === 'DampReqUnsatisfiedEvent') {
+            assert.pass('damp req selection unsatisfied');
+        }
+    });
+    damper.initiateSubprotocol(noop);
+});
+
+testRingpop({
+    async: true
+}, 'sends n-val damp-reqs', function t(deps, assert, done) {
+    assert.plan(2);
+
+    var config = deps.config;
+    var nVal = 10;
+    config.set('dampReqNVal', nVal);
+    config.set('dampReqRVal', nVal);
+
+    // Create enough members to satisfy damp-req selection
+    var targets = setupMembership(deps, nVal + 1);
+
+    // Remove member from list when a damp-req is sent to member.
+    stubClient(deps, function protocolDampReq(host, body, callback) {
+        targets = targets.filter(function filter(member) {
+            return member.address !== host;
+        });
+
+        process.nextTick(function onTick() {
+            callback(null, new DampReqResponse(deps.ringpop, body, {
+                dampScore: 0
+            }));
+        });
+    });
+
+    var damper = deps.damper;
+    var flappyMember = targets[targets.length - 1];
+    damper.addFlapper(flappyMember);
+    // By the time inconclusive event is emitted all members
+    // should have received a damp-req.
+    damper.on('event', function onEvent(event) {
+        if (event.name === 'DampingInconclusiveEvent') {
+            assert.equals(targets.length, 1, 'all n received damp req');
+            // Only one not to be filtered out: the flappy member itself.
+            assert.equals(targets[0].address, flappyMember.address,
+                'flappy member not filtered out');
+            done();
+        }
+    });
+    damper.initiateSubprotocol(noop);
+});
+
+testRingpop('adds flapper', function t(deps, assert) {
+    var damper = deps.damper;
+    var member1 = fixtures.member1(deps.ringpop);
+    assert.true(damper.addFlapper(member1), 'does not remove flapper');
+});
+
+testRingpop('does not add flapper if already damped', function t(deps, assert) {
+    var damper = deps.damper;
+    var member1 = fixtures.member1(deps.ringpop);
+    damper.addDampedMember(member1.address);
+    damper.addFlapper(member1);
+    assert.false(damper.hasFlapper(member1), 'does not have flapper');
+});
+
+testRingpop('does not add flapper twice', function t(deps, assert) {
+    var damper = deps.damper;
+    var member1 = fixtures.member1(deps.ringpop);
+    assert.true(damper.addFlapper(member1), 'adds flapper');
+    assert.false(damper.addFlapper(member1), 'does not add flapper');
+});
+
+testRingpop('starts damper after adding first flapper', function t(deps, assert) {
+    var damper = deps.damper;
+    assert.false(damper.hasStarted(), 'has not started');
+    var member1 = fixtures.member1(deps.ringpop);
+    damper.addFlapper(member1);
+    assert.true(damper.hasStarted(), 'has started');
+});
+
+testRingpop('removes flapper', function t(deps, assert) {
+    var damper = deps.damper;
+    var member1 = fixtures.member1(deps.ringpop);
+    damper.addFlapper(member1);
+    assert.true(damper.removeFlapper(member1), 'removes flapper');
+});
+
+testRingpop('does not remove flapper if never added', function t(deps, assert) {
+    var damper = deps.damper;
+    var member1 = fixtures.member1(deps.ringpop);
+    assert.false(damper.removeFlapper(member1), 'does not remove flapper');
+});
+
+testRingpop('stops damp timer if last flapper removed', function t(deps, assert) {
+    var damper = deps.damper;
+    var member1 = fixtures.member1(deps.ringpop);
+    damper.addFlapper(member1);
+    assert.true(damper.hasStarted(), 'has started');
+    damper.removeFlapper(member1);
+    assert.false(damper.hasStarted(), 'has stopped');
+});
+
+testRingpop({
+    async: true
+}, 'damps multiple members', function t(deps, assert, done) {
+    assert.plan(2);
+
+    var config = deps.config;
+    // Make sure we can damp as many members as needed
+    config.set('dampedMaxPercentage', 100);
+    var targets = setupMembership(deps, config.get('dampReqNVal'));
+    var flapper1 = targets[0];
+    var flapper2 = targets[1];
+
+    // Arrange scores for damp-req response gathered by subprotocol initiated
+    // below.
+    var dampScore = config.get('dampScoringSuppressLimit');
+    var scores = [{
+        member: flapper1.address,
+        dampScore: dampScore
+    }, {
+        member: flapper2.address,
+        dampScore: dampScore
+    }];
+
+    // Stub clients to respond with scores.
+    stubClient(deps, function protocolDampReq(host, body, callback) {
+        process.nextTick(function onTick() {
+            callback(null, new DampReqResponse(deps.ringpop, body, scores));
+        });
+    });
+
+    // Add flappers and initiate subprotocol that'll retrieve the scores
+    // arranged above.
+    var damper = deps.damper;
+    damper.addFlapper(flapper1);
+    damper.addFlapper(flapper2);
+    damper.initiateSubprotocol(function onSubprotocol() {
+        assert.true(damper.isDamped(flapper1), 'member is damped');
+        assert.true(damper.isDamped(flapper2), 'member is damped');
+        done();
+    });
+});
+
+testRingpop('damp timer initiates subprotocol', function t(deps, assert) {
+    assert.plan(2);
+
+    var timers = new TimeMock(Date.now());
+    var damper = deps.damper;
+    damper.timers = timers;
+    damper.on('event', function onEvent(event) {
+        if (event.name === 'DamperStartedEvent') {
+            assert.pass('damper started');
+        }
+    });
+
+    var member1 = fixtures.member1(deps.ringpop);
+    // Kicks off damp timer
+    damper.addFlapper(member1);
+
+    // Advance interval twice; expect subprotocol to be started
+    // twice.
+    var config = deps.config;
+    timers.advance(config.get('dampTimerInterval') + 1);
+    timers.advance(config.get('dampTimerInterval') + 1);
+});
+
+testRingpop('damping member starts expiration', function t(deps, assert) {
+    var damper = deps.damper;
+    var member1 = fixtures.member1(deps.ringpop);
+    assert.false(damper.dampMember(member1.address), 'cannot damp member');
+
+    var membership = deps.membership;
+    membership.makeAlive(member1.address, member1.incarnationNumber);
+    assert.false(damper.dampMember(member1.address), 'cannot damp member');
+
+    assert.false(damper.expirationTimer, 'expiration timer not started');
+    damper.addFlapper(member1);
+    damper.dampMember(member1.address);
+    assert.true(damper.isDamped(member1), 'member is damped');
+    assert.true(damper.expirationTimer, 'expiration timer started');
+});
+
+testRingpop('expires damped members', function t(deps, assert) {
+    assert.plan(5);
+
+    var damper = deps.damper;
+    var timers = new TimeMock(Date.now());
+    // Stub damper timers to allow for expiring damped members
+    damper.timers = timers;
+    damper.Date = timers;
+
+    // Before we advance time, let's make sure we tick the expiration timer once.
+    var config = deps.config;
+    var expirationInterval = config.get('dampedMemberExpirationInterval');
+    config.set('dampScoringSuppressDuration', expirationInterval - 1);
+
+    var member1 = fixtures.member1(deps.ringpop);
+    assert.false(damper.dampMember(member1.address), 'cannot damp member');
+
+    var membership = deps.membership;
+    membership.makeAlive(member1.address, member1.incarnationNumber);
+    assert.false(damper.dampMember(member1.address), 'member is not damped');
+
+    damper.addFlapper(member1);
+    damper.dampMember(member1.address);
+    assert.true(damper.isDamped(member1), 'member is damped');
+
+    // Advance fake time beyond damped member suppress duration
+    damper.on('event', function onEvent(event) {
+        if (event.name === 'DampedMemberExpirationEvent') {
+            var undampedMembers = event.undampedMembers;
+            assert.equals(undampedMembers.length, 1, 'a member has been undamped');
+            assert.false(damper.isDamped(member1), 'member is no longer damped');
+        }
+    });
+    timers.advance(expirationInterval + 1);
+});
+
+testRingpop('expires no damped members', function t(deps, assert) {
+    var damper = deps.damper;
+    var undampedMembers = damper.expireDampedMembers();
+    assert.equals(undampedMembers.length, 0, 'undamps no members');
+});
+
+testRingpop({
+    async: true
+}, 'deals with damp-req errors', function t(deps, assert, done) {
+    assert.plan(1);
+
+    var config = deps.config;
+    var nVal = 10;
+    config.set('dampReqNVal', nVal);
+    config.set('dampReqRVal', nVal);
+
+    // Create enough members to satisfy damp-req selection
+    var targets = setupMembership(deps, nVal + 1);
+
+    // Remove member from list when a damp-req is sent to member.
+    stubClient(deps, function protocolDampReq(host, body, callback) {
+        targets = targets.filter(function filter(member) {
+            return member.address !== host;
+        });
+
+        process.nextTick(function onTick() {
+            callback(new Error('damp-req error'));
+        });
+    });
+
+    var damper = deps.damper;
+    var flappyMember = targets[targets.length - 1];
+    damper.addFlapper(flappyMember);
+    damper.on('event', function onEvent(event) {
+        if (event.name === 'DampReqFailedEvent') {
+            assert.true(event.err, 'an error occurred');
+            done();
+        }
+    });
+    damper.initiateSubprotocol(noop);
+});
+
+testRingpop('damp these members', function t(deps, assert) {
+    var ringpop = deps.ringpop;
+    var config = deps.config;
+    config.set('dampScoringSuppressLimit', 4999);
+
+    var scores = [
+        new MemberDampScore('127.0.0.1:3000', 5000),
+        new MemberDampScore('127.0.0.1:3001', 5000),
+        new MemberDampScore('127.0.0.1:3002', 4998)
+    ];
+    var request = new DampReqRequest(ringpop);
+    var responses = [
+        new DampReqResponse(ringpop, request, scores),
+        new DampReqResponse(ringpop, request, scores),
+        new DampReqResponse(ringpop, request, scores)
+    ];
+
+    var rVal = config.get('dampReqRVal');
+    var membersToDamp = Damper.getMembersToDamp(responses, rVal, config);
+    assert.equals(membersToDamp.length, 2, '2 members to damp');
+    assert.true(membersToDamp.indexOf('127.0.0.1:3000') > -1, 'member to damp');
+    assert.true(membersToDamp.indexOf('127.0.0.1:3001') > -1, 'member to damp');
+});

--- a/test/unit/member_test.js
+++ b/test/unit/member_test.js
@@ -53,7 +53,7 @@ testRingpop('penalized for update', function t(deps, assert) {
 });
 
 testRingpop('flaps until exceeds suppress limit', function t(deps, assert) {
-    assert.plan(2);
+    assert.plan(1);
 
     var config= deps.config;
     config.set('dampScoringMax', 1000);
@@ -62,7 +62,7 @@ testRingpop('flaps until exceeds suppress limit', function t(deps, assert) {
 
     var membership = deps.membership;
     var member2 = addSecondMember(membership, '127.0.0.1:3001');
-    member2.on('suppressLimitExceeded', onExceeded);
+    member2.on('memberSuppressLimitExceeded', onExceeded);
     member2.evaluateUpdate({
         status: Member.Status.suspect,
         incarnationNumber: Date.now() + 1

--- a/test/unit/module_logger_test.js
+++ b/test/unit/module_logger_test.js
@@ -108,3 +108,30 @@ testRingpop('turn off gossip logging', function t(deps, assert) {
     // Replace with old logger after we're done.
     ringpop.logger = oldLogger;
 });
+
+testRingpop('can log at', function t(deps, assert) {
+    var config = deps.config;
+    config.set('defaultLogLevel', LoggingLevels.error);
+
+    var loggerFactory = deps.loggerFactory;
+    var logger = loggerFactory.getLogger('default');
+    assert.true(logger.canLogAt(LoggingLevels.error), 'can log at');
+    assert.false(logger.canLogAt(LoggingLevels.warn), 'cannot log at');
+    assert.false(logger.canLogAt(LoggingLevels.info), 'cannot log at');
+    assert.false(logger.canLogAt(LoggingLevels.debug), 'cannot log at');
+    assert.false(logger.canLogAt(LoggingLevels.warn), 'cannot log at');
+
+    config.set('defaultLogLevel', LoggingLevels.debug);
+    assert.true(logger.canLogAt(LoggingLevels.error), 'can log at');
+    assert.true(logger.canLogAt(LoggingLevels.warn), 'can log at');
+    assert.true(logger.canLogAt(LoggingLevels.info), 'can log at');
+    assert.true(logger.canLogAt(LoggingLevels.debug), 'can log at');
+    assert.true(logger.canLogAt(LoggingLevels.warn), 'can log at');
+
+    config.set('defaultLogLevel', LoggingLevels.off);
+    assert.false(logger.canLogAt(LoggingLevels.error), 'cannot log at');
+    assert.false(logger.canLogAt(LoggingLevels.warn), 'cannot log at');
+    assert.false(logger.canLogAt(LoggingLevels.info), 'cannot log at');
+    assert.false(logger.canLogAt(LoggingLevels.debug), 'cannot log at');
+    assert.false(logger.canLogAt(LoggingLevels.warn), 'cannot log at');
+});

--- a/test/unit/server/protocol/damp_req_test.js
+++ b/test/unit/server/protocol/damp_req_test.js
@@ -1,0 +1,87 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var _ = require('underscore');
+var after = require('after');
+var createDampReqHandler = require('../../../../server/protocol/damp_req.js');
+var fixtures = require('../../../fixtures.js');
+var testRingpop = require('../../../lib/test-ringpop.js');
+
+testRingpop({
+    async: true
+}, 'results in bad request', function t(deps, assert, done) {
+    var incrementalDone = after(2, done);
+
+    var handleDampReq = createDampReqHandler(deps.ringpop);
+    handleDampReq(null, null, null, onHandle1);
+    handleDampReq(null, JSON.stringify({ flappers: 1 }), null, onHandle2);
+
+    function onHandle1(err) {
+        assert.true(err, 'an error occurred');
+        assert.equals(err.type,
+            'ringpop.server.damp-req.bad-request.flappers-required',
+            'flappers required error');
+        incrementalDone();
+    }
+
+    function onHandle2(err) {
+        assert.true(err, 'an error occurred');
+        assert.equals(err.type,
+            'ringpop.server.damp-req.bad-request.flappers-array',
+            'flappers array error');
+        incrementalDone();
+    }
+});
+
+testRingpop('responds with damp scores', function t(deps, assert) {
+    assert.plan(2);
+
+    var ringpop = deps.ringpop;
+
+    // Generate 4 members. Add each member to the Ringpop
+    // membership list.
+    var genMember = fixtures.memberGenerator(ringpop);
+    var members = _.times(4, function eachTime() {
+        return genMember();
+    });
+    members.forEach(function each(member) {
+        ringpop.membership.makeAlive(member.address,
+            member.incarnationNumber);
+    });
+
+    // Clear changes from the dissemination component to
+    // pass through the final validation gate in the damp-req
+    // handler.
+    deps.dissemination.clearChanges();
+
+    var handleDampReq = createDampReqHandler(ringpop);
+    // Ask for the damp scores for only 3 of the 4 members
+    var flappers = _.chain(members).head(3).pluck('address').value();
+    handleDampReq(null, JSON.stringify({
+        flappers: flappers
+    }), null, function onHandle(err, res1, res2) {
+        assert.false(err, 'no error occurred');
+
+        var expected = ringpop.membership.collectDampScores(flappers);
+        var body = JSON.parse(res2);
+        assert.deepEquals(body.scores, expected, 'all damp scores returned');
+    });
+});


### PR DESCRIPTION
This PR introduces a Damper object which is responsible for:
* Tracking flappy members. A flappy member is one whose damp score exceeds the suppress limit.
* Periodically running a background damp timer that asks N-random other members for the damp scores of the same flappy members
* "Damping members" if the damp scores from the N-random members also exceed the suppress limit.
* Expiring damped members after members have been damped for greater than the suppression duration.

This PR does not actually 'treat' damped members other than logging an error when a Ringpop would have put a member in the damped status. The behavior to treat damped members will come in a later PR.

This PR is over 1200 lines. Take your time with it and of course, let me know if you have any high-level or fundamental questions.

Would like a lgtm from: @thanodnl @CorgiMan 
Would appreciate eyes and high-level feedback from: @benfleis @danielheller

@uber/ringpop 