### PR TITLE
Add stats to Monitoring section of Running Ringpop docs

### DIFF
--- a/docs/running_ringpop.md
+++ b/docs/running_ringpop.md
@@ -43,7 +43,89 @@ Content coming soon...
 Content coming soon...
 
 ## Monitoring
-Content coming soon...
+Ringpop emits stats by making use of the dependency it has on a Statsd-
+compatible client. It emits all stats with a prefix that includes its
+identity in the stat path, e.g. `ringpop.10_30_8_26_20600.*`; the dots
+and colon are replaced by underscores. The table below lists all stats
+that Ringpop emits:
+
+|Node.js Path|Description|Type
+|----|----|----
+|changes.apply|Number of changes applied per membership update|gauge
+|changes.disseminate|Number of changes disseminated per request/response|gauge
+|checksum|Value of membership checksum|gauge
+|compute-checksum|Time required to compute membership checksum|timer
+|damp-req.recv|Damp-req request received|count
+|damp-req.send|Damp-req request sent|count
+|damper.damp-req.damped|Damp-req resulted in members being damped|count
+|damper.damp-req.error|Damp-req resulted in an error|count
+|damper.damp-req.inconclusive|Damp-req results were inconclusive|count
+|damper.flapper.added|Flap damping detected a flappy node|count
+|damper.flapper.removed|Flap damping removed a flappy node|count
+|damper.flappers|Number of current flappers|gauge
+|filtered-change|A change to be disseminated was deduped|count
+|full-sync|Number of full syncs transmitted|count
+|join|Time required to complete join process successfully|timer
+|join.complete|Join process completed successfully|count
+|join.failed.destroyed|Join process failed because Ringpop had been destroyed|count
+|join.failed.err|Join process failed because of an error|count
+|join.recv|Join request received|count
+|join.retries|Number of retries required by join process|gauge
+|join.succeeded|Join process succeeded|count
+|lookup|Time required to perform a ring lookup|timer
+|make-alive|A member was declared alive|count
+|make-damped|A member was declared damped|count
+|make-faulty|A member was declared faulty|count
+|make-leave|A member was declared leave|count
+|make-suspect|A member was declared suspect|count
+|max-piggyback|Value of the max piggyback factor|gauge
+|membership-set.alive|A member was initialized in the alive state|count
+|membership-set.faulty|A member was initialized in the faulty state|count
+|membership-set.leave|A member was initialized in the leave state|count
+|membership-set.suspect|A member was initialized in the suspect state|count
+|membership-set.unknown|A member was initialized in an unknown state|count
+|membership-update.alive|A member was updated to be alive|count
+|membership-update.faulty|A member was updated to be faulty|count
+|membership-update.leave|A member was updated in the leave state|count
+|membership-update.suspect|A member was updated to be suspect|count
+|membership-update.unknown|A member was updated in the unknown state|count
+|membership.checksum-computed|Membership checksum was computed|count
+|not-ready.ping|Ping received before Ringpop was ready|count
+|not-ready.ping-req|Ping-req received before Ringpop was ready|count
+|num-members|Number of members in the membership|gauge
+|ping|Ping response time|timer
+|ping-req|Ping-req response time|timer
+|ping-req-ping|Indirect ping sent|timer
+|ping-req.other-members|Number of members selected for ping-req fanout|timer
+|ping-req.recv|Ping-req request received|count
+|ping-req.send|Ping-req request sent|count
+|ping.recv|Ping request received|count
+|ping.send|Ping request sent|count
+|protocol.damp-req|Damp-req response time|timer
+|protocol.delay|How often gossip protocol is expected to tick|timer
+|protocol.frequency|How often gossip protocol actually ticks|timer
+|refuted-update|A member refuted an update for itself|count
+|requestProxy.checksumsDiffer|Checksums differed when a forwarded request was received|count
+|requestProxy.egress|Request was forwarded|count
+|requestProxy.inflight|Number of inflight forwarded requests|gauge
+|requestProxy.ingress|Forward request was received|count
+|requestProxy.miscount.decrement|Number of inflight requests were miscounted after decrement|count
+|requestProxy.miscount.increment|Number of inflight requests were miscounted after increment|count
+|requestProxy.refused.eventloop|Request was refused due to event loop lag|count
+|requestProxy.refused.inflight|Request was refused due to number of inflight requests|count
+|requestProxy.retry.aborted|Forwarded request retry was aborted|count
+|requestProxy.retry.attempted|Forwarded request retry was attempted|count
+|requestProxy.retry.failed|Forwarded request failed after retries|count
+|requestProxy.retry.reroute.local|Forwarded request retry was rerouted to local node|count
+|requestProxy.retry.reroute.remote|Forwarded request retry was rerouted to remote node|count
+|requestProxy.retry.succeeded|Forwarded request succeeded after retries|count
+|requestProxy.send.error|Forwarded request failed|count
+|requestProxy.send.success|Forwarded request was successful|count
+|ring.change|Hash ring keyspace changed|gauge
+|ring.checksum-computed|Hash ring checksum was computed|count
+|ring.server-added|Node (and its points) added to hash ring|count
+|ring.server-removed|Node (and its points) removed from hash ring|count
+|updates|Number of membership updates applied|timer
 
 ## Benchmarks
 Content coming soon...


### PR DESCRIPTION
This documentation is generated from a script that parses a CSV and turns it into a Markdown table. The long-term form of our stats "schema" likely won't be a CSV so I've not included that script in this branch.

@uber/ringpop 