### PR TITLE
Parse the key from the body of /admin/lookup.

### DIFF
--- a/server/admin/lookup.js
+++ b/server/admin/lookup.js
@@ -19,11 +19,15 @@
 // THE SOFTWARE.
 'use strict';
 
+var safeParse = require('../../lib/util.js').safeParse;
+
 module.exports = function createLookupHandler(ringpop) {
     return function handleLookup(arg1, arg2, hostInfo, callback) {
-        var key = arg2.toString();
-        callback(null, null, JSON.stringify({
-            dest: ringpop.lookup(key)
-        }));
+        var body = safeParse(arg2.toString());
+        if (body && body.key) {
+            callback(null, null, JSON.stringify({
+                dest: ringpop.lookup(body.key)
+            }));
+        }
     };
 };

--- a/server/admin/lookup.js
+++ b/server/admin/lookup.js
@@ -20,14 +20,17 @@
 'use strict';
 
 var safeParse = require('../../lib/util.js').safeParse;
+var errors = require('../../lib/errors.js');
 
 module.exports = function createLookupHandler(ringpop) {
     return function handleLookup(arg1, arg2, hostInfo, callback) {
-        var body = safeParse(arg2.toString());
+        var body = safeParse(arg2);
         if (body && body.key) {
-            callback(null, null, JSON.stringify({
+            return callback(null, null, JSON.stringify({
                 dest: ringpop.lookup(body.key)
             }));
+        } else {
+            return callback(errors.ArgumentRequiredError({ argument: 'key' }));
         }
     };
 };


### PR DESCRIPTION
During the creation of the integration tests it came to my attention that the `/admin/lookup` endpoint was using the complete body as the key while the implementation in golang used the value provided in the `key` field of the body. This inconsistency made it impossible to test correctness of the lookup.

Looking in [`ringpop-admin`](https://github.com/uber/ringpop-admin/blob/master/lib/admin-client.js#L52-L54) (which I expect to be the only use of the lookup endpoint) revealed that sending a json object with a field `key` was the expected way to lookup a key.

This patch changes the `/admin/lookup/` endpoint in such a way that it will lookup the key for `your key` instead of `{key:"your key"}` when using `ringpop-admin lookup "host:port" --key "your key"`.

/cc @uber/ringpop 