### PR TITLE
Update tchan to 3.6.13 and fix two tests that broke because of it.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "pre-commit": "^0.0.9",
     "tape": "^3.0.3",
     "tape-cluster": "2.1.0",
-    "tchannel": "^2.10.1",
+    "tchannel": "^3.6.13",
     "tcurl": "^4.11.1",
     "time-mock": "^0.1.2",
     "tryit": "^1.0.1",

--- a/test/integration/gossip_test.js
+++ b/test/integration/gossip_test.js
@@ -196,7 +196,7 @@ testRingpopCluster({
     // unreachable and therefore, the results of ping-req inconclusive.
     ringpop.membership.members.forEach(function eachMember(member) {
         if (member.address !== unreachableMember.address) {
-            member.address += '001';
+            member.address = member.address.split(':')[0]+":9999"
         }
     });
 

--- a/test/lib/tchannel-proxy-cluster.js
+++ b/test/lib/tchannel-proxy-cluster.js
@@ -78,7 +78,7 @@ TChannelProxyCluster.prototype.bootstrap = function bootstrap(cb) {
         self.setupHandler('one', self.cluster.one);
         self.setupHandler('two', self.cluster.two);
         self.setupHandler('three', self.cluster.three);
-        self.client.listen(0, '127.0.0.1', onListen);
+        self.clientRootChannel.listen(0, '127.0.0.1', onListen);
     }
 
     function onListen() {


### PR DESCRIPTION
One test used to add '001' to the hostport to make it unreachable, tchannel doesn't allow huge port no.s anymore. The other test failed because: 'AssertionError: TChannel must listen on top channel'. Listening to the rootChannel fixed the test.