### PR TITLE
Module loggers w/ individually configurable levels

### DIFF
--- a/config.js
+++ b/config.js
@@ -21,6 +21,7 @@
 
 var _ = require('underscore');
 var EventEmitter = require('events').EventEmitter;
+var LoggingLevels = require('./lib/logging/levels.js');
 var util = require('util');
 
 // This Config class is meant to be a central store
@@ -65,9 +66,13 @@ Config.prototype._seed = function _seed(seed) {
     // All config names should be camel-cased.
     seedOrDefault('TEST_KEY', 100, numValidator); // never remove, tests and lives depend on it
 
+    // Logger configs
+    seedOrDefault('defaultLogLevel', LoggingLevels.info);
+    seedOrDefault('gossipLogLevel', LoggingLevels.off);
+    seedOrDefault('joinerLogLevel', LoggingLevels.warn);
+
     // Gossip configs
     seedOrDefault('autoGossip', true);
-    seedOrDefault('gossipLogLevel', Config.Defaults.gossipLogLevel);
 
     seedOrDefault('isCrossPlatform', false);
     seedOrDefault('dampScoringEnabled', true);

--- a/config.js
+++ b/config.js
@@ -69,7 +69,7 @@ Config.prototype._seed = function _seed(seed) {
     // Logger configs
     seedOrDefault('defaultLogLevel', LoggingLevels.info);
     seedOrDefault('gossipLogLevel', LoggingLevels.off);
-    seedOrDefault('joinerLogLevel', LoggingLevels.warn);
+    seedOrDefault('joinLogLevel', LoggingLevels.warn);
 
     // Gossip configs
     seedOrDefault('autoGossip', true);

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ var errors = require('./lib/errors.js');
 var getTChannelVersion = require('./lib/util.js').getTChannelVersion;
 var HashRing = require('./lib/ring');
 var initMembership = require('./lib/membership/index.js');
+var LoggerFactory = require('./lib/logging/logger_factory.js');
 var MembershipIterator = require('./lib/membership/iterator.js');
 var MembershipUpdateRollup = require('./lib/membership/rollup.js');
 var nulls = require('./lib/nulls');
@@ -120,6 +121,9 @@ function RingPop(options) {
     // Initialize Config before all other gossip, membership, forwarding,
     // and hash ring dependencies.
     this.config = new Config(this, options);
+    this.loggerFactory = new LoggerFactory({
+        ringpop: this
+    });
 
     // use fingerprint if ringpop needs to function cross different platforms
     if (this.config.get('isCrossPlatform')) {

--- a/lib/gossip/joiner.js
+++ b/lib/gossip/joiner.js
@@ -77,6 +77,7 @@ function Joiner(opts) {
     }
 
     this.ringpop = opts.ringpop;
+    this.joinerLogger = this.ringpop.loggerFactory.getLogger('joiner');
     this.timers = opts.timers || globalTimers;
     this.host = captureHost(this.ringpop.hostPort);
     this.joinTimeout = numOrDefault(opts.joinTimeout, JOIN_TIMEOUT);
@@ -177,7 +178,7 @@ Joiner.prototype.join = function join(callback) {
 
     // No need to go through the join process if you're the only one in the cluster.
     if (isSingleNodeCluster(this.ringpop)) {
-        this.ringpop.logger.info('ringpop received a single node cluster join', {
+        this.joinerLogger.info('ringpop received a single node cluster join', {
             local: this.ringpop.whoami()
         });
 
@@ -234,7 +235,7 @@ Joiner.prototype.join = function join(callback) {
             self.ringpop.stat('gauge', 'join.retries', self.joinRetries);
             self.ringpop.stat('timing', 'join', joinTime);
             self.ringpop.stat('increment', 'join.complete');
-            self.ringpop.logger.debug('ringpop join complete', {
+            self.joinerLogger.info('ringpop join complete', {
                 local: self.ringpop.whoami(),
                 joinSize: self.joinSize,
                 joinTime: joinTime,
@@ -250,7 +251,7 @@ Joiner.prototype.join = function join(callback) {
             var maxJoinDuration = self.ringpop.config.get('maxJoinDuration');
             if (joinDuration > maxJoinDuration) {
                 self.ringpop.stat('gauge', 'join.retries', self.joinRetries);
-                self.ringpop.logger.warn('ringpop max join duration exceeded', {
+                self.joinerLogger.warn('ringpop max join duration exceeded', {
                     local: self.ringpop.whoami(),
                     joinDuration: joinDuration,
                     maxJoinDuration: maxJoinDuration,
@@ -290,7 +291,7 @@ Joiner.prototype.join = function join(callback) {
                     'trouble joining a cluster and could be due to a ' +
                     'misconfiguration of your environment. ringpop will ' +
                     'continue to join up to the max join duration.';
-                self.ringpop.logger.error(errorMsg, {
+                self.joinerLogger.error(errorMsg, {
                     local: self.ringpop.whoami(),
                     retriesSoFar: self.joinRetries,
                     joinDelayMax: delayMax,
@@ -298,7 +299,7 @@ Joiner.prototype.join = function join(callback) {
                 });
             }
 
-            self.ringpop.logger.debug('ringpop joiner not yet complete; will attempt retry after delay', {
+            self.joinerLogger.info('ringpop joiner not yet complete; will attempt retry after delay', {
                 local: self.ringpop.whoami(),
                 retriesSoFar: self.joinRetries,
                 delay: self.joinDelay,
@@ -324,7 +325,7 @@ Joiner.prototype.joinGroup = function joinGroup(totalNodesJoined, callback) {
     var self = this;
     var group = this.selectGroup(totalNodesJoined);
 
-    this.ringpop.logger.debug('ringpop selected join group', {
+    this.joinerLogger.debug('ringpop selected join group', {
         local: self.ringpop.whoami(),
         group: group,
         numNodes: group.length
@@ -352,7 +353,7 @@ Joiner.prototype.joinGroup = function joinGroup(totalNodesJoined, callback) {
         // Finished when either all joins have completed or enough to satisfy
         // the join requirements as defined by `joinSize`.
         if (nodesJoined.length >= numNodesLeft || numCompleted >= group.length) {
-            self.ringpop.logger.debug('ringpop join group complete', {
+            self.joinerLogger.info('ringpop join group complete', {
                 local: self.ringpop.whoami(),
                 groupSize: group.length,
                 joinSize: self.joinSize,

--- a/lib/gossip/joiner.js
+++ b/lib/gossip/joiner.js
@@ -77,7 +77,7 @@ function Joiner(opts) {
     }
 
     this.ringpop = opts.ringpop;
-    this.joinerLogger = this.ringpop.loggerFactory.getLogger('joiner');
+    this.logger = this.ringpop.loggerFactory.getLogger('join');
     this.timers = opts.timers || globalTimers;
     this.host = captureHost(this.ringpop.hostPort);
     this.joinTimeout = numOrDefault(opts.joinTimeout, JOIN_TIMEOUT);
@@ -178,7 +178,7 @@ Joiner.prototype.join = function join(callback) {
 
     // No need to go through the join process if you're the only one in the cluster.
     if (isSingleNodeCluster(this.ringpop)) {
-        this.joinerLogger.info('ringpop received a single node cluster join', {
+        this.logger.info('ringpop received a single node cluster join', {
             local: this.ringpop.whoami()
         });
 
@@ -235,7 +235,7 @@ Joiner.prototype.join = function join(callback) {
             self.ringpop.stat('gauge', 'join.retries', self.joinRetries);
             self.ringpop.stat('timing', 'join', joinTime);
             self.ringpop.stat('increment', 'join.complete');
-            self.joinerLogger.info('ringpop join complete', {
+            self.logger.info('ringpop join complete', {
                 local: self.ringpop.whoami(),
                 joinSize: self.joinSize,
                 joinTime: joinTime,
@@ -251,7 +251,7 @@ Joiner.prototype.join = function join(callback) {
             var maxJoinDuration = self.ringpop.config.get('maxJoinDuration');
             if (joinDuration > maxJoinDuration) {
                 self.ringpop.stat('gauge', 'join.retries', self.joinRetries);
-                self.joinerLogger.warn('ringpop max join duration exceeded', {
+                self.logger.warn('ringpop max join duration exceeded', {
                     local: self.ringpop.whoami(),
                     joinDuration: joinDuration,
                     maxJoinDuration: maxJoinDuration,
@@ -291,7 +291,7 @@ Joiner.prototype.join = function join(callback) {
                     'trouble joining a cluster and could be due to a ' +
                     'misconfiguration of your environment. ringpop will ' +
                     'continue to join up to the max join duration.';
-                self.joinerLogger.error(errorMsg, {
+                self.logger.error(errorMsg, {
                     local: self.ringpop.whoami(),
                     retriesSoFar: self.joinRetries,
                     joinDelayMax: delayMax,
@@ -299,7 +299,7 @@ Joiner.prototype.join = function join(callback) {
                 });
             }
 
-            self.joinerLogger.info('ringpop joiner not yet complete; will attempt retry after delay', {
+            self.logger.info('ringpop joiner not yet complete; will attempt retry after delay', {
                 local: self.ringpop.whoami(),
                 retriesSoFar: self.joinRetries,
                 delay: self.joinDelay,
@@ -325,7 +325,7 @@ Joiner.prototype.joinGroup = function joinGroup(totalNodesJoined, callback) {
     var self = this;
     var group = this.selectGroup(totalNodesJoined);
 
-    this.joinerLogger.debug('ringpop selected join group', {
+    this.logger.debug('ringpop selected join group', {
         local: self.ringpop.whoami(),
         group: group,
         numNodes: group.length
@@ -353,7 +353,7 @@ Joiner.prototype.joinGroup = function joinGroup(totalNodesJoined, callback) {
         // Finished when either all joins have completed or enough to satisfy
         // the join requirements as defined by `joinSize`.
         if (nodesJoined.length >= numNodesLeft || numCompleted >= group.length) {
-            self.joinerLogger.info('ringpop join group complete', {
+            self.logger.info('ringpop join group complete', {
                 local: self.ringpop.whoami(),
                 groupSize: group.length,
                 joinSize: self.joinSize,

--- a/lib/gossip/ping-req-sender.js
+++ b/lib/gossip/ping-req-sender.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 'use strict';
 
-var gossipLogger = require('../loggers.js').gossipLogger;
 var safeParse = require('../util').safeParse;
 var TypedError = require('error/typed');
 
@@ -52,6 +51,7 @@ var PingReqPingError = TypedError({
 
 function PingReqSender(ring, member, target, callback) {
     this.ring = ring;
+    this.gossipLogger = this.ring.loggerFactory.getLogger('gossip');
     this.member = member;
     this.target = target;
     this.callback = callback;
@@ -132,7 +132,7 @@ PingReqSender.prototype.onPingReq = function (err, res1, res2) {
     }
 
     this.ring.membership.update(bodyObj.changes);
-    gossipLogger(this.ring, 'ringpop ping-req response', {
+    this.gossipLogger.info('ringpop ping-req response', {
         local: this.ring.whoami(),
         source: this.member.address,
         target: this.target.address,
@@ -153,6 +153,7 @@ PingReqSender.prototype.onPingReq = function (err, res1, res2) {
 
 module.exports = function sendPingReq(opts, callback) {
     var ringpop = opts.ringpop;
+    var gossipLogger = ringpop.loggerFactory.getLogger('gossip');
     var unreachableMember = opts.unreachableMember;
     var pingReqSize = opts.pingReqSize;
 
@@ -184,7 +185,7 @@ module.exports = function sendPingReq(opts, callback) {
     for (var i = 0; i < pingReqMembers.length; i++) {
         var pingReqMember = pingReqMembers[i];
 
-        gossipLogger(ringpop, 'ringpop ping-req send', {
+        gossipLogger.info('ringpop ping-req send', {
             local: ringpop.whoami(),
             peer: pingReqMember.address,
             target: unreachableMember.address

--- a/lib/gossip/ping-sender.js
+++ b/lib/gossip/ping-sender.js
@@ -19,18 +19,18 @@
 // THE SOFTWARE.
 'use strict';
 
-var gossipLogger = require('../loggers.js').gossipLogger;
 var safeParse = require('../util').safeParse;
 
 function PingSender(ring, member, callback) {
     this.ring = ring;
     this.address = member.address || member;
     this.callback = callback;
+    this.gossipLogger = this.ring.loggerFactory.getLogger('gossip');
 }
 
 PingSender.prototype.onPing = function onPing(err, res1, res2) {
     if (err) {
-        gossipLogger(this.ring, 'ringpop ping failed', {
+        this.gossipLogger.info('ringpop ping failed', {
             local: this.ring.whoami(),
             member: this.address,
             err: err
@@ -43,7 +43,7 @@ PingSender.prototype.onPing = function onPing(err, res1, res2) {
         this.ring.membership.update(bodyObj.changes);
         return this.doCallback(true, bodyObj);
     }
-    this.ring.logger.warn('ping failed member=' + this.address + ' bad response body=' + res2.toString());
+    this.gossipLogger.warn('ping failed member=' + this.address + ' bad response body=' + res2.toString());
     return this.doCallback(false);
 };
 
@@ -51,7 +51,7 @@ PingSender.prototype.onPing = function onPing(err, res1, res2) {
 PingSender.prototype.doCallback = function doCallback(isOk, bodyObj) {
     bodyObj = bodyObj || {};
 
-    gossipLogger(this.ring, 'ringpop ping response', {
+    this.gossipLogger.info('ringpop ping response', {
         local: this.ring.whoami(),
         member: this.address,
         changes: bodyObj.changes,
@@ -85,7 +85,7 @@ PingSender.prototype.send = function send() {
         sourceIncarnationNumber: this.ring.membership.getIncarnationNumber()
     });
 
-    gossipLogger(this.ring, 'ringpop ping send', {
+    this.gossipLogger.info('ringpop ping send', {
         local: this.ring.whoami(),
         member: this.address,
         changes: changes

--- a/lib/logging/levels.js
+++ b/lib/logging/levels.js
@@ -19,15 +19,38 @@
 // THE SOFTWARE.
 'use strict';
 
-function gossipLogger(ringpop, msg, meta) {
-    var logLevel = ringpop.config.get('gossipLogLevel');
-    if (logLevel !== 'info' && logLevel !== 'debug') {
-        logLevel = 'debug';
-    }
+var levels = ['trace', 'debug', 'info', 'warn', 'error', 'off'];
 
-    ringpop.logger[logLevel](msg, meta);
+// e.g. trace => 'trace', debug => 'debug', etc.
+var namedLevels = levels.reduce(function each(res, level) {
+    res[level] = level;
+    return res;
+}, {});
+
+// e.g. trace => 0, debug => 1, etc.
+var levelToInt = {};
+for (var i = 0; i < levels.length; i++) {
+    levelToInt[levels[i]] = i;
+}
+
+function convertIntToStr(intVal) {
+    return levels[intVal];
+}
+
+function convertStrToInt(str) {
+    return levelToInt[str];
 }
 
 module.exports = {
-    gossipLogger: gossipLogger
+    all: namedLevels,
+    trace: namedLevels.trace,
+    debug: namedLevels.debug,
+    info: namedLevels.info,
+    warn: namedLevels.warn,
+    error: namedLevels.error,
+    off: namedLevels.off,
+    convertIntToStr: convertIntToStr,
+    convertStrToInt: convertStrToInt,
+    minLevelInt: levelToInt[namedLevels.trace],
+    maxLevelInt: levelToInt[namedLevels.error]
 };

--- a/lib/logging/logger_factory.js
+++ b/lib/logging/logger_factory.js
@@ -38,7 +38,7 @@ LoggerFactory.prototype.getLogger = function getLogger(name) {
             break;
         case 'joiner':
             this.loggers[name] = new ModuleLogger(this.ringpop,
-                'joinerLogLevel');
+                'joinLogLevel');
             break;
         default:
             this.loggers[name] = new ModuleLogger(this.ringpop,

--- a/lib/logging/logger_factory.js
+++ b/lib/logging/logger_factory.js
@@ -36,7 +36,7 @@ LoggerFactory.prototype.getLogger = function getLogger(name) {
             this.loggers[name] = new ModuleLogger(this.ringpop,
                 'gossipLogLevel');
             break;
-        case 'joiner':
+        case 'join':
             this.loggers[name] = new ModuleLogger(this.ringpop,
                 'joinLogLevel');
             break;

--- a/lib/logging/logger_factory.js
+++ b/lib/logging/logger_factory.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var ModuleLogger = require('./module_logger.js');
+
+function LoggerFactory(opts) {
+    this.ringpop = opts.ringpop;
+    this.loggers = {}; // indexed by name
+}
+
+LoggerFactory.prototype.getLogger = function getLogger(name) {
+    if (this.loggers[name]) {
+        return this.loggers[name];
+    }
+
+    switch (name) {
+        case 'gossip':
+            this.loggers[name] = new ModuleLogger(this.ringpop,
+                'gossipLogLevel');
+            break;
+        case 'joiner':
+            this.loggers[name] = new ModuleLogger(this.ringpop,
+                'joinerLogLevel');
+            break;
+        default:
+            this.loggers[name] = new ModuleLogger(this.ringpop,
+                'defaultLogLevel');
+    }
+
+    return this.loggers[name];
+};
+
+module.exports = LoggerFactory;

--- a/lib/logging/module_logger.js
+++ b/lib/logging/module_logger.js
@@ -1,0 +1,64 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var Levels = require('./levels.js');
+
+function ModuleLogger(ringpop, configName) {
+    this.ringpop = ringpop;
+    this.configName = configName;
+    this.offInt = Levels.convertStrToInt(Levels.off);
+}
+
+ModuleLogger.prototype.debug = function debug(msg, meta) {
+    this._log('debug', msg, meta);
+};
+
+ModuleLogger.prototype.info = function info(msg, meta) {
+    this._log('info', msg, meta);
+};
+
+ModuleLogger.prototype.warn = function warn(msg, meta) {
+    this._log('warn', msg, meta);
+};
+
+ModuleLogger.prototype.error = function error(msg, meta) {
+    this._log('error', msg, meta);
+};
+
+ModuleLogger.prototype.trace = function trace(msg, meta) {
+    this._log('trace', msg, meta);
+};
+
+ModuleLogger.prototype._log = function _log(msgLevel, msg, meta) {
+    var configLevel = this.ringpop.config.get(this.configName);
+    var configInt = Levels.convertStrToInt(configLevel);
+    var msgInt = Levels.convertStrToInt(msgLevel);
+    if (typeof configInt === 'number' &&
+            !isNaN(configInt) &&
+            typeof msgInt === 'number' &&
+            !isNaN(msgInt) &&
+            msgInt >= configInt &&
+            msgInt < this.offInt) {
+        this.ringpop.logger[msgLevel](msg, meta);
+    }
+};
+
+module.exports = ModuleLogger;

--- a/server/protocol/ping-req.js
+++ b/server/protocol/ping-req.js
@@ -19,11 +19,12 @@
 // THE SOFTWARE.
 'use strict';
 
-var gossipLogger = require('../../lib/loggers.js').gossipLogger;
 var safeParse = require('../../lib/util').safeParse;
 var sendPing = require('../../lib/gossip/ping-sender.js');
 
 module.exports = function createPingReqHandler(ringpop) {
+    var gossipLogger = ringpop.loggerFactory.getLogger('gossip');
+
     return function handlePingReq(arg1, arg2, hostInfo, callback) {
         ringpop.stat('increment', 'ping-req.recv');
 
@@ -45,7 +46,7 @@ module.exports = function createPingReqHandler(ringpop) {
         ringpop.totalRate.mark();
         ringpop.membership.update(changes);
 
-        gossipLogger(ringpop, 'ringpop ping-req ping send', {
+        gossipLogger.info('ringpop ping-req ping send', {
             local: ringpop.whoami(),
             source: source,
             target: target
@@ -57,7 +58,7 @@ module.exports = function createPingReqHandler(ringpop) {
             target: target
         }, function (isOk, body) {
             ringpop.stat('timing', 'ping-req-ping', start);
-            gossipLogger(ringpop, 'ringpop ping-req ping response', {
+            gossipLogger.info('ringpop ping-req ping response', {
                 local: ringpop.whoami(),
                 source: source,
                 target: target,

--- a/test/lib/test-ringpop.js
+++ b/test/lib/test-ringpop.js
@@ -47,6 +47,7 @@ function testRingpop(opts, name, test) {
             gossip: ringpop.gossip,
             iterator: ringpop.memberIterator,
             localMember: ringpop.membership.localMember,
+            loggerFactory: ringpop.loggerFactory,
             membership: ringpop.membership,
             ringpop: ringpop,
             rollup: ringpop.membershipUpdateRollup,

--- a/test/unit/module_logger_test.js
+++ b/test/unit/module_logger_test.js
@@ -1,0 +1,110 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var LoggingLevels = require('../../lib/logging/levels.js');
+var testRingpop = require('../lib/test-ringpop.js');
+
+function stubLogger(ringpop, logIt) {
+    var oldLogger = ringpop.logger;
+    var newLogger = {};
+    Object.keys(LoggingLevels.all).forEach(function each(level) {
+        if (level === LoggingLevels.off) return;
+        newLogger[level] = logIt;
+    });
+    ringpop.logger = newLogger;
+    return oldLogger;
+}
+
+testRingpop('caches loggers', function t(deps, assert) {
+    var loggerFactory = deps.loggerFactory;
+    assertSameLogger('gossip');
+    assertSameLogger('joiner');
+    assertSameLogger('whatever');
+
+    function assertSameLogger(loggerName) {
+        var namedLogger = loggerFactory.getLogger(loggerName);
+        assert.equals(loggerFactory.getLogger(loggerName), namedLogger,
+            'same logger');
+    }
+});
+
+testRingpop('logs at correct level', function t(deps, assert) {
+    var ringpop = deps.ringpop;
+    var logItCount = 0;
+    var oldLogger = stubLogger(ringpop, function logIt() {
+        logItCount++;
+    });
+    var config = deps.config;
+    var loggerFactory = deps.loggerFactory;
+    var gossipLogger = loggerFactory.getLogger('gossip');
+
+    // Set gossip log level to each level and count how
+    // many times we've actually written to Ringpop's
+    // logger through the gossip logger.
+    var minLevel = LoggingLevels.minLevelInt;
+    var maxLevel = LoggingLevels.maxLevelInt;
+    for (var i = minLevel; i <= maxLevel; i++) {
+        var levelStr = LoggingLevels.convertIntToStr(i);
+        config.set('gossipLogLevel', levelStr);
+
+        // Attempt to log at each level. The levels at which
+        // we _actually_ write to Ringpop's logger is governed
+        // by the log level that we've set above.
+        Object.keys(LoggingLevels.all).forEach(logAtLevel);
+
+        // Expected number of times logged is all levels in between + the
+        // level that it is currently set at. That's the reason for the + 1.
+        assert.equal(logItCount, (maxLevel - i) + 1,
+            'logged correct # of times');
+
+        // Reset counter for the next run at the next log level
+        logItCount = 0;
+    }
+
+    ringpop.logger = oldLogger;
+
+    function logAtLevel(level) {
+        if (level === LoggingLevels.off) return;
+        gossipLogger[level]();
+    }
+});
+
+testRingpop('turn off gossip logging', function t(deps, assert) {
+    // Turn off gossip logger
+    var config = deps.config;
+    config.set('gossipLogLevel', LoggingLevels.off);
+
+    var ringpop = deps.ringpop;
+    var oldLogger = stubLogger(ringpop, function logIt() {
+        assert.fail('logged a message');
+    });
+
+    // Try to log things to gossip logger.
+    var loggerFactory = deps.loggerFactory;
+    var gossipLogger = loggerFactory.getLogger('gossip');
+    Object.keys(LoggingLevels.all).forEach(function each(level) {
+        if (level === LoggingLevels.off) return;
+        gossipLogger[level]();
+    });
+
+    // The teardown of Ringpop triggers some logging.
+    // Replace with old logger after we're done.
+    ringpop.logger = oldLogger;
+});


### PR DESCRIPTION
Some apps like to log. Some apps don't. Some logs are nice to have for debugging. Some logs aren't. Module loggers allow different Ringpop components/modules to have individually configurable logging levels which are settable in the Ringpop constructor or over the /admin/config/set endpoints.

reviewers: @thanodnl @benfleis 
cc: @uber/ringpop 