### PR TITLE
Backpressure at routing egress/ingress

### DIFF
--- a/config.js
+++ b/config.js
@@ -94,6 +94,12 @@ Config.prototype._seed = function _seed(seed) {
     seedOrDefault('joinTroubleErrorEnabled', true);
     seedOrDefault('maxJoinDuration', 20 * 60 * 1000, numValidator); // 20 mins in ms
 
+    // Forwarding config
+    seedOrDefault('backpressureEnabled', false);
+    seedOrDefault('lagSamplerInterval', 1000, numValidator);
+    seedOrDefault('maxEventLoopLag', 1500, numValidator);
+    seedOrDefault('maxInflightRequests', 5000, numValidator);
+
     seedOrDefault('memberBlacklist', [], function validator(vals) {
         return _.all(vals, function all(val) {
             return val instanceof RegExp;

--- a/index.js
+++ b/index.js
@@ -51,11 +51,13 @@ var getTChannelVersion = require('./lib/util.js').getTChannelVersion;
 var HashRing = require('./lib/ring');
 var initMembership = require('./lib/membership/index.js');
 var LoggerFactory = require('./lib/logging/logger_factory.js');
+var LagSampler = require('./lib/lag_sampler.js');
 var MembershipIterator = require('./lib/membership/iterator.js');
 var MembershipUpdateRollup = require('./lib/membership/rollup.js');
 var nulls = require('./lib/nulls');
 var rawHead = require('./lib/request-proxy/util.js').rawHead;
 var RequestProxy = require('./lib/request-proxy/index.js');
+var registerConfigListeners = require('./lib/on_config_event.js').register;
 var registerMembershipListeners = require('./lib/on_membership_event.js').register;
 var registerRingListeners = require('./lib/on_ring_event.js').register;
 var registerRingpopListeners = require('./lib/on_ringpop_event.js').register;
@@ -132,6 +134,10 @@ function RingPop(options) {
         this.hashFunc = farmhash.hash32;
     }
 
+    this.lagSampler = new LagSampler({
+        ringpop: this
+    });
+
     this.requestProxy = new RequestProxy({
         ringpop: this,
         maxRetries: options.requestProxyMaxRetries,
@@ -162,6 +168,7 @@ function RingPop(options) {
 
     this.tracers = new TracerStore(this);
 
+    registerConfigListeners(this);
     registerMembershipListeners(this);
     registerRingListeners(this);
     registerRingpopListeners(this);

--- a/lib/lag_sampler.js
+++ b/lib/lag_sampler.js
@@ -1,0 +1,81 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var globalTimers = require('timers');
+
+function LagSampler(opts) {
+    this.ringpop = opts.ringpop;
+    this.timers = opts.timers || globalTimers;
+    this.lagTimer = null;
+    this.currentLag = 0;
+
+    // toobusy auto-starts sampling. lazily-require until started.
+    this.toobusy = null;
+}
+
+LagSampler.prototype.start = function start() {
+    var self = this;
+
+    if (this.lagTimer) {
+        this.ringpop.logger.debug('ringpop lag sampler lag timer already started', {
+            local: this.ringpop.whoami()
+        });
+        return;
+    }
+
+    if (!this.toobusy) {
+        this.toobusy = require('toobusy');
+    }
+
+    schedule();
+    this.ringpop.logger.debug('ringpop lag sampler started', {
+        local: this.ringpop.whoami()
+    });
+
+    function schedule() {
+        self.lagTimer = self.timers.setTimeout(function onTimeout() {
+            self.currentLag = self.toobusy.lag();
+            schedule();
+        }, self.ringpop.config.get('lagSamplerInterval'));
+    }
+};
+
+LagSampler.prototype.stop = function stop() {
+    if (!this.lagTimer) {
+        this.ringpop.logger.debug('ringpop lag sampler lag timer already stopped', {
+            local: this.ringpop.whoami()
+        });
+        return;
+    }
+
+    this.timers.clearTimeout(this.lagTimer);
+    this.lagTimer = null;
+    this.ringpop.logger.debug('ringpop lag sampler stopped', {
+        local: this.ringpop.whoami()
+    });
+
+    if (this.toobusy) {
+        this.toobusy.shutdown();
+        this.toobusy = null;
+    }
+};
+
+module.exports = LagSampler;

--- a/lib/on_config_event.js
+++ b/lib/on_config_event.js
@@ -19,31 +19,21 @@
 // THE SOFTWARE.
 'use strict';
 
-function createReadyHandler(ringpop) {
-    return function onReady() {
-        if (ringpop.config.get('autoGossip')) {
-            ringpop.gossip.start();
-        }
-
-        if (ringpop.config.get('backpressureEnabled')) {
+function createBackpressureEnabledHandler(ringpop) {
+    return function onBackpressureEnabled(newValue) {
+        if (newValue === true) {
             ringpop.lagSampler.start();
+        } else {
+            ringpop.lagSampler.stop();
         }
-    };
-}
-
-function createDestroyedHandler(ringpop) {
-    return function onDestroyed() {
-        ringpop.lagSampler.stop();
     };
 }
 
 function register(ringpop) {
-    ringpop.on('destroyed', createDestroyedHandler(ringpop));
-    ringpop.on('ready', createReadyHandler(ringpop));
+    ringpop.config.on('set.backpressureEnabled',
+        createBackpressureEnabledHandler(ringpop));
 }
 
 module.exports = {
-    createDestroyedHandler: createDestroyedHandler,
-    createReadyHandler: createReadyHandler,
     register: register
 };

--- a/lib/request-proxy/index.js
+++ b/lib/request-proxy/index.js
@@ -19,17 +19,21 @@
 // THE SOFTWARE.
 'use strict';
 
-// 3rd party dependencies
 var body = require('body');
 var hammock = require('uber-hammock');
-var PassThrough = require('stream').PassThrough;
-var TypedError = require('error/typed');
-
-// 1st party dependencies
 var numOrDefault = require('../util.js').numOrDefault;
+var PassThrough = require('stream').PassThrough;
 var safeParse = require('../util.js').safeParse;
 var sendRequest = require('./send.js');
+var TypedError = require('error/typed');
 
+var HTTP_TOO_MANY_REQUESTS = 429;
+// Very very slight optimization, but there's no reason
+// to stringify the headers for every ingress request when
+// backpressure is applied. Once is enough.
+var INGRESS_BACKPRESSURE_HEAD = JSON.stringify({
+    statusCode: HTTP_TOO_MANY_REQUESTS
+});
 var InvalidCheckSumError = TypedError({
     type: 'ringpop.request-proxy.invalid-checksum',
     message: 'Expected the remote checksum to match local ' +
@@ -38,6 +42,14 @@ var InvalidCheckSumError = TypedError({
             'actual checksum ({actual}).\n',
     actual: null,
     expected: null
+});
+var TooManyRequestsError = TypedError({
+    type: 'ringpop.request-proxy.too-many-requests',
+    message: 'The number of inflight requests have exceeded a maximum of {max} at {egressOrIngress}',
+    statusCode: HTTP_TOO_MANY_REQUESTS,
+    max: null,
+    egressOrIngress: null,
+    metric: null
 });
 
 module.exports = RequestProxy;
@@ -49,22 +61,23 @@ function RequestProxy(opts) {
     this.enforceConsistency = opts.enforceConsistency === undefined ? true : opts.enforceConsistency;
 
     this.sends = [];
+
+    // Tracks number of inflight requests at both ingress (handleRequest())
+    // and egress (proxyReq()).
+    this.numInflightRequests = 0;
 }
 
-var proto = RequestProxy.prototype;
-
-proto.removeSend = function removeSend(send) {
+RequestProxy.prototype.removeSend = function removeSend(send) {
     var indexOf = this.sends.indexOf(send);
 
     if (indexOf !== -1) {
         this.sends.splice(indexOf, 1);
-        this.ringpop.stat('gauge', 'requestProxy.inflight', this.sends.length);
     }
 
     send.destroy();
 };
 
-proto.destroy = function destroy() {
+RequestProxy.prototype.destroy = function destroy() {
     this.sends.forEach(function eachSend(send) {
         send.destroy();
     });
@@ -72,7 +85,7 @@ proto.destroy = function destroy() {
     this.sends = [];
 };
 
-proto.proxyReq = function proxyReq(opts) {
+RequestProxy.prototype.proxyReq = function proxyReq(opts) {
     var self = this;
     var keys = opts.keys;
     var dest = opts.dest;
@@ -86,6 +99,14 @@ proto.proxyReq = function proxyReq(opts) {
     var timeout = opts.timeout ?
         opts.timeout : this.ringpop.proxyReqTimeout;
 
+    var tooManyErr = this._shouldRespondWithTooManyReqs('egress');
+    if (tooManyErr) {
+        sendError(res, tooManyErr);
+        return;
+    }
+
+    this._incrementInflightRequests();
+
     body(req, res, {
         cache: true,
         limit: opts.bodyLimit
@@ -97,7 +118,9 @@ proto.proxyReq = function proxyReq(opts) {
                 error: err,
                 url: req.url
             });
-            return sendError(res, err);
+            self._decrementInflightRequests();
+            sendError(res, err);
+            return;
         }
 
         self.ringpop.logger.trace('requestProxy sending tchannel proxy req', {
@@ -132,10 +155,10 @@ proto.proxyReq = function proxyReq(opts) {
         });
 
         self.sends.push(send);
-        self.ringpop.stat('gauge', 'requestProxy.inflight', self.sends.length);
 
         function onProxy(err, res1, res2) {
             self.removeSend(send);
+            self._decrementInflightRequests();
 
             if (err) {
                 self.ringpop.stat('increment', 'requestProxy.send.error');
@@ -167,7 +190,8 @@ proto.proxyReq = function proxyReq(opts) {
     }
 };
 
-proto.handleRequest = function handleRequest(head, body, cb) {
+RequestProxy.prototype.handleRequest = function handleRequest(head, body, cb) {
+    var self = this;
     var ringpop = this.ringpop;
     var url = head.url;
     var headers = head.headers;
@@ -197,18 +221,22 @@ proto.handleRequest = function handleRequest(head, body, cb) {
     httpRequest.headers = headers;
     httpRequest.method = method;
     httpRequest.httpVersion = httpVersion;
-
     httpRequest.end(body);
 
+    var tooManyErr = this._shouldRespondWithTooManyReqs('ingress');
+    if (tooManyErr) {
+        cb(null, INGRESS_BACKPRESSURE_HEAD, JSON.stringify(tooManyErr));
+        return;
+    }
+
+    this._incrementInflightRequests();
+
     var httpResponse = hammock.Response(onResponse);
-
-    ringpop.logger.trace('handleRequest emitting request', {
-        url: url
-    });
-
     ringpop.emit('request', httpRequest, httpResponse, head);
 
     function onResponse(err, resp) {
+        self._decrementInflightRequests();
+
         if (err) {
             ringpop.logger.warn('handleRequest got response error', {
                 error: err,
@@ -228,6 +256,74 @@ proto.handleRequest = function handleRequest(head, body, cb) {
 
         cb(null, responseHead, resp.body);
     }
+};
+
+RequestProxy.prototype._decrementInflightRequests = function _decrementInflightRequests() {
+    this.numInflightRequests--;
+    if (this.numInflightRequests < 0) {
+        // We miscounted number of inflight requests. Correct by setting to min.
+        this.ringpop.stat('increment', 'requestProxy.miscount.decrement');
+        this.numInflightRequests = 0;
+    }
+
+    this.ringpop.stat('gauge', 'requestProxy.inflight',
+        this.numInflightRequests);
+};
+
+RequestProxy.prototype._incrementInflightRequests = function _incrementInflightRequests() {
+    this.numInflightRequests++;
+    var max = this.ringpop.config.get('maxInflightRequests');
+    if (this.numInflightRequests > max) {
+        // We miscounted number of inflight requests. Correct by setting to max.
+        this.ringpop.stat('increment', 'requestProxy.miscount.increment');
+        this.numInflightRequests = max;
+    }
+
+    this.ringpop.stat('gauge', 'requestProxy.inflight',
+        this.numInflightRequests);
+};
+
+RequestProxy.prototype._hasExceededMaxInflightRequests =
+        function _hasExceededMaxInflightRequests() {
+    var config = this.ringpop.config;
+    var backpressureEnabled = config.get('backpressureEnabled');
+    var max = config.get('maxInflightRequests');
+
+    // We add one to the current number of inflight requests to account for
+    // the current request for which we are evaluating against the maximum.
+    return backpressureEnabled && (this.numInflightRequests + 1) > max;
+};
+
+RequestProxy.prototype._hasExceededMaxEventLoopLag =
+        function _hasExceededMaxEventLoopLag() {
+    var config = this.ringpop.config;
+    var backpressureEnabled = config.get('backpressureEnabled');
+    var max = config.get('maxEventLoopLag');
+    return backpressureEnabled && this.ringpop.lagSampler.currentLag > max;
+};
+
+RequestProxy.prototype._shouldRespondWithTooManyReqs =
+        function _shouldRespondWithTooManyReqs(egressOrIngress) {
+    if (this._hasExceededMaxInflightRequests()) {
+        this.ringpop.stat('increment', 'requestProxy.refused.inflight');
+        return new TooManyRequestsError({
+            egressOrIngress: egressOrIngress,
+            max: this.ringpop.config.get('maxInflightRequests'),
+            metric: 'inflight'
+        });
+    }
+
+    if (this._hasExceededMaxEventLoopLag()) {
+        this.ringpop.stat('increment', 'requestProxy.refused.eventloop');
+        return new TooManyRequestsError({
+            egressOrIngress: egressOrIngress,
+            max: this.ringpop.config.get('maxEventLoopLag'),
+            metric: 'eventloop'
+        });
+    }
+
+    // No back pressure.
+    return null;
 };
 
 function sendError(res, err) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "farmhash": "^0.2.0",
     "metrics": "^0.1.8",
     "node-uuid": "^1.4.3",
+    "toobusy": "^0.2.4",
     "uber-hammock": "^1.0.0",
     "underscore": "^1.5.2"
   },

--- a/test/lib/test-ringpop.js
+++ b/test/lib/test-ringpop.js
@@ -49,6 +49,7 @@ function testRingpop(opts, name, test) {
             localMember: ringpop.membership.localMember,
             loggerFactory: ringpop.loggerFactory,
             membership: ringpop.membership,
+            requestProxy: ringpop.requestProxy,
             ringpop: ringpop,
             rollup: ringpop.membershipUpdateRollup,
             suspicion: ringpop.suspicion


### PR DESCRIPTION
This pull request applies backpressure at Ringpop's forwarding egress and ingress by using the number of inflight requests and the current event loop lag as the metric to use when evaluating how "overwhelmed" an application is.

reviewers: @thanodnl @danielheller
cc: @uber/ringpop @weikai77 @markyen @fuj 