### PR TITLE
Let A Node Disseminate Itself After Join

### DIFF
--- a/config.js
+++ b/config.js
@@ -71,6 +71,7 @@ Config.prototype._seed = function _seed(seed) {
     seedOrDefault('dampingLogLevel', LoggingLevels.warn);
     seedOrDefault('gossipLogLevel', LoggingLevels.off);
     seedOrDefault('joinLogLevel', LoggingLevels.warn);
+    seedOrDefault('disseminationLogLevel', LoggingLevels.off);
 
     // Gossip configs
     seedOrDefault('autoGossip', true);

--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -21,6 +21,7 @@
 
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
+var GossipEvents = require('./events');
 
 var LOG_10 = Math.log(10);
 
@@ -31,6 +32,7 @@ function Dissemination(ringpop) {
     this.changes = {};
     this.maxPiggybackCount = Dissemination.Defaults.maxPiggybackCount;
     this.piggybackFactor = Dissemination.Defaults.piggybackFactor;
+    this.logger = this.ringpop.loggerFactory.getLogger('dissemination');
 }
 
 util.inherits(Dissemination, EventEmitter);
@@ -156,6 +158,9 @@ Dissemination.prototype._issueAs = function _issueAs(filterChange, mapChanges) {
 
         if (change.piggybackCount > this.maxPiggybackCount) {
             delete this.changes[address];
+            if (Object.keys(this.changes).length === 0) {
+                this.emit('changesExhausted', new GossipEvents.ChangesExhaustedEvent());
+            }
             continue;
         }
 
@@ -171,6 +176,14 @@ Dissemination.prototype._issueAs = function _issueAs(filterChange, mapChanges) {
     }
 
     this.ringpop.stat('gauge', 'changes.disseminate', changesToDisseminate.length);
+
+
+    if (changesToDisseminate.length > 0) {
+        this.logger.info('ringpop dissemination send', {
+            local: this.ringpop.whoami(),
+            changesCount: changesToDisseminate.length
+        });
+    }
 
     return mapChanges(changesToDisseminate);
 };

--- a/lib/gossip/events.js
+++ b/lib/gossip/events.js
@@ -19,41 +19,10 @@
 // THE SOFTWARE.
 'use strict';
 
-var ModuleLogger = require('./module_logger.js');
-
-function LoggerFactory(opts) {
-    this.ringpop = opts.ringpop;
-    this.loggers = {}; // indexed by name
+function ChangesExhaustedEvent() {
+    this.name = this.constructor.name;
 }
 
-LoggerFactory.prototype.getLogger = function getLogger(name) {
-    if (this.loggers[name]) {
-        return this.loggers[name];
-    }
-
-    switch (name) {
-        case 'damping':
-            this.loggers[name] = new ModuleLogger(this.ringpop,
-                'dampingLogLevel');
-            break;
-        case 'gossip':
-            this.loggers[name] = new ModuleLogger(this.ringpop,
-                'gossipLogLevel');
-            break;
-        case 'join':
-            this.loggers[name] = new ModuleLogger(this.ringpop,
-                'joinLogLevel');
-            break;
-        case 'dissemination':
-            this.loggers[name] = new ModuleLogger(this.ringpop, 
-                'disseminationLogLevel');
-            break;
-        default:
-            this.loggers[name] = new ModuleLogger(this.ringpop,
-                'defaultLogLevel');
-    }
-
-    return this.loggers[name];
+module.exports = {
+    ChangesExhaustedEvent: ChangesExhaustedEvent
 };
-
-module.exports = LoggerFactory;

--- a/server/protocol/join.js
+++ b/server/protocol/join.js
@@ -123,8 +123,6 @@ module.exports = function createJoinHandler(ringpop) {
         ringpop.serverRate.mark();
         ringpop.totalRate.mark();
 
-        ringpop.membership.makeAlive(source, incarnationNumber);
-
         callback(null, null, JSON.stringify({
             app: ringpop.app,
             coordinator: ringpop.whoami(),

--- a/test/integration/admin_test.js
+++ b/test/integration/admin_test.js
@@ -24,7 +24,8 @@ var RingpopClient = require('../../client.js');
 var testRingpopCluster = require('../lib/test-ringpop-cluster.js');
 
 testRingpopCluster({
-    size: 1
+    size: 1,
+    waitForConvergence: false
 }, 'config endpoints', function t(bootRes, cluster, assert) {
     assert.plan(4);
 
@@ -55,7 +56,8 @@ testRingpopCluster({
 // Test to make sure these endpoints are available. Find tests that test
 // behavior of handlers under unit tests.
 testRingpopCluster({
-    size: 1
+    size: 1,
+    waitForConvergence: false
 }, 'gossip endpoints', function t(bootRes, cluster, assert) {
     assert.plan(4);
 

--- a/test/integration/join-test.js
+++ b/test/integration/join-test.js
@@ -37,7 +37,8 @@ test('bootstrap with self is ok', function t(assert) {
 });
 
 testRingpopCluster({
-    size: 1
+    size: 1,
+    waitForConvergence: false
 }, 'one node can join', function t(bootRes, cluster, assert) {
     assert.ifErr(bootRes[cluster[0].hostPort].err, 'no error occurred');
     assert.end();
@@ -76,8 +77,7 @@ testRingpopCluster({
     var badNode = cluster[2].hostPort;
 
     cluster.forEach(function eachNode(node) {
-        assert.ok(node.isReady, 'node is bootstrapped');
-
+        assert.ok(node.isReady, 'node is ready');
         var nodesJoined = bootRes[node.hostPort].nodesJoined;
         assert.ok(nodesJoined.length >= 1, 'joined at least one other node');
         assert.ok(nodesJoined.indexOf(badNode) === -1, 'no one can join bad node');
@@ -92,12 +92,13 @@ testRingpopCluster({
     tap: function tap(cluster) {
         cluster[1].denyJoins();
         cluster[2].denyJoins();
-    }
+    },
+    waitForConvergence: false
 }, 'three nodes, two of them bad, join size equals two', function t(bootRes, cluster, assert) {
     assert.equal(cluster.length, 3, 'cluster of 3');
 
     cluster.forEach(function eachNode(node) {
-        assert.notok(node.isReady, 'node is not bootstrapped');
+        assert.notok(node.isReady, 'node is not ready');
         assert.equal(bootRes[node.hostPort].err.type,
             'ringpop.join-duration-exceeded',
             'join duration exceeded error');
@@ -133,7 +134,8 @@ testRingpopCluster({
                 }));
             }, 100);
         });
-    }
+    },
+    waitForConvergence: false
 }, 'slow joiner', function t(bootRes, cluster, assert) {
     assert.equal(cluster.length, 2, 'cluster of 2');
 
@@ -157,7 +159,8 @@ testRingpopCluster({
         cluster[0].config.set('joinDelayMin', 0);
         cluster[0].config.set('maxJoinDuration', 1);
         cluster[1].config.set('memberBlacklist', [/127.0.0.1:10000/]);
-    }
+    },
+    checkChecksums: false
 }, 'join blacklist', function t(bootRes, cluster, assert) {
     assert.notok(cluster[0].isReady, 'node one is not ready');
     assert.ok(cluster[1].isReady, 'node two is ready');

--- a/test/integration/proxy_test.js
+++ b/test/integration/proxy_test.js
@@ -1103,7 +1103,7 @@ test('proxies big json', function t(assert) {
 
     var opts = {
         bodyLimit: bodyLimit,
-        requestProxyMaxRetries: 0,
+        requestProxyMaxRetries: 0
     };
 
     var cluster = allocCluster(opts, function onReady() {


### PR DESCRIPTION
If a node get's a join request, it no longer adds the joining node to the membership.
A node is therefor expected to disseminate it's own existance to the membership.

T212923