### PR TITLE
Track potentially wedged requests and cancel them

### DIFF
--- a/client.js
+++ b/client.js
@@ -19,26 +19,26 @@
 // THE SOFTWARE.
 'use strict';
 
-var safeParse = require('./lib/util.js').safeParse;
-var validateHostPort = require('./lib/util.js').validateHostPort;
+var _ = require('underscore');
+var Config = require('./config.js');
+var ClientErrors = require('./client_errors.js');
+var ClientRequest = require('./client_request.js');
+var globalTimers = require('timers');
+var RingpopErrors = require('./ringpop_errors.js');
 var TChannel = require('tchannel');
-var TypedError = require('error/typed');
 
-var ChannelDestroyedError = TypedError({
-    type: 'ringpop.client.channel-destroyed',
-    message: 'Channel is already destroyed',
-    endpoint: null,
-    channelType: null
-});
-
-var InvalidHostPortError = TypedError({
-    type: 'ringpop.client.invalid-hostport',
-    message: 'Request made with invalid host port combination ({hostPort})',
-    hostPort: null
-});
-
-function RingpopClient(subChannel) {
+function RingpopClient(ringpop, subChannel, timers, date) {
+    this.ringpop = ringpop;
     this.subChannel = subChannel;
+    this.timers = timers || globalTimers;
+    this.date = date || Date;
+
+    this.config = this.ringpop.config;
+    this.logger = this.ringpop.loggerFactory.getLogger('client');
+
+    // If no subChannel provided, create one from a new instance
+    // of TChannel. This client then becomes the owner of that
+    // instance and is responsible for closing.
     this.isChannelOwner = false;
     if (!this.subChannel) {
         this.tchannel = new TChannel();
@@ -48,6 +48,10 @@ function RingpopClient(subChannel) {
         });
         this.isChannelOwner = true;
     }
+
+    this.requestsById = {};
+    this.wedgedTimer = null;
+    this.isDestroyed = false;
 }
 
 RingpopClient.prototype.adminConfigGet = function adminConfigGet(host, body, callback) {
@@ -100,75 +104,108 @@ RingpopClient.prototype.destroy = function destroy(callback) {
     if (this.isChannelOwner) {
         this.tchannel.close(callback);
     }
+
+    this.timers.clearTimeout(this.wedgedTimer);
+    this.isDestroyed = true;
+};
+
+// This function is "public" for ease of testing, but shouldn't be called by
+// anything other than the class itself.
+RingpopClient.prototype.scanForWedgedRequests = function scanForWedgedRequests() {
+    var wedgedRequests = [];
+
+    // Find all requests that have not been timed-out by TChannel.
+    // Induce Ringpop timeout for wedged requests and cancel them.
+    var requestIds = Object.keys(this.requestsById);
+    var scanTime = this.date.now();
+    for (var i = 0; i < requestIds.length; i++) {
+        var request = this.requestsById[requestIds[i]];
+        var timeInflight = scanTime - request.timestamp;
+        var isWedged = timeInflight >= (this.config.get('wedgedRequestTimeout') ||
+            Config.Defaults.wedgedRequestTimeout);
+        if (isWedged) {
+            delete this.requestsById[request.id];
+            request.cancel();
+            wedgedRequests.push(request);
+        }
+    }
+
+    if (wedgedRequests.length > 0) {
+        this.logger.error('ringpop canceled wedged requests', {
+            local: this.ringpop.whoami(),
+            numWedgedRequests: wedgedRequests.length,
+            wedgedRequests: wedgedRequestsToLog()
+        });
+        this._emitWedgedError();
+    }
+
+    return wedgedRequests;
+
+    // Log the first N requests only. We don't want to flood
+    // our pipes.
+    function wedgedRequestsToLog() {
+        return _.take(wedgedRequests, 10).map(function toLog(request) {
+            return request.toLog();
+        });
+    }
+};
+
+RingpopClient.prototype._emitWedgedError = function _emitWedgedError() {
+    var errorListeners = this.ringpop.listeners('error');
+    if (errorListeners.length > 0) {
+        this.ringpop.emit('error',
+            RingpopErrors.PotentiallyWedgedRequestsError());
+    }
 };
 
 /* jshint maxparams: 5 */
 RingpopClient.prototype._request = function _request(opts, endpoint, head, body, callback) {
     var self = this;
 
-    if (this.subChannel && this.subChannel.destroyed) {
+    if (!this.wedgedTimer) {
+        this._scheduleWedgedTimer();
+    }
+
+    var request = new ClientRequest(this, opts, endpoint, head, body,
+        this.date, onSend);
+
+    // Evaluate the number of inflight requests. If we've got more than the
+    // allowable limit it's a strong indication that at least some are wedged.
+    // Apply backpressure until the amount of inflight requests is reduced
+    // by cancellation or otherwise.
+    var inflightCurrent = Object.keys(this.requestsById).length;
+    var inflightMax = this.config.get('inflightClientRequestsLimit');
+    if (inflightCurrent >= inflightMax) {
         process.nextTick(function onTick() {
-            callback(ChannelDestroyedError({
-                endpoint: endpoint,
-                channelType: 'subChannel'
+            callback(ClientErrors.ClientRequestsLimitError({
+                inflightCurrent: inflightCurrent,
+                inflightMax: inflightMax,
+                endpoint: endpoint
             }));
         });
         return;
     }
 
-    if (this.subChannel &&
-            this.subChannel.topChannel &&
-            this.subChannel.topChannel.destroyed) {
-        process.nextTick(function onTick() {
-            callback(ChannelDestroyedError({
-                endpoint: endpoint,
-                channelType: 'topChannel'
-            }));
-        });
-        return;
+    // Registering the request by its ID must happen at the precise
+    // moment before we know it will be "inflight."
+    this.requestsById[request.id] = request;
+    request.send();
+
+    function onSend() {
+        delete self.requestsById[request.id];
+        var args = Array.prototype.splice.call(arguments, 0);
+        callback.apply(null, args);
     }
+};
 
-    if (!opts || !validateHostPort(opts.host)) {
-        callback(InvalidHostPortError({
-            hostPort: String(opts && opts.host)
-        }));
-        return;
-    }
-
-    self.subChannel.waitForIdentified({
-        host: opts.host
-    }, function onIdentified(err) {
-        if (err) {
-            callback(err);
-            return;
-        }
-
-        self.subChannel.request({
-            host: opts.host,
-            serviceName: 'ringpop',
-            hasNoParent: true,
-            retryLimit: opts.retryLimit || 0,
-            trace: false,
-            headers: {
-                as: 'raw',
-                cn: 'ringpop'
-            },
-            timeout: opts.timeout || 30000
-        }).send(endpoint, JSON.stringify(head), JSON.stringify(body), onSend);
-    });
-
-    function onSend(err, res, arg2, arg3) {
-        if (!err && !res.ok) {
-            err = safeParse(arg3) || new Error('Server Error');
-        }
-
-        if (err) {
-            callback(err);
-            return;
-        }
-
-        callback(null, safeParse(arg3));
-    }
+RingpopClient.prototype._scheduleWedgedTimer = function _scheduleWedgedTimer() {
+    var self = this;
+    this.wedgedTimer = this.timers.setTimeout(function onTimeout() {
+        if (self.isDestroyed) return;
+        self.scanForWedgedRequests();
+        self._scheduleWedgedTimer();
+    }, this.config.get('wedgedTimerInterval') || Config.Defaults.wedgedTimerInterval);
+    this.wedgedTimer.unref();
 };
 
 module.exports = RingpopClient;

--- a/client_errors.js
+++ b/client_errors.js
@@ -1,0 +1,32 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var TypedError = require('error/typed');
+
+module.exports = {
+    ClientRequestsLimitError: TypedError({
+        type: 'ringpop.client.limit-exceeded',
+        message: 'Client request limit reached',
+        inflightCurrent: null,
+        inflightMax: null,
+        endpoint: null
+    })
+};

--- a/client_request.js
+++ b/client_request.js
@@ -1,0 +1,210 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var ClientRequestErrors = require('./client_request_errors.js');
+var ClientRequestStates = require('./client_request_states.js');
+var EventEmitter = require('events').EventEmitter;
+var LoggingLevels = require('./lib/logging/levels.js');
+var safeParse = require('./lib/util.js').safeParse;
+var validateHostPort = require('./lib/util.js').validateHostPort;
+var uuid = require('node-uuid');
+var util = require('util');
+
+/* jshint maxparams: 7 */
+function ClientRequest(client, opts, endpoint, head, body, date, callback) {
+    this.client = client;
+    this.opts = opts;
+    this.endpoint = endpoint;
+    this.head = head;
+    this.body = body;
+    this.date = date || Date;
+    this.callback = callback;
+    this.id = uuid.v4();
+    this.isCanceled = false;
+    this.state = ClientRequestStates.initialized;
+    this.timestamp = this.date.now();
+}
+
+util.inherits(ClientRequest, EventEmitter);
+
+ClientRequest.prototype.cancel = function cancel() {
+    this.cancelTimestamp = this.date.now();
+    this.isCanceled = true;
+    this._invokeCallback(ClientRequestErrors.RequestCanceledError({
+        endpoint: this.endpoint
+    }));
+};
+
+ClientRequest.prototype.send = function send() {
+    var self = this;
+    var opts = this.opts;
+    var endpoint = this.endpoint;
+    var timeout = opts.timeout || 30000;
+    var subChannel = this.client.subChannel;
+
+    if (subChannel && subChannel.destroyed) {
+        process.nextTick(function onTick() {
+            self._invokeCallback(ClientRequestErrors.ChannelDestroyedError({
+                endpoint: endpoint,
+                channelType: 'subChannel'
+            }));
+        });
+        return;
+    }
+
+    if (subChannel &&
+            subChannel.topChannel &&
+            subChannel.topChannel.destroyed) {
+        process.nextTick(function onTick() {
+            self._invokeCallback(ClientRequestErrors.ChannelDestroyedError({
+                endpoint: endpoint,
+                channelType: 'topChannel'
+            }));
+        });
+        return;
+    }
+
+    if (!opts || !validateHostPort(opts.host)) {
+        process.nextTick(function onTick() {
+            self._invokeCallback(ClientRequestErrors.InvalidHostPortError({
+                hostPort: String(opts && opts.host)
+            }));
+        });
+        return;
+    }
+
+    self._changeState(ClientRequestStates.waitForIdentifiedPre);
+    subChannel.waitForIdentified({
+        host: opts.host
+    }, function onIdentified(err) {
+        self._changeState(ClientRequestStates.waitForIdentifiedPost);
+
+        if (self.isCanceled) {
+            self.client.logger.error('ringpop tchannel completed after request was canceled', {
+                local: self.client.ringpop.whoami(),
+                state: self.state,
+                request: self.toLog()
+            });
+            self.emit('alreadyCanceled', ClientRequestErrors.WaitForIdentifiedAfterCancelError());
+            return;
+        }
+
+        if (err) {
+            self._invokeCallback(err);
+            return;
+        }
+
+        self._changeState(ClientRequestStates.subChannelRequestPre);
+        // Set stringified head/body as member variables
+        // so we can log their size later.
+        self.strHead = JSON.stringify(self.head);
+        self.strBody = JSON.stringify(self.body);
+        subChannel.request({
+            host: opts.host,
+            serviceName: 'ringpop',
+            hasNoParent: true,
+            retryLimit: opts.retryLimit || 0,
+            trace: false,
+            headers: {
+                as: 'raw',
+                cn: 'ringpop'
+            },
+            timeout: timeout
+        }).send(endpoint, self.strHead, self.strBody, onSend);
+    });
+
+    function onSend(err, res, arg2, arg3) {
+        self._changeState(ClientRequestStates.subChannelRequestPost);
+
+        if (self.isCanceled) {
+            self.client.logger.error('ringpop tchannel completed after request was canceled', {
+                local: self.client.ringpop.whoami(),
+                state: self.state,
+                request: self.toLog()
+            });
+            self.emit('alreadyCanceled', ClientRequestErrors.SubChannelRequestAfterCancelError());
+            return;
+        }
+
+        if (!err && !res.ok) {
+            err = safeParse(arg3) || new Error('Server Error');
+        }
+
+        if (err) {
+            self._invokeCallback(err);
+            return;
+        }
+
+        self._invokeCallback(null, safeParse(arg3));
+    }
+};
+
+ClientRequest.prototype.toLog = function toLog() {
+    return {
+        id: this.id,
+        timestamp: this.timestamp,
+        cancelTimestamp: this.cancelTimestamp,
+        endpoint: this.endpoint,
+        headSize: this.strHead ? new Buffer(this.strHead).length : 0,
+        bodySize: this.strBody ? new Buffer(this.strBody).length : 0,
+        state: this.state,
+        isCanceled: this.isCanceled,
+        timeout: this.timeout,
+        timeToCancel: this.cancelTimestamp ?
+            this.cancelTimestamp - this.timestamp : null
+    };
+};
+
+ClientRequest.prototype._changeState = function _changeState(state) {
+    var oldState = this.state;
+    this.state = state;
+
+    if (this.client.logger.canLogAt(LoggingLevels.debug)) {
+        this.client.logger.debug('ringpop client request changed state', {
+            local: this.client.ringpop.whoami(),
+            oldState: oldState,
+            newState: this.state,
+            request: this.toLog()
+        });
+    }
+};
+
+ClientRequest.prototype._invokeCallback = function _invokeCallback() {
+    var args = Array.prototype.splice.call(arguments, 0);
+
+    // Callback is nullified after its first invocation.
+    if (!this.callback) {
+        this.client.logger.error('ringpop request callback already called', {
+            local: this.client.ringpop.whoami(),
+            // Log the first argument just in case it is TChannel trying to communicate
+            // an error to us.
+            err: args[0],
+            request: this.toLog()
+        });
+        this.emit('alreadyCalled');
+        return;
+    }
+
+    this.callback.apply(null, args);
+    this.callback = null;
+};
+
+module.exports = ClientRequest;

--- a/client_request_errors.js
+++ b/client_request_errors.js
@@ -1,0 +1,48 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var TypedError = require('error/typed');
+
+module.exports = {
+    ChannelDestroyedError: TypedError({
+        type: 'ringpop.client.channel-destroyed',
+        message: 'Channel is already destroyed',
+        endpoint: null,
+        channelType: null
+    }),
+    InvalidHostPortError: TypedError({
+        type: 'ringpop.client.invalid-hostport',
+        message: 'Request made with invalid host port combination ({hostPort})',
+        hostPort: null
+    }),
+    RequestCanceledError: TypedError({
+        type: 'ringpop.client.request-cancled',
+        message: 'Request was canceled while waiting for TChannel response'
+    }),
+    SubChannelRequestAfterCancelError: TypedError({
+        type: 'ringpop.client-request.sub-channel-request-after-cancel',
+        message: 'TChannel sub-channel request completed after request was canceled'
+    }),
+    WaitForIdentifiedAfterCancelError: TypedError({
+        type: 'ringpop.client-request.wait-for-identified-after-cancel',
+        message: 'TChannel waitForIdentified completed after request was canceled'
+    })
+};

--- a/client_request_states.js
+++ b/client_request_states.js
@@ -1,0 +1,29 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+module.exports = {
+    initialized: 0,
+    waitForIdentifiedPre: 1,
+    waitForIdentifiedPost: 2,
+    subChannelRequestPre: 3,
+    subChannelRequestPost: 4, // This also represents TChannel completeness
+    completed: 4
+};

--- a/config.js
+++ b/config.js
@@ -37,7 +37,9 @@ function Config(ringpop, seedConfig) {
 util.inherits(Config, EventEmitter);
 
 Config.Defaults = {
-    gossipLogLevel: 'debug'
+    gossipLogLevel: 'debug',
+    wedgedRequestTimeout: 30 * 1000,
+    wedgedTimerInterval: 1000
 };
 
 Config.prototype.get = function get(key) {
@@ -68,6 +70,7 @@ Config.prototype._seed = function _seed(seed) {
 
     // Logger configs; should be at least error by default.
     seedOrDefault('defaultLogLevel', LoggingLevels.info);
+    seedOrDefault('clientLogLevel', LoggingLevels.error);
     seedOrDefault('dampingLogLevel', LoggingLevels.error);
     seedOrDefault('disseminationLogLevel', LoggingLevels.error);
     seedOrDefault('gossipLogLevel', LoggingLevels.error);
@@ -119,6 +122,13 @@ Config.prototype._seed = function _seed(seed) {
     }, 'expected to be array of RegExp objects');
     seedOrDefault('membershipUpdateRollupEnabled', false);
     seedOrDefault('tchannelRetryLimit', 0);
+    // How long a request is outstanding until is it considered
+    // wedged and then canceled.
+    seedOrDefault('wedgedRequestTimeout', Config.Defaults.wedgedRequestTimeout);
+    // How often the wedge timer ticks.
+    seedOrDefault('wedgedTimerInterval', Config.Defaults.wedgedTimerInterval);
+    // Number of allowable inflight requests sent by RingpopClient.
+    seedOrDefault('inflightClientRequestsLimit', 100);
 
     function seedOrDefault(name, defaultVal, validator, reason) {
         var seedVal = seed[name];

--- a/index.js
+++ b/index.js
@@ -236,7 +236,7 @@ RingPop.prototype.destroy = function destroy() {
 };
 
 RingPop.prototype.setupChannel = function setupChannel() {
-    this.client = new RingpopClient(this.channel);
+    this.client = new RingpopClient(this, this.channel);
     this.server = new RingpopServer(this, this.channel);
 };
 

--- a/lib/logging/logger_factory.js
+++ b/lib/logging/logger_factory.js
@@ -25,6 +25,7 @@ var ModuleLogger = require('./module_logger.js');
 // level names by convention (logger name + "LogLevel") is the way
 // to go.
 var loggerNamesToLevels = {
+    client: 'clientLogLevel',
     damping: 'dampingLogLevel',
     dissemination: 'disseminationLogLevel',
     gossip: 'gossipLogLevel',

--- a/ringpop_errors.js
+++ b/ringpop_errors.js
@@ -1,0 +1,34 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var TypedError = require('error/typed');
+
+module.exports = {
+    PotentiallyWedgedRequestsError: TypedError({
+        type: 'ringpop.client.wedged-requests',
+        message: 'Ringpop has timed-out protocol requests that were expected ' +
+            'to be timed-out by TChannel. This may be an indication that TChannel ' +
+            'has become wedged. Our tests have shown that Ringpop continues ' +
+            'to function while in this state, but we advise vigilance and continued ' +
+            'monitoring of potentially worsening conditions. You may even want to ' +
+            'kill this process and have it restart.'
+    })
+};

--- a/test/integration/admin_test.js
+++ b/test/integration/admin_test.js
@@ -29,7 +29,7 @@ testRingpopCluster({
 }, 'config endpoints', function t(bootRes, cluster, assert) {
     assert.plan(4);
 
-    var client = new RingpopClient();
+    var client = new RingpopClient(cluster[0]);
     async.series([
         function configSetPart(callback) {
             client.adminConfigSet(cluster[0].whoami(), {
@@ -61,7 +61,7 @@ testRingpopCluster({
 }, 'gossip endpoints', function t(bootRes, cluster, assert) {
     assert.plan(4);
 
-    var client = new RingpopClient();
+    var client = new RingpopClient(cluster[0]);
     async.series([
         adminGossip('adminGossipStart'),
         adminGossip('adminGossipStop'),

--- a/test/unit/client_request_test.js
+++ b/test/unit/client_request_test.js
@@ -1,0 +1,137 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var ClientRequest = require('../../client_request.js');
+var ClientRequestErrors = require('../../client_request_errors.js');
+var ClientRequestStates = require('../../client_request_states.js');
+var test = require('tape');
+
+var noop = function noop() {};
+
+function createRequest(wedgedChannel, callback) {
+    var dummyClient = {
+        logger: {
+            canLogAt: function canLogAt() { return false; },
+            error: function noop(){}
+        },
+        ringpop: {
+            whoami: function whoami() { return 'whoever'; }
+        },
+        subChannel: wedgedChannel
+    };
+    var opts = {
+        host: '192.0.2.1:1'
+    };
+    return new ClientRequest(dummyClient, opts, null, null, null, null,
+        callback);
+}
+
+test('waitForIdentified request after cancel', function t(assert) {
+    assert.plan(2);
+
+    // Verify alreadyCanceled event emitted after wedged channel unwedges
+    // and calls its waitForIdentified callback.
+    var waitForIdentifiedCallback;
+    var wedgedChannel = {
+        waitForIdentified: function(_, callback) {
+            waitForIdentifiedCallback = callback;
+        }
+    };
+    var request = createRequest(wedgedChannel, function onSend() {
+        // Unwedge channel once the requests callback is invoked by the cancel()
+        // call below.
+        waitForIdentifiedCallback(new Error('tchannelerror'));
+    });
+    request.once('alreadyCanceled', function onAlreadyCanceled(err) {
+        assert.equals(err.type,
+            ClientRequestErrors.WaitForIdentifiedAfterCancelError().type,
+            'wait for identified error');
+    });
+    request.send();
+    request.cancel();
+    assert.equals(request.state, ClientRequestStates.waitForIdentifiedPost,
+        'after wait for identified state');
+    assert.end();
+});
+
+test('subChannel request after cancel', function t(assert) {
+    assert.plan(2);
+
+    // Verify alreadyCanceled event emitted after wedged channel unwedges
+    // and calls its send callback.
+    var sendCallback;
+    var sender = {
+        send: function send(_, _2, _3, callback) {
+            sendCallback = callback;
+        }
+    };
+    var wedgedChannel = {
+        waitForIdentified: function(_, callback) {
+            callback();
+        },
+        request: function request() { return sender; }
+    };
+    var request = createRequest(wedgedChannel, function onSend() {
+        // Unwedge channel once the requests callback is invoked by the cancel()
+        // call below.
+        sendCallback(Error('tchannelerror'));
+    });
+    request.once('alreadyCanceled', function onAlreadyCanceled(err) {
+        assert.equals(err.type,
+            ClientRequestErrors.SubChannelRequestAfterCancelError().type,
+            'sub-channel request error');
+    });
+    request.send();
+    request.cancel();
+    assert.equals(request.state, ClientRequestStates.subChannelRequestPost,
+        'after wait for identified state');
+    assert.end();
+});
+
+test('canceled request in correct state', function t(assert) {
+    assert.plan(2);
+
+    var dummyChannel = {
+        waitForIdentified: noop
+    };
+    var request = createRequest(dummyChannel, noop);
+    request.send();
+    request.cancel();
+    assert.ok(request.isCanceled, 'request is canceled');
+    assert.equals(null, request.callback, 'callback is nullified');
+    assert.end();
+});
+
+test('double cancel; callback already called', function t(assert) {
+    assert.pass(1);
+
+    var dummyChannel = {
+        waitForIdentified: noop
+    };
+    var request = createRequest(dummyChannel, noop);
+    request.on('alreadyCalled', function onAlreadyCalled() {
+        assert.pass('callback already called');
+    });
+    request.send();
+    request.cancel();
+    request.cancel();
+    assert.end();
+});


### PR DESCRIPTION
This pull requests creates a trackable request object (`ClientRequest`). Inflight requests (that have not had their callback called) are placed into `requestsById` in the `Client` object. There is a background timer (`wedgedTimer`) that periodically scans for "wedged requests" and cancels the request by preemptively invoking its callback. A wedged requests is canceled if it has been inflight for greater than `wedgedRequestTimeout`.

Internally, `ClientRequest` maintains a "state machine" at each step of the TChannel-send process. When a `ClientRequest` is canceled, its callback will be invoked by `Client`. The `ClientRequest` also makes sure that a callback isn't called multiple times by nullifying the callback after its first invocation.

@uber/ringpop 