### PR TITLE
Syncer

### DIFF
--- a/client.js
+++ b/client.js
@@ -96,7 +96,7 @@ RingpopClient.prototype._request = function _request(host, endpoint, head, body,
             return;
         }
 
-        if (head.gzip === true) {
+        if (head && head.gzip === true) {
             zlib.gunzip(arg3, function onGunzip(err, data) {
                 if (err) {
                     callback(err);

--- a/client.js
+++ b/client.js
@@ -36,45 +36,27 @@ function RingpopClient(subChannel) {
 }
 
 RingpopClient.prototype.adminConfigGet = function adminConfigGet(host, body, callback) {
-    this._request(host, '/admin/config/get', null, body, null, callback);
+    this._request(host, '/admin/config/get', null, body, callback);
 };
 
 RingpopClient.prototype.adminConfigSet = function adminConfigSet(host, body, callback) {
-    this._request(host, '/admin/config/set', null, body, null, callback);
+    this._request(host, '/admin/config/set', null, body, callback);
 };
 
 RingpopClient.prototype.adminGossipStart = function adminGossipStart(host, callback) {
-    this._request(host, '/admin/gossip/start', null, null, null, callback);
+    this._request(host, '/admin/gossip/start', null, null, callback);
 };
 
 RingpopClient.prototype.adminGossipStop = function adminGossipStop(host, callback) {
-    this._request(host, '/admin/gossip/stop', null, null, null, callback);
+    this._request(host, '/admin/gossip/stop', null, null, callback);
 };
 
 RingpopClient.prototype.adminGossipTick = function adminGossipTick(host, callback) {
-    this._request(host, '/admin/gossip/tick', null, null, null, callback);
+    this._request(host, '/admin/gossip/tick', null, null, callback);
 };
 
-RingpopClient.prototype.protocolSync = function protocolSync(opts, callback) {
-    opts = opts || {};
-    var host = opts.host;
-    var body = opts.body;
-
-    if (!host) {
-        process.nextTick(function onTick() {
-            callback(new Error('Bad request: host is required'));
-        });
-        return;
-    }
-
-    if (!body) {
-        process.nextTick(function onTick() {
-            callback(new Error('Bad request: body is required'));
-        });
-        return;
-    }
-
-    this._request(host, '/protocol/sync', null, body, opts, callback);
+RingpopClient.prototype.protocolSync = function protocolSync(host, head, body, callback) {
+    this._request(host, '/protocol/sync', head, body, callback);
 };
 
 RingpopClient.prototype.destroy = function destroy(callback) {
@@ -85,9 +67,7 @@ RingpopClient.prototype.destroy = function destroy(callback) {
 
 /* jshint maxparams: 6 */
 // Valid opts are: gzip
-RingpopClient.prototype._request = function _request(host, endpoint, head, body, opts, callback) {
-    opts = opts || {};
-
+RingpopClient.prototype._request = function _request(host, endpoint, head, body, callback) {
     var self = this;
     this.subChannel.waitForIdentified({
         host: host
@@ -116,7 +96,7 @@ RingpopClient.prototype._request = function _request(host, endpoint, head, body,
             return;
         }
 
-        if (opts.gzip === true) {
+        if (head.gzip === true) {
             zlib.gunzip(arg3, function onGunzip(err, data) {
                 if (err) {
                     callback(err);

--- a/client.js
+++ b/client.js
@@ -66,7 +66,6 @@ RingpopClient.prototype.destroy = function destroy(callback) {
 };
 
 /* jshint maxparams: 6 */
-// Valid opts are: gzip
 RingpopClient.prototype._request = function _request(host, endpoint, head, body, callback) {
     var self = this;
     this.subChannel.waitForIdentified({

--- a/client.js
+++ b/client.js
@@ -95,7 +95,8 @@ RingpopClient.prototype._request = function _request(host, endpoint, head, body,
             return;
         }
 
-        if (head && head.gzip === true) {
+        var respHead = safeParse(arg2 && arg2.toString());
+        if (respHead && respHead.gzip === true) {
             zlib.gunzip(arg3, function onGunzip(err, data) {
                 if (err) {
                     callback(err);

--- a/client.js
+++ b/client.js
@@ -54,6 +54,10 @@ RingpopClient.prototype.adminGossipTick = function adminGossipTick(host, callbac
     this._request(host, '/admin/gossip/tick', null, null, callback);
 };
 
+RingpopClient.prototype.protocolSync = function protocolSync(host, body, callback) {
+    this._request(host, '/protocol/sync', null, body, callback);
+};
+
 RingpopClient.prototype.destroy = function destroy(callback) {
     if (this.isChannelOwner) {
         this.tchannel.close(callback);

--- a/config.js
+++ b/config.js
@@ -98,6 +98,7 @@ Config.prototype._seed = function _seed(seed) {
     seedOrDefault('maxJoinAttempts', 50, numValidator);
     seedOrDefault('syncGzipEnabled', true);
     seedOrDefault('syncInterval', 10000, numValidator);
+    seedOrDefault('syncerEnabled', true);
 
     function seedOrDefault(name, defaultVal, validator, reason) {
         var seedVal = seed[name];

--- a/config.js
+++ b/config.js
@@ -95,7 +95,6 @@ Config.prototype._seed = function _seed(seed) {
         });
     }, 'expected to be array of RegExp objects');
     seedOrDefault('membershipUpdateRollupEnabled', false);
-    seedOrDefault('maxJoinAttempts', 50, numValidator);
     seedOrDefault('syncGzipEnabled', true);
     seedOrDefault('syncInterval', 10000, numValidator);
     seedOrDefault('syncerEnabled', true);

--- a/config.js
+++ b/config.js
@@ -95,6 +95,8 @@ Config.prototype._seed = function _seed(seed) {
         });
     }, 'expected to be array of RegExp objects');
     seedOrDefault('membershipUpdateRollupEnabled', false);
+    seedOrDefault('maxJoinAttempts', 50, numValidator);
+    seedOrDefault('syncInterval', 10000, numValidator);
 
     function seedOrDefault(name, defaultVal, validator, reason) {
         var seedVal = seed[name];

--- a/config.js
+++ b/config.js
@@ -96,6 +96,7 @@ Config.prototype._seed = function _seed(seed) {
     }, 'expected to be array of RegExp objects');
     seedOrDefault('membershipUpdateRollupEnabled', false);
     seedOrDefault('maxJoinAttempts', 50, numValidator);
+    seedOrDefault('syncGzipEnabled', true);
     seedOrDefault('syncInterval', 10000, numValidator);
 
     function seedOrDefault(name, defaultVal, validator, reason) {

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ var RingpopClient = require('./client.js');
 var RingpopServer = require('./server');
 var safeParse = require('./lib/util').safeParse;
 var sendJoin = require('./lib/gossip/joiner.js').joinCluster;
+var Syncer = require('./lib/gossip/syncer.js');
 var TracerStore = require('./lib/trace/store.js');
 
 var HOST_PORT_PATTERN = /^(\d+.\d+.\d+.\d+):\d+$/;
@@ -147,6 +148,9 @@ function RingPop(options) {
         ringpop: this,
         minProtocolPeriod: options.minProtocolPeriod
     });
+    this.syncer = new Syncer({
+        ringpop: this
+    });
     this.suspicion = new Suspicion({
         ringpop: this,
         suspicionTimeout: options.suspicionTimeout
@@ -190,7 +194,6 @@ RingPop.prototype.destroy = function destroy() {
 
     this.emit('destroying');
 
-    this.gossip.stop();
     this.suspicion.stopAll();
     this.membershipUpdateRollup.destroy();
     this.requestProxy.destroy();

--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -94,7 +94,9 @@ Dissemination.prototype.issueAsSender = function issueAsSender() {
     }
 };
 
-Dissemination.prototype.issueAsReceiver = function issueAsReceiver(senderAddr, senderIncarnationNumber) {
+Dissemination.prototype.issueAsReceiver = function issueAsReceiver(senderAddr, senderIncarnationNumber, senderChecksum) {
+    var self = this;
+
     return this._issueAs(filterChange, mapChanges);
 
     function filterChange(change) {
@@ -107,7 +109,24 @@ Dissemination.prototype.issueAsReceiver = function issueAsReceiver(senderAddr, s
     }
 
     function mapChanges(changes) {
-        return changes;
+        // If no changes left to disseminate and checksums do not match, perform a full-sync.
+        if (changes.length > 0) {
+            return changes;
+        } else if (self.ringpop.config.get('syncerEnabled') === false &&
+                self.ringpop.membership.checksum !== senderChecksum) {
+            self.ringpop.stat('increment', 'full-sync');
+            self.ringpop.logger.info('full sync', {
+                local: self.ringpop.whoami(),
+                localChecksum: self.ringpop.membership.checksum,
+                dest: senderAddr,
+                destChecksum: senderChecksum
+            });
+
+            // TODO Somehow send back indication of isFullSync
+            return self.fullSync();
+        } else {
+            return [];
+        }
     }
 };
 

--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -22,6 +22,7 @@
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
+var EMPTY = [];
 var LOG_10 = Math.log(10);
 
 function Dissemination(ringpop) {
@@ -43,7 +44,8 @@ Dissemination.prototype.adjustMaxPiggybackCount = function adjustMaxPiggybackCou
     if (this.maxPiggybackCount !== newPiggybackCount) {
         this.maxPiggybackCount = newPiggybackCount;
         this.ringpop.stat('gauge', 'max-piggyback', this.maxPiggybackCount);
-        this.ringpop.logger.debug('adjusted max piggyback count', {
+        this.ringpop.logger.debug('ringpop dissemination adjusted max piggyback count', {
+            local: this.ringpop.whoami(),
             newPiggybackCount: this.maxPiggybackCount,
             oldPiggybackCount: prevPiggybackCount,
             piggybackFactor: this.piggybackFactor,
@@ -75,6 +77,15 @@ Dissemination.prototype.fullSync = function fullSync() {
     return changes;
 };
 
+Dissemination.prototype.maybeFullSync = function maybeFullSync(membershipChecksum) {
+    if (!membershipChecksum ||
+        membershipChecksum === this.ringpop.membership.checksum) {
+        return EMPTY;
+    }
+
+    return this.fullSync();
+};
+
 Dissemination.prototype.issueAsSender = function issueAsSender() {
     return this._issueAs(null, mapChanges);
 
@@ -83,9 +94,7 @@ Dissemination.prototype.issueAsSender = function issueAsSender() {
     }
 };
 
-Dissemination.prototype.issueAsReceiver = function issueAsReceiver(senderAddr, senderIncarnationNumber, senderChecksum) {
-    var self = this;
-
+Dissemination.prototype.issueAsReceiver = function issueAsReceiver(senderAddr, senderIncarnationNumber) {
     return this._issueAs(filterChange, mapChanges);
 
     function filterChange(change) {
@@ -98,23 +107,7 @@ Dissemination.prototype.issueAsReceiver = function issueAsReceiver(senderAddr, s
     }
 
     function mapChanges(changes) {
-        // If no changes left to disseminate and checksums do not match, perform a full-sync.
-        if (changes.length > 0) {
-            return changes;
-        } else if (self.ringpop.membership.checksum !== senderChecksum) {
-            self.ringpop.stat('increment', 'full-sync');
-            self.ringpop.logger.info('full sync', {
-                local: self.ringpop.whoami(),
-                localChecksum: self.ringpop.membership.checksum,
-                dest: senderAddr,
-                destChecksum: senderChecksum
-            });
-
-            // TODO Somehow send back indication of isFullSync
-            return self.fullSync();
-        } else {
-            return [];
-        }
+        return changes;
     }
 };
 

--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -42,7 +42,7 @@ Dissemination.prototype.adjustMaxPiggybackCount = function adjustMaxPiggybackCou
     var newPiggybackCount = this.piggybackFactor * Math.ceil(Math.log(serverCount + 1) / LOG_10);
 
     if (this.maxPiggybackCount !== newPiggybackCount) {
-        this.maxPiggybackCount = 0; //newPiggybackCount;
+        this.maxPiggybackCount = newPiggybackCount;
         this.ringpop.stat('gauge', 'max-piggyback', this.maxPiggybackCount);
         this.ringpop.logger.debug('ringpop dissemination adjusted max piggyback count', {
             local: this.ringpop.whoami(),

--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -42,7 +42,7 @@ Dissemination.prototype.adjustMaxPiggybackCount = function adjustMaxPiggybackCou
     var newPiggybackCount = this.piggybackFactor * Math.ceil(Math.log(serverCount + 1) / LOG_10);
 
     if (this.maxPiggybackCount !== newPiggybackCount) {
-        this.maxPiggybackCount = newPiggybackCount;
+        this.maxPiggybackCount = 0; //newPiggybackCount;
         this.ringpop.stat('gauge', 'max-piggyback', this.maxPiggybackCount);
         this.ringpop.logger.debug('ringpop dissemination adjusted max piggyback count', {
             local: this.ringpop.whoami(),

--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -29,7 +29,7 @@ function Dissemination(ringpop) {
     this.ringpop = ringpop;
     this.ringpop.on('ringChanged', this.onRingChanged.bind(this));
 
-    this.changes = {};
+    this.membershipChanges = {};
     this.maxPiggybackCount = Dissemination.Defaults.maxPiggybackCount;
     this.piggybackFactor = Dissemination.Defaults.piggybackFactor;
 }
@@ -57,7 +57,7 @@ Dissemination.prototype.adjustMaxPiggybackCount = function adjustMaxPiggybackCou
 };
 
 Dissemination.prototype.clearChanges = function clearChanges() {
-    this.changes = [];
+    this.membershipChanges = {};
 };
 
 Dissemination.prototype.fullSync = function fullSync() {
@@ -77,9 +77,15 @@ Dissemination.prototype.fullSync = function fullSync() {
     return changes;
 };
 
+Dissemination.prototype.isEmpty = function isEmpty() {
+    return Object.keys(this.membershipChanges).length === 0;
+};
+
 Dissemination.prototype.maybeFullSync = function maybeFullSync(membershipChecksum) {
-    if (!membershipChecksum ||
-        membershipChecksum === this.ringpop.membership.checksum) {
+    // If there are still changes left to disseminate or the membership checksums
+    // are the same, return no membership changes.
+    if (!this.isEmpty() ||
+            membershipChecksum === this.ringpop.membership.checksum) {
         return EMPTY;
     }
 
@@ -135,7 +141,7 @@ Dissemination.prototype.onRingChanged = function onRingChanged() {
 };
 
 Dissemination.prototype.recordChange = function recordChange(change) {
-    this.changes[change.address] = change;
+    this.membershipChanges[change.address] = change;
 };
 
 Dissemination.prototype.resetMaxPiggybackCount = function resetMaxPiggybackCount() {
@@ -145,11 +151,11 @@ Dissemination.prototype.resetMaxPiggybackCount = function resetMaxPiggybackCount
 Dissemination.prototype._issueAs = function _issueAs(filterChange, mapChanges) {
     var changesToDisseminate = [];
 
-    var changedNodes = Object.keys(this.changes);
+    var changedNodes = Object.keys(this.membershipChanges);
 
     for (var i = 0; i < changedNodes.length; i++) {
         var address = changedNodes[i];
-        var change = this.changes[address];
+        var change = this.membershipChanges[address];
 
         // TODO We're bumping the piggyback count even though
         // we don't know whether the change successfully made
@@ -167,7 +173,7 @@ Dissemination.prototype._issueAs = function _issueAs(filterChange, mapChanges) {
         change.piggybackCount += 1;
 
         if (change.piggybackCount > this.maxPiggybackCount) {
-            delete this.changes[address];
+            delete this.membershipChanges[address];
             continue;
         }
 

--- a/lib/gossip/events.js
+++ b/lib/gossip/events.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+function SyncEmptyEvent() {
+    this.name = this.constructor.name;
+}
+
+function SyncFailedEvent() {
+    this.name = this.constructor.name;
+}
+
+function SyncedEvent() {
+    this.name = this.constructor.name;
+}
+
+function SyncerStartedEvent() {
+    this.name = this.constructor.name;
+}
+
+function SyncerStoppedEvent() {
+    this.name = this.constructor.name;
+}
+
+module.exports = {
+    SyncEmptyEvent: SyncEmptyEvent,
+    SyncFailedEvent: SyncFailedEvent,
+    SyncedEvent: SyncedEvent,
+    SyncerStartedEvent: SyncerStartedEvent,
+    SyncerStoppedEvent: SyncerStoppedEvent
+};

--- a/lib/gossip/events.js
+++ b/lib/gossip/events.js
@@ -35,6 +35,10 @@ function SyncerAlreadyStartedEvent() {
     this.name = this.constructor.name;
 }
 
+function SyncerAlreadyStoppedEvent() {
+    this.name = this.constructor.name;
+}
+
 function SyncerDisabledEvent() {
     this.name = this.constructor.name;
 }
@@ -56,6 +60,7 @@ module.exports = {
     SyncFailedEvent: SyncFailedEvent,
     SyncedEvent: SyncedEvent,
     SyncerAlreadyStartedEvent: SyncerAlreadyStartedEvent,
+    SyncerAlreadyStoppedEvent: SyncerAlreadyStoppedEvent,
     SyncerDisabledEvent: SyncerDisabledEvent,
     SyncerStartedEvent: SyncerStartedEvent,
     SyncerStoppedEvent: SyncerStoppedEvent,

--- a/lib/gossip/events.js
+++ b/lib/gossip/events.js
@@ -31,6 +31,14 @@ function SyncedEvent() {
     this.name = this.constructor.name;
 }
 
+function SyncerAlreadyStartedEvent() {
+    this.name = this.constructor.name;
+}
+
+function SyncerDisabledEvent() {
+    this.name = this.constructor.name;
+}
+
 function SyncerStartedEvent() {
     this.name = this.constructor.name;
 }
@@ -39,10 +47,17 @@ function SyncerStoppedEvent() {
     this.name = this.constructor.name;
 }
 
+function SyncerSyncingEvent() {
+    this.name = this.constructor.name;
+}
+
 module.exports = {
     SyncEmptyEvent: SyncEmptyEvent,
     SyncFailedEvent: SyncFailedEvent,
     SyncedEvent: SyncedEvent,
+    SyncerAlreadyStartedEvent: SyncerAlreadyStartedEvent,
+    SyncerDisabledEvent: SyncerDisabledEvent,
     SyncerStartedEvent: SyncerStartedEvent,
-    SyncerStoppedEvent: SyncerStoppedEvent
+    SyncerStoppedEvent: SyncerStoppedEvent,
+    SyncerSyncingEvent: SyncerSyncingEvent
 };

--- a/lib/gossip/events.js
+++ b/lib/gossip/events.js
@@ -19,6 +19,10 @@
 // THE SOFTWARE.
 'use strict';
 
+function ChangesPendingEvent() {
+    this.name = this.constructor.name;
+}
+
 function NoSyncTargetEvent() {
     this.name = this.constructor.name;
 }
@@ -65,6 +69,7 @@ function SyncerSyncingEvent() {
 }
 
 module.exports = {
+    ChangesPendingEvent: ChangesPendingEvent,
     NoSyncTargetEvent: NoSyncTargetEvent,
     SyncEmptyEvent: SyncEmptyEvent,
     SyncFailedEvent: SyncFailedEvent,

--- a/lib/gossip/events.js
+++ b/lib/gossip/events.js
@@ -31,8 +31,9 @@ function SyncFailedEvent() {
     this.name = this.constructor.name;
 }
 
-function SyncedEvent() {
+function SyncedEvent(membershipChanges) {
     this.name = this.constructor.name;
+    this.membershipChanges = membershipChanges;
 }
 
 function SyncerAlreadyStartedEvent() {

--- a/lib/gossip/events.js
+++ b/lib/gossip/events.js
@@ -19,6 +19,10 @@
 // THE SOFTWARE.
 'use strict';
 
+function NoSyncTargetEvent() {
+    this.name = this.constructor.name;
+}
+
 function SyncEmptyEvent() {
     this.name = this.constructor.name;
 }
@@ -39,6 +43,10 @@ function SyncerAlreadyStoppedEvent() {
     this.name = this.constructor.name;
 }
 
+function SyncerAlreadySyncingEvent() {
+    this.name = this.constructor.name;
+}
+
 function SyncerDisabledEvent() {
     this.name = this.constructor.name;
 }
@@ -56,11 +64,13 @@ function SyncerSyncingEvent() {
 }
 
 module.exports = {
+    NoSyncTargetEvent: NoSyncTargetEvent,
     SyncEmptyEvent: SyncEmptyEvent,
     SyncFailedEvent: SyncFailedEvent,
     SyncedEvent: SyncedEvent,
     SyncerAlreadyStartedEvent: SyncerAlreadyStartedEvent,
     SyncerAlreadyStoppedEvent: SyncerAlreadyStoppedEvent,
+    SyncerAlreadySyncingEvent: SyncerAlreadySyncingEvent,
     SyncerDisabledEvent: SyncerDisabledEvent,
     SyncerStartedEvent: SyncerStartedEvent,
     SyncerStoppedEvent: SyncerStoppedEvent,

--- a/lib/gossip/index.js
+++ b/lib/gossip/index.js
@@ -94,7 +94,6 @@ Gossip.prototype.start = function start() {
         return;
     }
 
-    this.ringpop.membership.shuffle();
     this.run();
     this.startProtocolRateTimer();
     this.isStopped = false;

--- a/lib/gossip/index.js
+++ b/lib/gossip/index.js
@@ -22,7 +22,6 @@
 var metrics = require('metrics');
 var sendPing = require('./ping-sender.js');
 var sendPingReq = require('./ping-req-sender.js');
-var Syncer = require('./syncer.js');
 
 function Gossip(options) {
     this.ringpop = options.ringpop;

--- a/lib/gossip/index.js
+++ b/lib/gossip/index.js
@@ -201,8 +201,4 @@ Gossip.Status = {
     Stopped: 'stopped'
 };
 
-module.exports = function createGossip(opts, syncerOpts) {
-    var gossip = new Gossip(opts);
-    gossip.syncer = new Syncer(syncerOpts);
-    return gossip;
-};
+module.exports = Gossip;

--- a/lib/gossip/index.js
+++ b/lib/gossip/index.js
@@ -22,6 +22,7 @@
 var metrics = require('metrics');
 var sendPing = require('./ping-sender.js');
 var sendPingReq = require('./ping-req-sender.js');
+var Syncer = require('./syncer.js');
 
 function Gossip(options) {
     this.ringpop = options.ringpop;
@@ -200,4 +201,8 @@ Gossip.Status = {
     Stopped: 'stopped'
 };
 
-module.exports = Gossip;
+module.exports = function createGossip(opts, syncerOpts) {
+    var gossip = new Gossip(opts);
+    gossip.syncer = new Syncer(syncerOpts);
+    return gossip;
+};

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -102,8 +102,10 @@ Syncer.prototype.sync = function sync(callback) {
             self.ringpop.logger.info('ringpop syncer applied membership changes', {
                 local: self.ringpop.whoami(),
                 target: pingableMember.address,
-                membershipChecksum: membershipChecksum,
-                numMembershipChanges: membershipChanges.length
+                numMembershipChanges: membershipChanges.length,
+                prevChecksum: membershipChecksum,
+                currentChecksum: self.ringpop.membership.checksum,
+                targetChecksum: response.membershipChecksum
             });
         }
 

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -26,6 +26,7 @@ var MemberIterator = require('../membership/iterator.js');
 var RequestResponse = require('../../request_response.js');
 var util = require('util');
 
+var noop = function noop() {};
 var SyncRequestBody = RequestResponse.SyncRequestBody;
 var SyncRequestHeaders = RequestResponse.SyncRequestHeaders;
 
@@ -34,6 +35,7 @@ function Syncer(opts) {
     this.timers = opts.timers || globalTimers;
     this.syncTimer = null;
     this.memberIterator = null;
+    this.isSyncing = false;
 }
 
 util.inherits(Syncer, EventEmitter);
@@ -85,7 +87,17 @@ Syncer.prototype.stop = function stop() {
 
 Syncer.prototype.sync = function sync(callback) {
     var self = this;
+    callback = callback || noop;
 
+    if (this.isSyncing) {
+        this.ringpop.logger.debug('ringpop syncer already syncing', {
+            local: this.ringpop.whoami()
+        });
+        cleanup(events.SyncerAlreadySyncingEvent);
+        return;
+    }
+
+    this.isSyncing = true;
     this.emit('event', new events.SyncerSyncingEvent());
 
     // Lazily initialize by waiting until sync is started
@@ -98,9 +110,7 @@ Syncer.prototype.sync = function sync(callback) {
         this.ringpop.logger.debug('ringpop syncer next member does not exist', {
             local: this.ringpop.whoami()
         });
-        process.nextTick(function onTick() {
-            callback();
-        });
+        cleanup(events.NoSyncTargetEvent);
         return;
     }
 
@@ -124,16 +134,14 @@ Syncer.prototype.sync = function sync(callback) {
                 target: pingableMember.address,
                 err: err
             });
-            self.emit('event', new events.SyncFailedEvent());
-            callback();
+            cleanup(events.SyncFailedEvent);
             return;
         }
 
         self.ringpop.stat('increment', 'sync.send.success');
         var membershipChanges = response.membershipChanges;
         if (!Array.isArray(membershipChanges) || membershipChanges.length === 0) {
-            self.emit('event', new events.SyncEmptyEvent());
-            callback();
+            cleanup(events.SyncEmptyEvent);
             return;
         }
 
@@ -147,7 +155,12 @@ Syncer.prototype.sync = function sync(callback) {
             numMembershipChanges: membershipChanges.length,
             numUpdatesApplied: updates.length
         });
-        self.emit('event', new events.SyncedEvent());
+        cleanup(events.SyncedEvent);
+    }
+
+    function cleanup(Event) {
+        self.isSyncing = false;
+        self.emit('event', new Event());
         callback();
     }
 };

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -98,14 +98,15 @@ Syncer.prototype.sync = function sync(callback) {
         self.ringpop.stat('increment', 'sync.send.success');
         var membershipChanges = response.membershipChanges;
         if (Array.isArray(membershipChanges) && membershipChanges.length > 0) {
-            self.ringpop.membership.update(response.membershipChanges);
+            var updates = self.ringpop.membership.update(response.membershipChanges);
             self.ringpop.logger.info('ringpop syncer applied membership changes', {
                 local: self.ringpop.whoami(),
                 target: pingableMember.address,
-                numMembershipChanges: membershipChanges.length,
                 prevChecksum: membershipChecksum,
                 currentChecksum: self.ringpop.membership.checksum,
-                targetChecksum: response.membershipChecksum
+                targetChecksum: response.membershipChecksum,
+                numMembershipChanges: membershipChanges.length,
+                numUpdatesApplied: updates.length
             });
         }
 

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -144,12 +144,26 @@ Syncer.prototype.sync = function sync(callback) {
         self.ringpop.stat('increment', 'sync.send.success');
         var membershipChanges = response.membershipChanges;
         if (!Array.isArray(membershipChanges) || membershipChanges.length === 0) {
+            self.ringpop.stat('increment', 'sync.changes.none');
+            self.ringpop.logger.info('ringpop syncer synced; no changes', {
+                local: self.ringpop.whoami(),
+                target: pingableMember.address,
+                currentChecksum: self.ringpop.membership.checksum,
+                targetChecksum: response.membershipChecksum
+            });
             cleanup(new events.SyncEmptyEvent());
             return;
         }
 
         var updates = self.ringpop.membership.update(membershipChanges);
-        self.ringpop.logger.info('ringpop syncer applied membership changes', {
+
+        if (updates.length === 0) {
+            self.ringpop.stat('increment', 'sync.changes.notapplicable');
+        } else {
+            self.ringpop.stat('increment', 'sync.changes.applied');
+        }
+
+        self.ringpop.logger.info('ringpop syncer synced; processed changes', {
             local: self.ringpop.whoami(),
             target: pingableMember.address,
             prevChecksum: membershipChecksum,

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -31,6 +31,13 @@ function Syncer(opts) {
 Syncer.prototype.start = function start() {
     var self = this;
 
+    if (this.ringpop.config.get('syncerEnabled') === false) {
+        this.ringpop.logger.warn('ringpop syncer is disabled', {
+            local: this.ringpop.whoami()
+        });
+        return;
+    }
+
     if (this.syncTimer) {
         this.ringpop.logger.warn('ringpop sync timer already started', {
             local: this.ringpop.whoami()

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -74,6 +74,7 @@ Syncer.prototype.stop = function stop() {
         this.ringpop.logger.warn('ringpop sync timer already stopped', {
             local: this.ringpop.whoami()
         });
+        this.emit('event', new events.SyncerAlreadyStoppedEvent());
         return;
     }
 

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -157,7 +157,7 @@ Syncer.prototype.sync = function sync(callback) {
 
         var updates = self.ringpop.membership.update(membershipChanges);
 
-        if (updates.length === 0) {
+        if (!Array.isArray(updates) || updates.length === 0) {
             self.ringpop.stat('increment', 'sync.changes.notapplicable');
         } else {
             self.ringpop.stat('increment', 'sync.changes.applied');

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -1,0 +1,80 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var globalTimers = require('timers');
+var MemberIterator = require('../membership/iterator.js');
+
+function Syncer(opts) {
+    this.ringpop = opts.ringpop;
+    this.timers = opts.timers || globalTimers;
+    this.syncTimer = null;
+}
+
+Syncer.prototype.start = function start() {
+    var self = this;
+
+    if (this.syncTimer) {
+        this.ringpop.logger.warn('ringpop sync timer already started', {
+            local: this.ringpop.whoami()
+        });
+        return;
+    }
+
+    schedule();
+    this.memberIterator = new MemberIterator(this.ringpop);
+
+    function schedule() {
+        self.syncTimer = self.timers.setTimeout(function onTimeout() {
+            self.sync(function onSync() {
+                schedule();
+            });
+        }, self.ringpop.config.get('syncInterval'));
+    }
+};
+
+Syncer.prototype.stop = function stop() {
+    if (!this.syncTimer) {
+        this.ringpop.logger.warn('ringpop sync timer already stopped', {
+            local: this.ringpop.whoami()
+        });
+        return;
+    }
+
+    this.timers.clearTimeout(this.syncTimer);
+    this.syncTimer = null;
+};
+
+Syncer.prototype.sync = function sync() {
+    var self = this;
+    var pingableMember = this.memberIterator.next();
+    this.ringpop.stat('increment', 'sync.send');
+    this.ringpop.client.protocolSync(pingableMember.address, {
+        membershipChecksum: this.ringpop.membership.checksum
+    }, function onSync(err, response) {
+        if (err) {
+            return;
+        }
+
+        self.ringpop.membership.update(response.membershipChanges);
+    });
+};
+
+module.exports = Syncer;

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -19,14 +19,24 @@
 // THE SOFTWARE.
 'use strict';
 
+var events = require('./events.js');
+var EventEmitter = require('events').EventEmitter;
 var globalTimers = require('timers');
 var MemberIterator = require('../membership/iterator.js');
+var RequestResponse = require('../../request_response.js');
+var util = require('util');
+
+var SyncRequestBody = RequestResponse.SyncRequestBody;
+var SyncRequestHeaders = RequestResponse.SyncRequestHeaders;
 
 function Syncer(opts) {
     this.ringpop = opts.ringpop;
     this.timers = opts.timers || globalTimers;
     this.syncTimer = null;
+    this.memberIterator = null;
 }
+
+util.inherits(Syncer, EventEmitter);
 
 Syncer.prototype.start = function start() {
     var self = this;
@@ -46,7 +56,7 @@ Syncer.prototype.start = function start() {
     }
 
     schedule();
-    this.memberIterator = new MemberIterator(this.ringpop);
+    this.emit('event', new events.SyncerStartedEvent());
 
     function schedule() {
         self.syncTimer = self.timers.setTimeout(function onTimeout() {
@@ -67,10 +77,17 @@ Syncer.prototype.stop = function stop() {
 
     this.timers.clearTimeout(this.syncTimer);
     this.syncTimer = null;
+    this.emit('event', new events.SyncerStoppedEvent());
 };
 
 Syncer.prototype.sync = function sync(callback) {
     var self = this;
+
+    // Lazily initialize by waiting until sync is started
+    if (!this.memberIterator) {
+        this.memberIterator = new MemberIterator(this.ringpop);
+    }
+
     var pingableMember = this.memberIterator.next();
     if (!pingableMember) {
         this.ringpop.logger.debug('ringpop syncer next member does not exist', {
@@ -83,15 +100,18 @@ Syncer.prototype.sync = function sync(callback) {
     }
 
     this.ringpop.stat('increment', 'sync.send.attempt');
+    this.ringpop.logger.info('ringpop syncer starting', {
+        local: this.ringpop.whoami(),
+        target: pingableMember.address
+    });
     var membershipChecksum = this.ringpop.membership.checksum;
-    var head = {
-        gzip: this.ringpop.config.get('syncGzipEnabled')
-    };
-    var body = {
-        membershipChecksum: membershipChecksum
-    };
-    this.ringpop.client.protocolSync(pingableMember.address, head, body,
-            function onSync(err, response) {
+    this.ringpop.client.protocolSync(
+        pingableMember.address,
+        new SyncRequestHeaders(this.ringpop.config.get('syncGzipEnabled')),
+        new SyncRequestBody(membershipChecksum),
+        onSync);
+
+    function onSync(err, response) {
         if (err) {
             self.ringpop.stat('increment', 'sync.send.error');
             self.ringpop.logger.warn('ringpop protocol sync error', {
@@ -99,27 +119,32 @@ Syncer.prototype.sync = function sync(callback) {
                 target: pingableMember.address,
                 err: err
             });
+            self.emit('event', new events.SyncFailedEvent());
             callback();
             return;
         }
 
         self.ringpop.stat('increment', 'sync.send.success');
         var membershipChanges = response.membershipChanges;
-        if (Array.isArray(membershipChanges) && membershipChanges.length > 0) {
-            var updates = self.ringpop.membership.update(response.membershipChanges);
-            self.ringpop.logger.info('ringpop syncer applied membership changes', {
-                local: self.ringpop.whoami(),
-                target: pingableMember.address,
-                prevChecksum: membershipChecksum,
-                currentChecksum: self.ringpop.membership.checksum,
-                targetChecksum: response.membershipChecksum,
-                numMembershipChanges: membershipChanges.length,
-                numUpdatesApplied: updates.length
-            });
+        if (!Array.isArray(membershipChanges) || membershipChanges.length === 0) {
+            self.emit('event', new events.SyncEmptyEvent());
+            callback();
+            return;
         }
 
+        var updates = self.ringpop.membership.update(membershipChanges);
+        self.ringpop.logger.info('ringpop syncer applied membership changes', {
+            local: self.ringpop.whoami(),
+            target: pingableMember.address,
+            prevChecksum: membershipChecksum,
+            currentChecksum: self.ringpop.membership.checksum,
+            targetChecksum: response.membershipChecksum,
+            numMembershipChanges: membershipChanges.length,
+            numUpdatesApplied: updates.length
+        });
+        self.emit('event', new events.SyncedEvent());
         callback();
-    });
+    }
 };
 
 module.exports = Syncer;

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -105,9 +105,17 @@ Syncer.prototype.sync = function sync(callback) {
         this.memberIterator = new MemberIterator(this.ringpop);
     }
 
+    if (!this.ringpop.dissemination.isEmpty()) {
+        this.ringpop.logger.debug('ringpop syncer syncing skipped; changes pending', {
+            local: this.ringpop.whoami()
+        });
+        cleanup(new events.ChangesPendingEvent());
+        return;
+    }
+
     var pingableMember = this.memberIterator.next();
     if (!pingableMember) {
-        this.ringpop.logger.debug('ringpop syncer next member does not exist', {
+        this.ringpop.logger.debug('ringpop syncer syncing skipped; next member does not exist', {
             local: this.ringpop.whoami()
         });
         cleanup(new events.NoSyncTargetEvent());

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -45,6 +45,7 @@ Syncer.prototype.start = function start() {
         this.ringpop.logger.warn('ringpop syncer is disabled', {
             local: this.ringpop.whoami()
         });
+        this.emit('event', new events.SyncerDisabledEvent());
         return;
     }
 
@@ -52,6 +53,7 @@ Syncer.prototype.start = function start() {
         this.ringpop.logger.warn('ringpop sync timer already started', {
             local: this.ringpop.whoami()
         });
+        this.emit('event', new events.SyncerAlreadyStartedEvent());
         return;
     }
 
@@ -82,6 +84,8 @@ Syncer.prototype.stop = function stop() {
 
 Syncer.prototype.sync = function sync(callback) {
     var self = this;
+
+    this.emit('event', new events.SyncerSyncingEvent());
 
     // Lazily initialize by waiting until sync is started
     if (!this.memberIterator) {

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -77,13 +77,14 @@ Syncer.prototype.sync = function sync(callback) {
 
     this.ringpop.stat('increment', 'sync.send.attempt');
     var membershipChecksum = this.ringpop.membership.checksum;
-    this.ringpop.client.protocolSync({
-        host: pingableMember.address,
-        body: {
-            membershipChecksum: membershipChecksum
-        },
+    var head = {
         gzip: this.ringpop.config.get('syncGzipEnabled')
-    }, function onSync(err, response) {
+    };
+    var body = {
+        membershipChecksum: membershipChecksum
+    };
+    this.ringpop.client.protocolSync(pingableMember.address, head, body,
+            function onSync(err, response) {
         if (err) {
             self.ringpop.stat('increment', 'sync.send.error');
             self.ringpop.logger.warn('ringpop protocol sync error', {

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -74,15 +74,15 @@ Syncer.prototype.sync = function sync(callback) {
         });
         return;
     }
+
     this.ringpop.stat('increment', 'sync.send.attempt');
     var membershipChecksum = this.ringpop.membership.checksum;
-    this.ringpop.logger.info('ringpop syncer sending protocol sync', {
-        local: this.ringpop.whoami(),
-        target: pingableMember.address,
-        membershipChecksum: this.ringpop.membership.checksum
-    });
-    this.ringpop.client.protocolSync(pingableMember.address, {
-        membershipChecksum: membershipChecksum
+    this.ringpop.client.protocolSync({
+        host: pingableMember.address,
+        body: {
+            membershipChecksum: membershipChecksum
+        },
+        gzip: this.ringpop.config.get('syncGzipEnabled')
     }, function onSync(err, response) {
         if (err) {
             self.ringpop.stat('increment', 'sync.send.error');

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -93,7 +93,7 @@ Syncer.prototype.sync = function sync(callback) {
         this.ringpop.logger.debug('ringpop syncer already syncing', {
             local: this.ringpop.whoami()
         });
-        cleanup(events.SyncerAlreadySyncingEvent);
+        cleanup(new events.SyncerAlreadySyncingEvent());
         return;
     }
 
@@ -110,7 +110,7 @@ Syncer.prototype.sync = function sync(callback) {
         this.ringpop.logger.debug('ringpop syncer next member does not exist', {
             local: this.ringpop.whoami()
         });
-        cleanup(events.NoSyncTargetEvent);
+        cleanup(new events.NoSyncTargetEvent());
         return;
     }
 
@@ -134,14 +134,14 @@ Syncer.prototype.sync = function sync(callback) {
                 target: pingableMember.address,
                 err: err
             });
-            cleanup(events.SyncFailedEvent);
+            cleanup(new events.SyncFailedEvent());
             return;
         }
 
         self.ringpop.stat('increment', 'sync.send.success');
         var membershipChanges = response.membershipChanges;
         if (!Array.isArray(membershipChanges) || membershipChanges.length === 0) {
-            cleanup(events.SyncEmptyEvent);
+            cleanup(new events.SyncEmptyEvent());
             return;
         }
 
@@ -155,12 +155,12 @@ Syncer.prototype.sync = function sync(callback) {
             numMembershipChanges: membershipChanges.length,
             numUpdatesApplied: updates.length
         });
-        cleanup(events.SyncedEvent);
+        cleanup(new events.SyncedEvent(membershipChanges));
     }
 
-    function cleanup(Event) {
+    function cleanup(event) {
         self.isSyncing = false;
-        self.emit('event', new Event());
+        self.emit('event', event);
         callback();
     }
 };

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -120,6 +120,7 @@ Syncer.prototype.sync = function sync(callback) {
         target: pingableMember.address
     });
     var membershipChecksum = this.ringpop.membership.checksum;
+    var startTime = Date.now();
     this.ringpop.client.protocolSync(
         pingableMember.address,
         new SyncRequestHeaders(this.ringpop.config.get('syncGzipEnabled')),
@@ -127,6 +128,8 @@ Syncer.prototype.sync = function sync(callback) {
         onSync);
 
     function onSync(err, response) {
+        self.ringpop.stat('timing', 'sync.response', Date.now() - startTime);
+
         if (err) {
             self.ringpop.stat('increment', 'sync.send.error');
             self.ringpop.logger.warn('ringpop protocol sync error', {

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -62,18 +62,52 @@ Syncer.prototype.stop = function stop() {
     this.syncTimer = null;
 };
 
-Syncer.prototype.sync = function sync() {
+Syncer.prototype.sync = function sync(callback) {
     var self = this;
     var pingableMember = this.memberIterator.next();
-    this.ringpop.stat('increment', 'sync.send');
-    this.ringpop.client.protocolSync(pingableMember.address, {
+    if (!pingableMember) {
+        this.ringpop.logger.debug('ringpop syncer next member does not exist', {
+            local: this.ringpop.whoami()
+        });
+        process.nextTick(function onTick() {
+            callback();
+        });
+        return;
+    }
+    this.ringpop.stat('increment', 'sync.send.attempt');
+    var membershipChecksum = this.ringpop.membership.checksum;
+    this.ringpop.logger.info('ringpop syncer sending protocol sync', {
+        local: this.ringpop.whoami(),
+        target: pingableMember.address,
         membershipChecksum: this.ringpop.membership.checksum
+    });
+    this.ringpop.client.protocolSync(pingableMember.address, {
+        membershipChecksum: membershipChecksum
     }, function onSync(err, response) {
         if (err) {
+            self.ringpop.stat('increment', 'sync.send.error');
+            self.ringpop.logger.warn('ringpop protocol sync error', {
+                local: self.ringpop.whoami(),
+                target: pingableMember.address,
+                err: err
+            });
+            callback();
             return;
         }
 
-        self.ringpop.membership.update(response.membershipChanges);
+        self.ringpop.stat('increment', 'sync.send.success');
+        var membershipChanges = response.membershipChanges;
+        if (Array.isArray(membershipChanges) && membershipChanges.length > 0) {
+            self.ringpop.membership.update(response.membershipChanges);
+            self.ringpop.logger.info('ringpop syncer applied membership changes', {
+                local: self.ringpop.whoami(),
+                target: pingableMember.address,
+                membershipChecksum: membershipChecksum,
+                numMembershipChanges: membershipChanges.length
+            });
+        }
+
+        callback();
     });
 };
 

--- a/lib/gossip/syncer.js
+++ b/lib/gossip/syncer.js
@@ -156,7 +156,6 @@ Syncer.prototype.sync = function sync(callback) {
         }
 
         var updates = self.ringpop.membership.update(membershipChanges);
-
         if (!Array.isArray(updates) || updates.length === 0) {
             self.ringpop.stat('increment', 'sync.changes.notapplicable');
         } else {

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -323,10 +323,6 @@ Membership.prototype.update = function update(changes, isLocal) {
     }
 };
 
-Membership.prototype.shuffle = function shuffle() {
-    this.members = _.shuffle(this.members);
-};
-
 Membership.prototype.startDampScoreDecayer = function startDampScoreDecayer() {
     var self = this;
 

--- a/lib/membership/iterator.js
+++ b/lib/membership/iterator.js
@@ -57,7 +57,7 @@ MembershipIterator.prototype.next = function next() {
 };
 
 MembershipIterator.prototype._shuffleMembers = function _shuffleMembers() {
-    this.members = _.shuffle(this.membership.members);
+    this.members = _.shuffle(this.ringpop.membership.members);
 };
 
 module.exports = MembershipIterator;

--- a/lib/membership/iterator.js
+++ b/lib/membership/iterator.js
@@ -19,27 +19,33 @@
 // THE SOFTWARE.
 'use strict';
 
+var _ = require('underscore');
+
 function MembershipIterator(ringpop) {
     this.ringpop = ringpop;
     this.currentIndex = -1;
     this.currentRound = 0;
+    this.members = null;
 }
 
 MembershipIterator.prototype.next = function next() {
+    if (this.members === null) {
+        this._shuffleMembers();
+    }
+
     var membersVisited = {};
     var maxMembersToVisit = this.ringpop.membership.getMemberCount();
 
     while (Object.keys(membersVisited).length < maxMembersToVisit) {
         this.currentIndex++;
 
-        if (this.currentIndex >= this.ringpop.membership.getMemberCount()) {
+        if (this.currentIndex >= this.members.length) {
             this.currentIndex = 0;
             this.currentRound++;
-            this.ringpop.membership.shuffle();
+            this._shuffleMembers();
         }
 
-        var member = this.ringpop.membership.getMemberAt(this.currentIndex);
-
+        var member = this.members[this.currentIndex];
         membersVisited[member.address] = true;
 
         if (this.ringpop.membership.isPingable(member)) {
@@ -48,6 +54,10 @@ MembershipIterator.prototype.next = function next() {
     }
 
     return null;
+};
+
+MembershipIterator.prototype._shuffleMembers = function _shuffleMembers() {
+    this.members = _.shuffle(this.membership.members);
 };
 
 module.exports = MembershipIterator;

--- a/lib/on_ringpop_event.js
+++ b/lib/on_ringpop_event.js
@@ -19,19 +19,30 @@
 // THE SOFTWARE.
 'use strict';
 
+function createDestroyedHandler(ringpop) {
+    return function onDestroyed() {
+        ringpop.gossip.stop();
+        ringpop.syncer.stop();
+    };
+}
+
 function createReadyHandler(ringpop) {
     return function onReady() {
         if (ringpop.config.get('autoGossip')) {
             ringpop.gossip.start();
         }
+
+        ringpop.syncer.start();
     };
 }
 
 function register(ringpop) {
+    ringpop.on('destroyed', createDestroyedHandler(ringpop));
     ringpop.on('ready', createReadyHandler(ringpop));
 }
 
 module.exports = {
+    createDestroyedHandler: createDestroyedHandler,
     createReadyHandler: createReadyHandler,
     register: register
 };

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "pre-commit": "^0.0.9",
     "tape": "^3.0.3",
     "tape-cluster": "2.1.0",
-    "tchannel": "2.10.1",
+    "tchannel": "^2.10.1",
     "tcurl": "^4.11.1",
     "time-mock": "^0.1.2",
     "tryit": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "pre-commit": "^0.0.9",
     "tape": "^3.0.3",
     "tape-cluster": "2.1.0",
-    "tchannel": "^3.5.14",
+    "tchannel": "2.10.1",
     "tcurl": "^4.11.1",
     "time-mock": "^0.1.2",
     "tryit": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "pre-commit": "^0.0.9",
     "tape": "^3.0.3",
     "tape-cluster": "2.1.0",
-    "tchannel": "^2.10.1",
+    "tchannel": "^3.5.14",
     "tcurl": "^4.11.1",
     "time-mock": "^0.1.2",
     "tryit": "^1.0.1",

--- a/request_response.js
+++ b/request_response.js
@@ -1,0 +1,33 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+function SyncRequestHeaders(gzip) {
+    this.gzip = gzip;
+}
+
+function SyncRequestBody(membershipChecksum) {
+    this.membershipChecksum = membershipChecksum;
+}
+
+module.exports = {
+    SyncRequestHeaders: SyncRequestHeaders,
+    SyncRequestBody: SyncRequestBody
+};

--- a/request_response.js
+++ b/request_response.js
@@ -27,7 +27,12 @@ function SyncRequestBody(membershipChecksum) {
     this.membershipChecksum = membershipChecksum;
 }
 
+function SyncResponseHeaders(gzip) {
+    this.gzip = gzip;
+}
+
 module.exports = {
     SyncRequestHeaders: SyncRequestHeaders,
-    SyncRequestBody: SyncRequestBody
+    SyncRequestBody: SyncRequestBody,
+    SyncResponseHeaders: SyncResponseHeaders
 };

--- a/server/index.js
+++ b/server/index.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 'use strict';
 
-
 function RingpopServer(ringpop, tchannel) {
     var self = this;
     self.ringpop = ringpop;
@@ -53,7 +52,6 @@ function RingpopServer(ringpop, tchannel) {
             function onResponse(err, res1, res2) {
                 res.headers.as = 'raw';
                 if (err) {
-                    self.ringpop.logger.warn(err.message, err);
                     res.sendNotOk(null, err.message);
                 } else {
                     if (res2 && !Buffer.isBuffer(res2)) {

--- a/server/protocol/index.js
+++ b/server/protocol/index.js
@@ -31,5 +31,9 @@ module.exports = {
     pingReq: {
         endpoint: '/protocol/ping-req',
         handler: require('./ping-req.js')
+    },
+    sync: {
+        endpoint: '/protocol/sync',
+        handler: require('./sync.js')
     }
 };

--- a/server/protocol/sync.js
+++ b/server/protocol/sync.js
@@ -26,8 +26,8 @@ module.exports = function createSyncHandler(ringpop) {
     return function handleSync(arg2, arg3, hostInfo, callback) {
         ringpop.stat('increment', 'sync.recv');
 
-        var head = safeParse(arg2.toString());
-        var body = safeParse(arg3.toString());
+        var head = safeParse(arg2 && arg2.toString());
+        var body = safeParse(arg3 && arg3.toString());
         if (!body || !body.membershipChecksum) {
             callback(new Error('Bad request: membershipChecksum is required'));
             return;
@@ -54,7 +54,7 @@ module.exports = function createSyncHandler(ringpop) {
                     return;
                 }
 
-                ringpop.stat('gauge', 'sync.size.postzip', postzip.length)
+                ringpop.stat('gauge', 'sync.size.postzip', postzip.length);
                 callback(null, null, postzip);
             });
             return;

--- a/server/protocol/sync.js
+++ b/server/protocol/sync.js
@@ -19,35 +19,7 @@
 // THE SOFTWARE.
 'use strict';
 
-function MembershipIterator(ringpop) {
-    this.ringpop = ringpop;
-    this.currentIndex = -1;
-    this.currentRound = 0;
-}
-
-MembershipIterator.prototype.next = function next() {
-    var membersVisited = {};
-    var maxMembersToVisit = this.ringpop.membership.getMemberCount();
-
-    while (Object.keys(membersVisited).length < maxMembersToVisit) {
-        this.currentIndex++;
-
-        if (this.currentIndex >= this.ringpop.membership.getMemberCount()) {
-            this.currentIndex = 0;
-            this.currentRound++;
-            this.ringpop.membership.shuffle();
-        }
-
-        var member = this.ringpop.membership.getMemberAt(this.currentIndex);
-
-        membersVisited[member.address] = true;
-
-        if (this.ringpop.membership.isPingable(member)) {
-            return member;
-        }
-    }
-
-    return null;
+module.exports = function createSyncHandler(ringpop) {
+    return function handleSync(arg1, arg2, hostInfo, callback) {
+    };
 };
-
-module.exports = MembershipIterator;

--- a/server/protocol/sync.js
+++ b/server/protocol/sync.js
@@ -26,6 +26,7 @@ module.exports = function createSyncHandler(ringpop) {
     return function handleSync(arg2, arg3, hostInfo, callback) {
         ringpop.stat('increment', 'sync.recv');
 
+        var head = safeParse(arg2.toString());
         var body = safeParse(arg3.toString());
         if (!body || !body.membershipChecksum) {
             callback(new Error('Bad request: membershipChecksum is required'));
@@ -38,7 +39,7 @@ module.exports = function createSyncHandler(ringpop) {
                 body.membershipChecksum)
         });
 
-        if (ringpop.config.get('syncGzipEnabled')) {
+        if (head && head.gzip === true) {
             var start = Date.now();
             zlib.gzip(new Buffer(payload), function onZip(err, buffer) {
                 ringpop.stat('timing', 'sync.gzip', Date.now() - start);

--- a/server/protocol/sync.js
+++ b/server/protocol/sync.js
@@ -41,7 +41,9 @@ module.exports = function createSyncHandler(ringpop) {
 
         if (head && head.gzip === true) {
             var start = Date.now();
-            zlib.gzip(new Buffer(payload), function onZip(err, buffer) {
+            var prezip = new Buffer(payload);
+            ringpop.stat('gauge', 'sync.size.prezip', prezip.length);
+            zlib.gzip(prezip, function onZip(err, postzip) {
                 ringpop.stat('timing', 'sync.gzip', Date.now() - start);
                 if (err) {
                     ringpop.logger.warn('ringpop sync gzip error', {
@@ -52,7 +54,8 @@ module.exports = function createSyncHandler(ringpop) {
                     return;
                 }
 
-                callback(null, null, buffer);
+                ringpop.stat('gauge', 'sync.size.postzip', postzip.length)
+                callback(null, null, postzip);
             });
             return;
         }

--- a/test/integration/syncer_test.js
+++ b/test/integration/syncer_test.js
@@ -29,7 +29,10 @@ testRingpopCluster({
     var ringpop2 = cluster[1];
     ringpop2.destroy();
 
-    var syncer1 = cluster[0].syncer;
+    var ringpop1 = cluster[0];
+    ringpop1.dissemination.clearChanges();
+
+    var syncer1 = ringpop1.syncer;
     syncer1.on('event', function onEvent(event) {
         if (event.name === 'SyncFailedEvent') {
             assert.pass('sync failed');

--- a/test/integration/syncer_test.js
+++ b/test/integration/syncer_test.js
@@ -19,4 +19,52 @@
 // THE SOFTWARE.
 'use strict';
 
-// Things here
+var testRingpopCluster = require('../lib/test-ringpop-cluster.js');
+
+testRingpopCluster('sync fails', function t(bootRes, cluster, assert) {
+    assert.plan(1);
+
+    var ringpop2 = cluster[1];
+    ringpop2.channel.close(attemptSync);
+
+    function attemptSync() {
+        var syncer1 = cluster[0].syncer;
+        syncer1.on('event', function onEvent(event) {
+            console.dir(event);
+            if (event.name === 'SyncFailedEvent') {
+                assert.pass('sync failed');
+                assert.end();
+            }
+        });
+        syncer1.sync();
+    }
+});
+
+testRingpopCluster('sync empty', function t(bootRes, cluster, assert) {
+    assert.plan(1);
+
+    var ringpop2 = cluster[1];
+    ringpop2.dissemination.clearChanges();
+
+    var syncer1 = cluster[0].syncer;
+    syncer1.on('event', function onEvent(event) {
+        if (event.name === 'SyncEmptyEvent') {
+            assert.pass('sync empty');
+            assert.end();
+        }
+    });
+    syncer1.sync();
+});
+
+testRingpopCluster('synced', function t(bootRes, cluster, assert) {
+    assert.plan(1);
+
+    var syncer1 = cluster[0].syncer;
+    syncer1.on('event', function onEvent(event) {
+        if (event.name === 'SyncedEvent') {
+            assert.pass('synced');
+            assert.end();
+        }
+    });
+    syncer1.sync();
+});

--- a/test/integration/syncer_test.js
+++ b/test/integration/syncer_test.js
@@ -1,0 +1,22 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+// Things here

--- a/test/lib/tchannel-proxy-cluster.js
+++ b/test/lib/tchannel-proxy-cluster.js
@@ -77,7 +77,7 @@ TChannelProxyCluster.prototype.bootstrap = function bootstrap(cb) {
         self.setupHandler('one', self.cluster.one);
         self.setupHandler('two', self.cluster.two);
         self.setupHandler('three', self.cluster.three);
-        self.client.listen(0, '127.0.0.1', onListen);
+        self.clientRootChannel.listen(0, '127.0.0.1', onListen);
     }
 
     function onListen() {

--- a/test/lib/test-ringpop.js
+++ b/test/lib/test-ringpop.js
@@ -50,7 +50,8 @@ function testRingpop(opts, name, test) {
             membership: ringpop.membership,
             ringpop: ringpop,
             rollup: ringpop.membershipUpdateRollup,
-            suspicion: ringpop.suspicion
+            suspicion: ringpop.suspicion,
+            syncer: ringpop.syncer
         };
 
         if (opts.async) {

--- a/test/unit/membership_test.js
+++ b/test/unit/membership_test.js
@@ -153,7 +153,7 @@ testRingpop('generate checksums string preserves order of members', function t(d
     }
 
     // Make sure they're out of order
-    membership.shuffle();
+    membership.members.reverse();
 
     assert.equal(membership.getMemberCount(), 100, '100 members');
 

--- a/test/unit/server/protocol/sync_test.js
+++ b/test/unit/server/protocol/sync_test.js
@@ -1,0 +1,78 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var createSyncHandler = require('../../../../server/protocol/sync.js');
+var RequestResponse = require('../../../../request_response.js');
+var testRingpop = require('../../../lib/test-ringpop.js');
+var zlib = require('zlib');
+
+testRingpop('no checksum fail', function t(deps, assert) {
+    var handleSync = createSyncHandler(deps.ringpop);
+    handleSync(null, null, null, function onSync(err) {
+        assert.true(err, 'an error occurred');
+    });
+    var body = JSON.stringify(new RequestResponse.SyncRequestBody());
+    handleSync(null, body, null, function onSync(err) {
+        assert.true(err, 'an error occurred');
+    });
+});
+
+testRingpop({
+    async: true
+}, 'gzip response', function t(deps, assert, done) {
+    assert.plan(3);
+
+    var ringpop = deps.ringpop;
+
+    var headers = JSON.stringify(new RequestResponse.SyncRequestHeaders(true));
+    var checksum = ringpop.membership.checksum;
+    var body = JSON.stringify(new RequestResponse.SyncRequestBody(checksum));
+
+    var handleSync = createSyncHandler(ringpop);
+    handleSync(headers, body, null, function onSync(err, res1, res2) {
+        zlib.gunzip(res2, function onGunzip(err, data) {
+            var response = JSON.parse(data);
+            assert.false(err, 'no err occurred');
+            assert.equals(checksum, response.membershipChecksum, 'checksums match');
+            assert.deepEquals([], response.membershipChanges, 'empty changeset');
+            done();
+        });
+    });
+});
+
+testRingpop('non-gzip response', function t(deps, assert) {
+    assert.plan(3);
+
+    var ringpop = deps.ringpop;
+
+    var headers = JSON.stringify(new RequestResponse.SyncRequestHeaders(false));
+    var checksum = ringpop.membership.checksum;
+    var body = JSON.stringify(new RequestResponse.SyncRequestBody(checksum));
+
+    var handleSync = createSyncHandler(ringpop);
+    handleSync(headers, body, null, function onSync(err, res1, res2) {
+        assert.false(err, 'no err occurred');
+
+        var response = JSON.parse(res2);
+        assert.equals(checksum, response.membershipChecksum, 'checksums match');
+        assert.deepEquals([], response.membershipChanges, 'empty changeset');
+    });
+});

--- a/test/unit/syncer_test.js
+++ b/test/unit/syncer_test.js
@@ -22,6 +22,12 @@
 var testRingpop = require('../lib/test-ringpop.js');
 var TimeMock = require('time-mock');
 
+function assertNoPendingChanges(deps, assert) {
+    var dissemination = deps.dissemination;
+    dissemination.clearChanges();
+    assert.true(dissemination.isEmpty(), 'no pending changes');
+}
+
 function expectSyncerEvent(assert, syncer, expectedName) {
     syncer.once('event', function onEvent(event) {
         assert.equals(event.name, expectedName, 'event emitted');
@@ -93,7 +99,9 @@ testRingpop('start syncs', function t(deps, assert) {
 });
 
 testRingpop('no sync target', function t(deps, assert) {
-    assert.plan(1);
+    assert.plan(2);
+
+    assertNoPendingChanges(deps, assert);
 
     var syncer = deps.syncer;
     syncer.on('event', function onEvent(event) {
@@ -107,11 +115,13 @@ testRingpop('no sync target', function t(deps, assert) {
 testRingpop({
     async: true
 }, 'already syncing', function t(deps, assert, done) {
-    assert.plan(1);
+    assert.plan(2);
 
     // Create a second member to allow syncer to have a target
     // to sync to.
     deps.membership.makeAlive('127.0.0.1:3001', Date.now());
+
+    assertNoPendingChanges(deps, assert);
 
     // Artificially delay sync request of first sync() call below.
     var timer;
@@ -134,5 +144,19 @@ testRingpop({
         }
     });
     syncer.sync();
+    syncer.sync();
+});
+
+testRingpop('changes pending', function t(deps, assert) {
+    assert.plan(1);
+
+    // Take note that we're not clearing changes
+    // in the dissemination component.
+    var syncer = deps.syncer;
+    syncer.on('event', function onEvent(event) {
+        if (event.name === 'ChangesPendingEvent') {
+            assert.pass('changes pending');
+        }
+    });
     syncer.sync();
 });

--- a/test/unit/syncer_test.js
+++ b/test/unit/syncer_test.js
@@ -1,0 +1,74 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var testRingpop = require('../lib/test-ringpop.js');
+var TimeMock = require('time-mock');
+
+function expectSyncerEvent(assert, syncer, expectedName) {
+    syncer.once('event', function onEvent(event) {
+        assert.equals(event.name, expectedName, 'event emitted');
+    });
+}
+
+testRingpop('start starts', function t(deps, assert) {
+    assert.plan(1);
+
+    var syncer = deps.syncer;
+    expectSyncerEvent(assert, syncer, 'SyncerStartedEvent');
+    syncer.start();
+});
+
+testRingpop('already started', function t(deps, assert) {
+    assert.plan(1);
+
+    var syncer = deps.syncer;
+    syncer.start();
+    expectSyncerEvent(assert, syncer, 'SyncerAlreadyStartedEvent');
+    syncer.start();
+});
+
+testRingpop('can disable', function t(deps, assert) {
+    assert.plan(1);
+
+    deps.config.set('syncerEnabled', false);
+
+    var syncer = deps.syncer;
+    expectSyncerEvent(assert, syncer, 'SyncerDisabledEvent');
+    syncer.start();
+});
+
+testRingpop('start syncs', function t(deps, assert) {
+    assert.plan(1);
+
+    var syncer = deps.syncer;
+    var timers = new TimeMock(Date.now());
+    syncer.timers = timers;
+    syncer.on('event', function onEvent(event) {
+        if (event.name === 'SyncerSyncingEvent') {
+            assert.pass('syncer syncing');
+        }
+    });
+    syncer.start();
+
+    // Advancing timer triggers sync interval
+    var config = deps.config;
+    timers.advance(config.get('syncInterval') + 1);
+});

--- a/test/unit/syncer_test.js
+++ b/test/unit/syncer_test.js
@@ -36,6 +36,15 @@ testRingpop('start starts', function t(deps, assert) {
     syncer.start();
 });
 
+testRingpop('stop stops', function t(deps, assert) {
+    assert.plan(1);
+
+    var syncer = deps.syncer;
+    syncer.start();
+    expectSyncerEvent(assert, syncer, 'SyncerStoppedEvent');
+    syncer.stop();
+});
+
 testRingpop('already started', function t(deps, assert) {
     assert.plan(1);
 
@@ -43,6 +52,16 @@ testRingpop('already started', function t(deps, assert) {
     syncer.start();
     expectSyncerEvent(assert, syncer, 'SyncerAlreadyStartedEvent');
     syncer.start();
+});
+
+testRingpop('already stopped', function t(deps, assert) {
+    assert.plan(1);
+
+    var syncer = deps.syncer;
+    syncer.start();
+    syncer.stop();
+    expectSyncerEvent(assert, syncer, 'SyncerAlreadyStoppedEvent');
+    syncer.stop();
 });
 
 testRingpop('can disable', function t(deps, assert) {


### PR DESCRIPTION
This feature takes full-syncing out of the ping and ping-req protocol and moves it to a periodic background timer run as often as `syncInterval`. Running the background syncer can also be disabled w/ config param `syncerEnabled`. 

Syncs requests will be made every 10s (by default). The response will contain the full state of the cluster if and only if the checksums of sender and receiver differ and there are no changes left to disseminate.

The reasoning: full syncs are a sort of anti-entropy mechanism and should be done under a more controlled manner than the gossip protocol. Subtle bugs in the gossip protocol can initiate more full syncs than desired and can cause more CPU and network burn.

Full syncing also supports gzip compression which is controlled by config `syncGzipEnabled`.

@uber/ringpop 