### PR TITLE
Share arrays of added and removed addresses on ringChanged

### DIFF
--- a/lib/on_membership_event.js
+++ b/lib/on_membership_event.js
@@ -21,7 +21,7 @@
 
 var Member = require('./membership/member.js');
 var MembershipEvents = require('./membership/events.js');
-var RingEvents = require('../ring/events.js');
+var RingEvents = require('./ring/events.js');
 
 function createChecksumComputedHandler(ringpop) {
     return function onMembershipChecksumComputed() {

--- a/lib/on_membership_event.js
+++ b/lib/on_membership_event.js
@@ -62,7 +62,8 @@ function createSetHandler(ringpop) {
         // efficiency gains when only having to compute the ring
         // checksum once.
         if (serversToAdd.length > 0) {
-            ringpop.ring.addRemoveServers(serversToAdd);
+            ringpop.ring.addRemoveServers(serversToAdd, []);
+            ringpop.emit('ringChanged', serversToAdd, []);
         }
     };
 }
@@ -127,7 +128,7 @@ function createUpdatedHandlerForRing(ringpop) {
                 serversToRemove);
 
             if (ringChanged) {
-                ringpop.emit('ringChanged');
+                ringpop.emit('ringChanged', serversToAdd, serversToRemove);
             }
         }
     };

--- a/lib/on_membership_event.js
+++ b/lib/on_membership_event.js
@@ -21,6 +21,7 @@
 
 var Member = require('./membership/member.js');
 var MembershipEvents = require('./membership/events.js');
+var RingEvents = require('../ring/events.js');
 
 function createChecksumComputedHandler(ringpop) {
     return function onMembershipChecksumComputed() {
@@ -63,7 +64,8 @@ function createSetHandler(ringpop) {
         // checksum once.
         if (serversToAdd.length > 0) {
             ringpop.ring.addRemoveServers(serversToAdd, []);
-            ringpop.emit('ringChanged', serversToAdd, []);
+            ringpop.emit('ringChanged', new RingEvents.RingChanged(
+                serversToAdd, []));
         }
     };
 }
@@ -128,7 +130,8 @@ function createUpdatedHandlerForRing(ringpop) {
                 serversToRemove);
 
             if (ringChanged) {
-                ringpop.emit('ringChanged', serversToAdd, serversToRemove);
+                ringpop.emit('ringChanged', new RingEvents.RingChanged(
+                    serversToAdd, serversToRemove));
             }
         }
     };

--- a/lib/on_membership_event.js
+++ b/lib/on_membership_event.js
@@ -21,7 +21,6 @@
 
 var Member = require('./membership/member.js');
 var MembershipEvents = require('./membership/events.js');
-var RingEvents = require('./ring/events.js');
 
 function createChecksumComputedHandler(ringpop) {
     return function onMembershipChecksumComputed() {
@@ -64,8 +63,6 @@ function createSetHandler(ringpop) {
         // checksum once.
         if (serversToAdd.length > 0) {
             ringpop.ring.addRemoveServers(serversToAdd, []);
-            ringpop.emit('ringChanged', new RingEvents.RingChanged(
-                serversToAdd, []));
         }
     };
 }
@@ -126,13 +123,8 @@ function createUpdatedHandlerForRing(ringpop) {
         // efficiency gains when only having to compute the ring
         // checksum once.
         if (serversToAdd.length > 0 || serversToRemove.length > 0) {
-            var ringChanged = ringpop.ring.addRemoveServers(serversToAdd,
+            ringpop.ring.addRemoveServers(serversToAdd,
                 serversToRemove);
-
-            if (ringChanged) {
-                ringpop.emit('ringChanged', new RingEvents.RingChanged(
-                    serversToAdd, serversToRemove));
-            }
         }
     };
 }

--- a/lib/on_ring_event.js
+++ b/lib/on_ring_event.js
@@ -26,6 +26,12 @@ function createChecksumComputedHandler(ringpop) {
     };
 }
 
+function createRingChangedHandler(ringpop) {
+    return function onRingChanged(event) {
+        ringpop.emit('ringChanged', event);
+    };
+}
+
 function createServerAddedHandler(ringpop) {
     return function onRingServerAdded() {
         ringpop.stat('increment', 'ring.server-added');
@@ -44,11 +50,13 @@ function register(ringpop) {
     var ring = ringpop.ring;
     ring.on('added', createServerAddedHandler(ringpop));
     ring.on('checksumComputed', createChecksumComputedHandler(ringpop));
+    ring.on('ringChanged', createRingChangedHandler(ringpop));
     ring.on('removed', createServerRemovedHandler(ringpop));
 }
 
 module.exports = {
     createChecksumComputedHandler: createChecksumComputedHandler,
+    createRingChangedHandler: createRingChangedHandler,
     createServerAddedHandler: createServerAddedHandler,
     createServerRemovedHandler: createServerRemovedHandler,
     register: register

--- a/lib/ring/events.js
+++ b/lib/ring/events.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+function RingChangedEvent(adding, removing) {
+    this.name = this.constructor.name;
+    this.adding = added;
+    this.removing = removing;
+}
+
+module.exports = {
+    RingChangedEvent: RingChangedEvent
+};

--- a/lib/ring/events.js
+++ b/lib/ring/events.js
@@ -19,10 +19,10 @@
 // THE SOFTWARE.
 'use strict';
 
-function RingChangedEvent(adding, removing) {
+function RingChangedEvent(added, removed) {
     this.name = this.constructor.name;
-    this.adding = adding;
-    this.removing = removing;
+    this.added = added;
+    this.removed = removed;
 }
 
 module.exports = {

--- a/lib/ring/events.js
+++ b/lib/ring/events.js
@@ -21,7 +21,7 @@
 
 function RingChangedEvent(adding, removing) {
     this.name = this.constructor.name;
-    this.adding = added;
+    this.adding = adding;
     this.removing = removing;
 }
 

--- a/lib/ring/index.js
+++ b/lib/ring/index.js
@@ -21,6 +21,7 @@ var EventEmitter = require('events').EventEmitter;
 var farmhash = require('farmhash');
 var util = require('util');
 var RBTree = require('./rbtree').RBTree;
+var RingEvents = require('./events.js');
 
 function HashRing(options) {
     this.options = options || {};
@@ -88,6 +89,8 @@ HashRing.prototype.addRemoveServers = function addRemoveServers(serversToAdd, se
 
     if (ringChanged) {
         this.computeChecksum();
+        this.emit('ringChanged', new RingEvents.RingChangedEvent(
+            serversToAdd, serversToRemove));
     }
 
     return ringChanged;

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -385,10 +385,10 @@ test('emits ring changed event', function t(assert) {
             assert.pass('membership changed');
         });
 
-        ringpop.once('ringChanged', function onRingChanged(added, removed) {
+        ringpop.once('ringChanged', function onRingChanged(event) {
             assert.pass('ring changed');
-            assert.deepEquals(added, intent.adding, 'expected servers added');
-            assert.deepEquals(removed, intent.removing, 'expected servers removed');
+            assert.deepEquals(event.added, intent.adding, 'expected servers added');
+            assert.deepEquals(event.removed, intent.removing, 'expected servers removed');
         });
 
         changer();


### PR DESCRIPTION
Over in Hyperbahn, I would like to incrementally update sorted arrays of affine relay addresses to reduce the cost of updating the service proxy in response to ring changes. To that end, I would like to thread the arrays of added and removed servers through the event.

I’ve added this feature and altered the existing test to verify the intended added and removed hosts, initializing the test to reflect reality since, but please check…it does not match my intuition.

r @uber/ringpop @jwolski 