### PR TITLE
T287803 ring.checksum stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,6 +172,7 @@ function RingPop(options) {
     registerRingpopListeners(this);
 
     this.periodicStats = new PeriodicStats(this, {timers: timers});
+    this.periodicStats.start();
 
     this.clientRate = new metrics.Meter();
     this.serverRate = new metrics.Meter();
@@ -204,6 +205,7 @@ RingPop.prototype.destroy = function destroy() {
     this.gossip.stop();
     this.suspicion.stopAll();
     this.membershipUpdateRollup.destroy();
+    this.periodicStats.stop();
     this.requestProxy.destroy();
     this.tracers.destroy();
 

--- a/lib/on_membership_event.js
+++ b/lib/on_membership_event.js
@@ -27,6 +27,7 @@ function createChecksumComputedHandler(ringpop) {
 
     return function onMembershipChecksumComputed(event) {
         ringpop.stat('increment', 'membership.checksum-computed');
+        ringpop.stat('gauge', 'membership.checksum', event.checksum);
         ringpop.emit('membershipChecksumComputed');
 
         if (event.oldChecksum !== event.checksum) {

--- a/lib/on_ring_event.js
+++ b/lib/on_ring_event.js
@@ -24,6 +24,7 @@ function createChecksumComputedHandler(ringpop) {
 
     return function onRingChecksumComputed(event) {
         ringpop.stat('increment', 'ring.checksum-computed');
+        ringpop.stat('gauge', 'ring.checksum', event.checksum);
         ringpop.emit('ringChecksumComputed');
 
         if (event.oldChecksum !== event.checksum) {

--- a/lib/stats-periodic.js
+++ b/lib/stats-periodic.js
@@ -49,7 +49,6 @@ function PeriodicStats(ringpop, options) {
     this.ringpop = ringpop;
     this.options = options;
     this.logger = ringpop.logger;
-    this.stat = ringpop.stat;
     this.timers = this.options.timers || ringpop.timers || timers;
     this.running = false;
 
@@ -70,7 +69,7 @@ PeriodicStats.prototype.start = function start() {
     function emitChecksum() {
         var checksum = self.ringpop.ring.checksum;
         if (checksum !== null && checksum !== undefined) {
-            self.stat('gauge', 'ring.checksum-periodic', checksum);
+            self.ringpop.stat('gauge', 'ring.checksum-periodic', checksum);
         }
     }
 }

--- a/lib/stats-periodic.js
+++ b/lib/stats-periodic.js
@@ -34,11 +34,12 @@ var periodMinimum = 10;
 //
 // Currently supported:
 // {
-//   timers: { ... }
+//   timers: { ... }           // (like timer-shim, built in timers module)
 //   periods: {
-//     default: ...
-//     minimum: ...
-//     ringChecksum: default
+//     default: period-in-ms
+//     minimum: period-in-ms   // never allow below this, typ. 10ms
+//     membershipChecksum: period-in-ms
+//     ringChecksum: period-in-ms
 //   }
 // }
 //
@@ -54,6 +55,8 @@ function PeriodicStats(ringpop, options) {
 
     this.periodDefault = periods.default || periodDefault;
     this.periodMinimum = periods.minimum || periodMinimum;
+
+    this.membershipChecksumPeriod = this.normalizePeriod(periods.membershipChecksum);
     this.ringChecksumPeriod = this.normalizePeriod(periods.ringChecksum);
 }
 
@@ -61,12 +64,26 @@ PeriodicStats.prototype.start = function start() {
     var self = this;
 
     var setInterval = self.timers.setInterval;
-    self.ringChecksumTimer = setInterval(emitChecksum, self.ringChecksumPeriod);
+
+    self.membershipChecksumTimer =
+        setInterval(emitMembershipChecksum, self.membershipChecksumPeriod);
+    self.membershipChecksumTimer.unref();
+
+    self.ringChecksumTimer =
+        setInterval(emitRingChecksum, self.ringChecksumPeriod);
     self.ringChecksumTimer.unref();
+
     self.running = true;
     return;
 
-    function emitChecksum() {
+    function emitMembershipChecksum() {
+        var checksum = self.ringpop.membership.checksum;
+        if (checksum !== null && checksum !== undefined) {
+            self.ringpop.stat('gauge', 'membership.checksum-periodic', checksum);
+        }
+    }
+
+    function emitRingChecksum() {
         var checksum = self.ringpop.ring.checksum;
         if (checksum !== null && checksum !== undefined) {
             self.ringpop.stat('gauge', 'ring.checksum-periodic', checksum);
@@ -76,8 +93,13 @@ PeriodicStats.prototype.start = function start() {
 
 PeriodicStats.prototype.stop = function stop() {
     var clearInterval = this.timers.clearInterval;
+
+    this.membershipChecksumTimer && clearInterval(this.membershipChecksumTimer);
+    this.membershipChecksumTimer = null;
+
     this.ringChecksumTimer && clearInterval(this.ringChecksumTimer);
     this.ringChecksumTimer = null;
+
     this.running = false;
 }
 

--- a/lib/stats-periodic.js
+++ b/lib/stats-periodic.js
@@ -1,0 +1,111 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+'use strict';
+
+var timers = require('timers');
+
+// local constants
+var periodDefault = 5000;
+var periodMinimum = 10;
+
+//
+// Periodic Stats Timers are bound as such:
+//   default:  5000 (see above)
+//   <=0    -> disabled (-1)
+//   (0,10) -> 10
+//   >=10   -> unchanged
+//
+// Currently supported:
+// {
+//   timers: { ... }
+//   periods: {
+//     default: ...
+//     minimum: ...
+//     ringChecksum: default
+//   }
+// }
+//
+function PeriodicStats(ringpop, options) {
+    options = options || {};
+    var periods = options.periods || {};
+
+    this.ringpop = ringpop;
+    this.options = options;
+    this.logger = ringpop.logger;
+    this.stat = ringpop.stat;
+    this.timers = this.options.timers || ringpop.timers || timers;
+    this.running = false;
+
+    this.periodDefault = periods.default || periodDefault;
+    this.periodMinimum = periods.minimum || periodMinimum;
+    this.ringChecksumPeriod = this.normalizePeriod(periods.ringChecksum);
+}
+
+PeriodicStats.prototype.start = function start() {
+    var self = this;
+
+    var setInterval = self.timers.setInterval;
+    self.ringChecksumTimer = setInterval(emitChecksum, self.ringChecksumPeriod);
+    self.ringChecksumTimer.unref();
+    self.running = true;
+    return;
+
+    function emitChecksum() {
+        var checksum = self.ringpop.ring.checksum;
+        if (checksum !== null && checksum !== undefined) {
+            self.stat('gauge', 'ring.checksum-periodic', checksum);
+        }
+    }
+}
+
+PeriodicStats.prototype.stop = function stop() {
+    var clearInterval = this.timers.clearInterval;
+    this.ringChecksumTimer && clearInterval(this.ringChecksumTimer);
+    this.ringChecksumTimer = null;
+    this.running = false;
+}
+
+PeriodicStats.prototype.normalizePeriod = function normalizePeriod(period) {
+    if (period === null || period === undefined) {
+        return this.periodDefault;
+    }
+    if (isNaN(period)) {
+        this.logger.warn('invalid stats period found; using default', {
+            local: this.ringpop.whoami(),
+            period: period,
+            default: this.periodDefault
+        });
+        return this.periodDefault;
+    }
+    if (period < 0 || period === 0) {
+        return -1;
+    }
+    if (period < 10) {
+        this.logger.info('too aggressive stats period found; using minimum', {
+            local: this.ringpop.whoami(),
+            period: period,
+            minimum: this.periodMinimum
+        });
+        return 10;
+    }
+    return Number(period);
+}
+
+module.exports = PeriodicStats;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "tape-cluster": "2.1.0",
     "tchannel": "^3.6.13",
     "tcurl": "^4.11.1",
-    "time-mock": "^0.1.2",
+    "timer-shim": "^0.3.0",
     "tryit": "^1.0.1",
     "uber-licence": "^1.1.0",
     "winston": "^1.0.1"

--- a/test/integration/proxy_test.js
+++ b/test/integration/proxy_test.js
@@ -27,10 +27,10 @@ var bufferEqual = require('buffer-equal');
 var express = require('express');
 var http = require('http');
 var jsonBody = require('body/json');
+var makeTimersMock = require('../lib/timers-mock');
 var strHead = require('../../lib/request-proxy/util.js').strHead;
 var test = require('tape');
 var testRingpopCluster = require('../lib/test-ringpop-cluster.js');
-var TimeMock = require('time-mock');
 var tryIt = require('tryit');
 
 var retrySchedule = [0, 0.01, 0.02];
@@ -788,7 +788,7 @@ test('can serialize httpVersion', function t(assert) {
 });
 
 test('will timeout after default timeout', function t(assert) {
-    var timers = TimeMock(Date.now());
+    var timers = makeTimersMock();
     var cluster = allocCluster({
         timers: timers,
         createHandler: function createHandler() {
@@ -912,7 +912,7 @@ test('can send back a close event');
 
 // lack of coverage.
 test('custom timeouts', function t(assert) {
-    var timers = TimeMock(Date.now());
+    var timers = makeTimersMock();
     var cluster = allocCluster({
         timers: timers,
         createHandler: function createHandler() {

--- a/test/lib/alloc-ringpop.js
+++ b/test/lib/alloc-ringpop.js
@@ -21,7 +21,8 @@
 'use strict';
 
 var TChannel = require('tchannel');
-var TimeMock = require('time-mock');
+
+var makeTimersMock = require('../lib/timers-mock');
 
 var globalTimers = {
     setTimeout: require('timers').setTimeout,
@@ -44,7 +45,7 @@ function allocRingpop(name, options) {
         logger: DebuglogLogger((name && name + 'tchannel') || 'tchannel')
     });
 
-    var timers = TimeMock(Date.now());
+    var timers = makeTimersMock();
     var ringpop = new RingPop({
         app: 'test.ringpop.proxy_req_test',
         hostPort: host + ':' + String(port),

--- a/test/lib/timers-mock.js
+++ b/test/lib/timers-mock.js
@@ -1,0 +1,51 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var timerShim = require('timer-shim');
+
+// make a simple wrapper to timerShim which is mostly better than time-mock,
+// but lacks its .now function. This has everything that require('timers')
+// provides, PLUS .now().  Would be better to add .now to timer-shim, but
+// that's for another moment.
+function makeTimersMock(start) {
+    start = start || 0;
+
+    var t = new timerShim.Timer();
+    t.pause();
+    var cur = start;
+    if (start) {
+        t.wind(start);
+    }
+    return {
+        setTimeout: t.setTimeout.bind(t),
+        clearTimeout: t.clearTimeout.bind(t),
+        setInterval: t.setInterval.bind(t),
+        clearInterval: t.clearInterval.bind(t),
+        now: function() { return cur; },
+        advance: function(s) {
+            cur += s;
+            t.wind(s);
+        }
+    }
+}
+
+module.exports = makeTimersMock;

--- a/test/unit/client_test.js
+++ b/test/unit/client_test.js
@@ -22,9 +22,9 @@
 var Client = require('../../client.js');
 var ClientErrors = require('../../client_errors.js');
 var EventEmitter = require('events').EventEmitter;
+var makeTimersMock = require('../lib/timers-mock');
 var RingpopErrors = require('../../ringpop_errors.js');
 var test = require('tape');
-var TimeMock = require('time-mock');
 var util = require('util');
 
 var noop = function noop() {};
@@ -210,7 +210,7 @@ test('cancels correct number of requests', function t(assert) {
         host: '192.0.2.1:1'
     };
     var timeout = 15000;
-    var timeMock = new TimeMock(Date.now());
+    var timers = makeTimersMock();
 
     // Create a Ringpop that is configured with a 15s
     // wedgedRequestTimeout.
@@ -229,7 +229,7 @@ test('cancels correct number of requests', function t(assert) {
         waitForIdentified: function noop() {}
     };
 
-    var client = new Client(dummyRingpop, wedgedChannel, null, timeMock);
+    var client = new Client(dummyRingpop, wedgedChannel, null, timers);
 
     // Send 3 pings. Each of the pings create a single ClientRequest object
     // marked with a timestamp equal to the present.
@@ -239,7 +239,7 @@ test('cancels correct number of requests', function t(assert) {
 
     // Advance time by twice the timeout value causing each of the 3
     // previous sent pings to be marked for expiry when scanned below.
-    timeMock.advance(timeout * 2);
+    timers.advance(timeout * 2);
 
     // The last and final ping happens after the clock has been advanced
     // and all 4 pending requests will be evaluated to see if they have
@@ -266,7 +266,7 @@ test('emits ringpop error on canceled request', function t(assert) {
         host: '192.0.2.1:1'
     };
     var timeout = 15000;
-    var timeMock = new TimeMock(Date.now());
+    var timers = makeTimersMock();
 
     // Create a Ringpop that is configured with a 15s
     // wedgedRequestTimeout.
@@ -285,11 +285,11 @@ test('emits ringpop error on canceled request', function t(assert) {
         waitForIdentified: function noop() {}
     };
 
-    var client = new Client(dummyRingpop, wedgedChannel, null, timeMock);
+    var client = new Client(dummyRingpop, wedgedChannel, null, timers);
     // Send 1 ping on wedged channel.
     client.protocolPing(opts, null, noop);
     // Advance time to trigger cancellation of previous ping request.
-    timeMock.advance(timeout * 2);
+    timers.advance(timeout * 2);
 
     // Register for error just prior to it being raised by call to
     // scanForWedgedRequests() below.

--- a/test/unit/damper_test.js
+++ b/test/unit/damper_test.js
@@ -23,9 +23,10 @@ var fixtures = require('../fixtures.js');
 var Damper = require('../../lib/gossip/damper.js');
 var DampReqRequest = require('../../request_response.js').DampReqRequest;
 var DampReqResponse = require('../../request_response.js').DampReqResponse;
+var makeTimersMock = require('../lib/timers-mock');
 var MemberDampScore = require('../../lib/membership/member_damp_score.js');
 var testRingpop = require('../lib/test-ringpop.js');
-var TimeMock = require('time-mock');
+var timers = require('timer-shim');
 
 var noop = function noop() {};
 
@@ -212,7 +213,7 @@ testRingpop({
 testRingpop('damp timer initiates subprotocol', function t(deps, assert) {
     assert.plan(2);
 
-    var timers = new TimeMock(Date.now());
+    var timers = makeTimersMock();
     var damper = deps.damper;
     damper.timers = timers;
     damper.on('started', function onEvent(event) {
@@ -250,7 +251,7 @@ testRingpop('expires damped members', function t(deps, assert) {
     assert.plan(5);
 
     var damper = deps.damper;
-    var timers = new TimeMock(Date.now());
+    var timers = makeTimersMock();
     // Stub damper timers to allow for expiring damped members
     damper.timers = timers;
     damper.Date = timers;

--- a/test/unit/stats-test.js
+++ b/test/unit/stats-test.js
@@ -41,7 +41,12 @@ test('periodic stats have correct defaults', function t(assert) {
     stats.start();
     assert.deepEqual(ringpop.journal, [], 'empty journal after start');
     ringpop.timers.advance(5000);
-    assert.deepEqual(ringpop.journal, [['stat', 'gauge', 'ring.checksum-periodic', 0xDEADBEEF]]);
+    debugger;
+    assert.deepEqual(ringpop.journal, [
+        // hard ordering, not worth changing for 2. _.contains doesn't work :(
+        ['stat', 'gauge', 'membership.checksum-periodic', 0xCAFED00D],
+        ['stat', 'gauge', 'ring.checksum-periodic', 0xDEADBEEF]
+    ]);
 
     stats.stop();
     assert.end();
@@ -60,7 +65,11 @@ test('periodic stats respect period overrides', function t(assert) {
     stats.start();
     assert.deepEqual(ringpop.journal, [], 'empty journal after start');
     ringpop.timers.advance(500);
-    assert.deepEqual(ringpop.journal, [['stat', 'gauge', 'ring.checksum-periodic', 0xDEADBEEF]]);
+    assert.deepEqual(ringpop.journal, [
+        // hard ordering, not worth changing for 2. _.contains doesn't work :(
+        ['stat', 'gauge', 'membership.checksum-periodic', 0xCAFED00D],
+        ['stat', 'gauge', 'ring.checksum-periodic', 0xDEADBEEF]
+    ]);
 
     stats.stop();
     assert.end();
@@ -127,8 +136,10 @@ test('start/stop works too', function t(assert) {
 
     stats.start();
     ringpop.timers.advance(5000);
-    assert.deepEqual(ringpop.journal.length, 1, 'journal contains 1 entry');
-    assert.deepEqual(ringpop.journal[0][3], 0xDEADBEEF, 'journal contains checksum');
+    // hard ordering, not worth changing for 2. _.contains doesn't work :(
+    assert.deepEqual(ringpop.journal.length, 2, 'journal contains 1 entry');
+    assert.deepEqual(ringpop.journal[0][3], 0xCAFED00D, 'journal contains checksum');
+    assert.deepEqual(ringpop.journal[1][3], 0xDEADBEEF, 'journal contains checksum');
     ringpop.journal = [];
 
     stats.stop();
@@ -198,6 +209,7 @@ function RingpopMock() {
         info: push.bind(null, 'logger.info'),
         warn: push.bind(null, 'logger.warn'),
     };
+    this.membership = {checksum: 0xCAFED00D};
     this.ring = {checksum: 0xDEADBEEF};
     this.stat = push.bind(null, 'stat');
     this.timers = makeTimersMock();

--- a/test/unit/stats-test.js
+++ b/test/unit/stats-test.js
@@ -1,0 +1,205 @@
+// Copyright (c) 2015 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+
+var _ = require('underscore');
+var test = require('tape');
+
+var PeriodicStats = require('../../lib/stats-periodic');
+var makeTimersMock = require('../lib/timers-mock');
+
+test('periodic stats have correct defaults', function t(assert) {
+    var opts = null;
+
+    var ringpop = new RingpopMock();
+    var stats = new PeriodicStats(ringpop, null);
+
+    assert.equal(stats.periodDefault, 5000, 'period default');
+    assert.equal(stats.periodMinimum, 10, 'period minimum');
+    assert.equal(stats.ringChecksumPeriod, 5000, 'ring checksum period');
+
+    stats.start();
+    assert.deepEqual(ringpop.journal, [], 'empty journal after start');
+    ringpop.timers.advance(5000);
+    assert.deepEqual(ringpop.journal, [['stat', 'gauge', 'ring.checksum-periodic', 0xDEADBEEF]]);
+
+    stats.stop();
+    assert.end();
+});
+
+test('periodic stats respect period overrides', function t(assert) {
+    var opts = {periods: {default: 500, minimum: 20}};;
+
+    var ringpop = new RingpopMock();
+    var stats = new PeriodicStats(ringpop, opts);
+
+    assert.equal(stats.periodDefault, 500, 'period default');
+    assert.equal(stats.periodMinimum, 20, 'period minimum');
+    assert.equal(stats.ringChecksumPeriod, 500, 'ring checksum period');
+
+    stats.start();
+    assert.deepEqual(ringpop.journal, [], 'empty journal after start');
+    ringpop.timers.advance(500);
+    assert.deepEqual(ringpop.journal, [['stat', 'gauge', 'ring.checksum-periodic', 0xDEADBEEF]]);
+
+    stats.stop();
+    assert.end();
+});
+
+test('periodic stats bounded by minimum', function t(assert) {
+    var opts = {periods: {ringChecksum: 5}};
+
+    var ringpop = new RingpopMock();
+    var stats = new PeriodicStats(ringpop, opts);
+
+    assert.equal(stats.ringChecksumPeriod, 10, 'ring checksum period');
+    assert.deepEqual(
+        ringpop.journal[0],
+        ['logger.info', 'too aggressive stats period found; using minimum', {local: 'me', minimum: 10, period: 5}]);
+
+    stats.start();
+    ringpop.timers.advance(10);
+    assert.deepEqual(ringpop.journal[1], ['stat', 'gauge', 'ring.checksum-periodic', 0xDEADBEEF]);
+
+    stats.stop();
+    assert.end();
+});
+
+test('ringChecksumPeriod honored if in bounds', function t(assert) {
+    var opts = {periods: {ringChecksum: 42}};
+
+    var ringpop = new RingpopMock();
+    var stats = new PeriodicStats(ringpop, opts);
+
+    assert.equal(stats.ringChecksumPeriod, 42, 'ring checksum period');
+
+    stats.start();
+    assert.deepEqual(ringpop.journal, [], 'empty journal after start');
+    ringpop.timers.advance(42);
+    assert.deepEqual(ringpop.journal, [['stat', 'gauge', 'ring.checksum-periodic', 0xDEADBEEF]]);
+
+    stats.stop();
+    assert.end();
+});
+
+test('ringChecksumPeriod survives invalid option', function t(assert) {
+    var opts = {periods: {ringChecksum: 'invalid period'}};
+
+    var ringpop = new RingpopMock();
+    var stats = new PeriodicStats(ringpop, opts);
+
+    assert.equal(stats.ringChecksumPeriod, 5000, 'ring checksum period');
+    assert.deepEqual(
+        ringpop.journal[0],
+        ['logger.warn', 'invalid stats period found; using default', {local: 'me', default: 5000, period: 'invalid period'}]);
+
+    assert.end();
+});
+
+test('start/stop works too', function t(assert) {
+    var ringpop = new RingpopMock();
+    var stats = new PeriodicStats(ringpop, null);
+
+    // confirm that nothing is generated until start, and that after stop, no more.
+    assert.deepEqual(ringpop.journal, [], 'journal empty');
+    ringpop.timers.advance(10000);
+    assert.deepEqual(ringpop.journal, [], 'journal empty before start after 10s');
+
+    stats.start();
+    ringpop.timers.advance(5000);
+    assert.deepEqual(ringpop.journal.length, 1, 'journal contains 1 entry');
+    assert.deepEqual(ringpop.journal[0][3], 0xDEADBEEF, 'journal contains checksum');
+    ringpop.journal = [];
+
+    stats.stop();
+    ringpop.timers.advance(5000);
+    assert.deepEqual(ringpop.journal, [], 'journal contains nothing new after stop');
+
+    assert.end();
+});
+
+test.skip('trace events get traced', function t(assert) {
+    var ringpop = new RingpopMock();
+    var store = new TracerStore(ringpop);
+    var config = core.resolveEventConfig(ringpop, 'membership.checksum.update');
+    var opts = {expiresIn: 50, sink: {type: 'log'}};
+    var tracer = store.add(config, opts);
+
+    assert.plan(5);
+    tracer.on('connectSink', function onTracer() {
+        // now test events on this thing
+        assert.equal(ringpop.journal.length, 0, 'journal starts empty');
+        ringpop.membership.emit('checksumUpdate', 'foo');
+        assert.equal(ringpop.journal.length, 1, 'journal has 1 entry');
+        assert.equal(ringpop.journal[0], 'foo', 'journal added foo');
+
+        ringpop.membership.emit('checksumUpdate', 'bar');
+        assert.equal(ringpop.journal.length, 2, 'journal has 2 entries');
+        assert.equal(ringpop.journal[1], 'bar', 'journal added bar');
+    });
+});
+
+test.skip('trace events can renew, and expire', function t(assert) {
+    var ringpop = new RingpopMock();
+    var store = new TracerStore(ringpop, { timers: timers });
+    var config = core.resolveEventConfig(ringpop, 'membership.checksum.update');
+    var opts = {expiresIn: 50, sink: {type: 'log'}};
+    store.add(config, opts);
+
+    assert.plan(3);
+
+    // nextTick okay since log "connects" instantly
+    process.nextTick(function onTracer() {
+        ringpop.membership.emit('checksumUpdate', 'foo');
+        assert.equal(ringpop.journal.length, 1, 'trace added correctly');
+
+        timer.advance(25);
+        store.add(config, opts);
+
+        timer.advance(49);
+        ringpop.membership.emit('checksumUpdate', 'bar');
+        assert.equal(ringpop.journal.length, 2, 'trace readd survived timeout');
+
+        timer.advance(1);
+        ringpop.membership.emit('checksumUpdate', 'dropped');
+        assert.equal(ringpop.journal.length, 2, 'timer dropped trace @timeout');
+    });
+});
+
+// dumbest of mocks for our trace element
+function RingpopMock() {
+    var journal = [];
+    var push = function() {
+        journal.push(Array.prototype.slice.call(arguments));
+    }
+
+    this.journal = journal;
+    this.logger = {
+        info: push.bind(null, 'logger.info'),
+        warn: push.bind(null, 'logger.warn'),
+    };
+    this.ring = {checksum: 0xDEADBEEF};
+    this.stat = push.bind(null, 'stat');
+    this.timers = makeTimersMock();
+    this.whoami = function() { return 'me'; };
+}


### PR DESCRIPTION
add {membership,ring}-checksum{,-periodic} stats for partition detection

replaced time-mock with timer-shim, to work with intervals, added small wrapper for trivial compatibility.

@uber/ringpop 