### PR TITLE
Use the correct isPinging flags

### DIFF
--- a/lib/gossip/index.js
+++ b/lib/gossip/index.js
@@ -28,6 +28,7 @@ function Gossip(options) {
     this.minProtocolPeriod = options.minProtocolPeriod ||
         Gossip.Defaults.minProtocolPeriod;
 
+    this.isPinging = false;
     this.isStopped = true;
     this.lastProtocolPeriod = Date.now();
     this.lastProtocolRate = 0;
@@ -35,7 +36,6 @@ function Gossip(options) {
     this.protocolPeriodTimer = null;
     this.protocolRateTimer = null;
     this.protocolTiming = new metrics.Histogram();
-
     this.protocolTiming.update(this.minProtocolPeriod);
 }
 

--- a/lib/gossip/index.js
+++ b/lib/gossip/index.js
@@ -135,7 +135,7 @@ Gossip.prototype.stop = function stop() {
 Gossip.prototype.tick = function tick(callback) {
     callback = callback || function() {};
 
-    if (this.ringpop.isPinging) {
+    if (this.isPinging) {
         this.ringpop.logger.warn('aborting ping because one is in progress');
         return callback();
     }
@@ -161,7 +161,7 @@ Gossip.prototype.tick = function tick(callback) {
     }, function(isOk, body) {
         self.ringpop.stat('timing', 'ping', start);
         if (isOk) {
-            self.ringpop.isPinging = false;
+            self.isPinging = false;
             self.ringpop.membership.update(body.changes);
             return callback();
         }
@@ -184,7 +184,7 @@ Gossip.prototype.tick = function tick(callback) {
             pingReqSize: self.ringpop.pingReqSize
         }, function onPingReq() {
             self.ringpop.stat('timing', 'ping-req', pingReqStartTime);
-            self.ringpop.isPinging = false;
+            self.isPinging = false;
 
             callback.apply(null, Array.prototype.splice.call(arguments, 0));
         });


### PR DESCRIPTION
`this.ringpop.isPinging` was never set to true. 

`this.ringpop.gossip.isPinging` was never set to false.

At some point when I rearranged code, I'm sure I unintentionally broke this. It likely isn't showing up as any sort of production bug because it was originally put in place to make sure that tick-cluster's manual tick never ticked while a gossip tick was outstanding.

@uber/ringpop 