### PR TITLE
unref() has a memory leak; don't use it

### DIFF
--- a/client.js
+++ b/client.js
@@ -205,7 +205,6 @@ RingpopClient.prototype._scheduleWedgedTimer = function _scheduleWedgedTimer() {
         self.scanForWedgedRequests();
         self._scheduleWedgedTimer();
     }, this.config.get('wedgedTimerInterval') || Config.Defaults.wedgedTimerInterval);
-    this.wedgedTimer.unref();
 };
 
 module.exports = RingpopClient;

--- a/test/unit/client_test.js
+++ b/test/unit/client_test.js
@@ -299,5 +299,6 @@ test('emits ringpop error on canceled request', function t(assert) {
     });
 
     client.scanForWedgedRequests();
+    client.destroy();
     assert.end();
 });


### PR DESCRIPTION
unref'ing a setTimeout leaks memory:

Orig issue: https://github.com/nodejs/node-v0.x-archive/issues/8364
Changelog: https://github.com/nodejs/node/blob/v0.10.40-release/ChangeLog#L77

@uber/ringpop @Raynos 