### PR TITLE
Disable interactive mode if stdin is not available

### DIFF
--- a/scripts/tick-cluster.js
+++ b/scripts/tick-cluster.js
@@ -479,7 +479,7 @@ function startCluster() {
 }
 
 function main() {
-    logMsg('init', color.cyan('tick-cluster started ') + color.red('d: debug flags, g: gossip, j: join, k: kill, K: revive all, l: sleep, p: protocol stats, q: quit, s: cluster stats, t: tick'));
+    logMsg('init', color.cyan('tick-cluster started '));
 
     findLocalIP();
     hosts = generateHosts(localIP, 3000, procsToStart, 'hosts.json');
@@ -491,11 +491,16 @@ function main() {
         trace: false
     });
 
-    var stdin = process.stdin;
-    stdin.setRawMode(true);
-    stdin.resume();
-    stdin.setEncoding('utf8');
-    stdin.on('data', onData);
+    try {
+        var stdin = process.stdin;
+        stdin.setRawMode(true);
+        stdin.resume();
+        stdin.setEncoding('utf8');
+        stdin.on('data', onData);
+        logMsg('init', color.red('d: debug flags, g: gossip, j: join, k: kill, K: revive all, l: sleep, p: protocol stats, q: quit, s: cluster stats, t: tick'));
+    } catch (e) {
+        logMsg('init', 'Unable to open stdin; interactive commands disabled');
+    }
 }
 
 function displayMenu(logFn) {


### PR DESCRIPTION
Previously an exception would be thrown if stdin was not available at startup, e.g.:

```
dan-mbp-uber:tests dan$ ~/uber/projects/ringpop-node/scripts/tick-cluster.js ./../node_modules/ringpop/main.js <&-
[init] 09:56:24.110 tick-cluster started d: debug flags, g: gossip, j: join, k: kill, K: revive all, l: sleep, p: protocol stats, q: quit, s: cluster stats, t: tick
[cluster] 09:56:24.112 using 172.18.25.93 to listen
[init] 09:56:24.131 started 5 procs: 58433, 58434, 58435, 58436, 58437

/Users/dan/uber/projects/ringpop-node/scripts/tick-cluster.js:495
    stdin.setRawMode(true);
          ^
TypeError: Object #<Socket> has no method 'setRawMode'
    at main (/Users/dan/uber/projects/ringpop-node/scripts/tick-cluster.js:495:11)
    at Object.<anonymous> (/Users/dan/uber/projects/ringpop-node/scripts/tick-cluster.js:594:1)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
    at startup (node.js:119:16)
    at node.js:929:3
```

This change allows tick-cluster to continue albeit with interactive commands disabled. The case where stdin is not available to open occurs when tick-cluster has been spawned in the background from a shell script.

The ringpop-admin test runner needs to spawn tick-cluster in the background so it can run tests for ringpop-admin using a real ringpop cluster.

After this change:

```
dan-mbp-uber:tests dan$ ~/uber/projects/ringpop-node/scripts/tick-cluster.js ./../node_modules/ringpop/main.js <&-
[init] 10:05:19.323 tick-cluster started 
[cluster] 10:05:19.325 using 172.18.25.93 to listen
[init] 10:05:19.351 started 5 procs: 58782, 58783, 58784, 58785, 58786
[init] 10:05:19.354 Unable to open stdin; interactive commands disabled
[...]
```