### PR TITLE
Travis jshint

### DIFF
--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -246,7 +246,7 @@ Dissemination.prototype.tryStartReverseFullSync = function tryStartReverseFullSy
 
 Dissemination.prototype._reverseFullSync = function _reverseFullSync(target, timeout, callback) {
     var self = this;
-    
+
     this.ringpop.stat('increment', 'full-sync.reverse');
     this.ringpop.client.protocolJoin({
         host: target,
@@ -257,6 +257,15 @@ Dissemination.prototype._reverseFullSync = function _reverseFullSync(target, tim
         source: this.ringpop.whoami(),
         incarnationNumber: this.ringpop.membership.localMember.incarnationNumber
     }, onJoin);
+
+    function process(joinResponse) {
+        self.logger.info('bidirectional full sync', {remote: target});
+
+        var updates = self.ringpop.membership.update(joinResponse.members);
+        if (updates.length === 0) {
+            self.ringpop.stat('increment', 'full-sync.redundant-reverse');
+        }
+    }
 
     function onJoin(err, res) {
         if (err) {
@@ -273,15 +282,6 @@ Dissemination.prototype._reverseFullSync = function _reverseFullSync(target, tim
             members: res.membership
         });
         callback();
-    }
-
-    function process(joinResponse) {
-        self.logger.info('bidirectional full sync', {remote: target});
-
-        var updates = self.ringpop.membership.update(joinResponse.members);
-        if (updates.length === 0) {
-            self.ringpop.stat('increment', 'full-sync.redundant-reverse');
-        }
     }
 };
 

--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -246,7 +246,7 @@ Dissemination.prototype.tryStartReverseFullSync = function tryStartReverseFullSy
 
 Dissemination.prototype._reverseFullSync = function _reverseFullSync(target, timeout, callback) {
     var self = this;
-
+    
     this.ringpop.stat('increment', 'full-sync.reverse');
     this.ringpop.client.protocolJoin({
         host: target,
@@ -257,15 +257,6 @@ Dissemination.prototype._reverseFullSync = function _reverseFullSync(target, tim
         source: this.ringpop.whoami(),
         incarnationNumber: this.ringpop.membership.localMember.incarnationNumber
     }, onJoin);
-
-    function process(joinResponse) {
-        self.logger.info('bidirectional full sync', {remote: target});
-
-        var updates = self.ringpop.membership.update(joinResponse.members);
-        if (updates.length === 0) {
-            self.ringpop.stat('increment', 'full-sync.redundant-reverse');
-        }
-    }
 
     function onJoin(err, res) {
         if (err) {
@@ -282,6 +273,15 @@ Dissemination.prototype._reverseFullSync = function _reverseFullSync(target, tim
             members: res.membership
         });
         callback();
+    }
+
+    function process(joinResponse) {
+        self.logger.info('bidirectional full sync', {remote: target});
+
+        var updates = self.ringpop.membership.update(joinResponse.members);
+        if (updates.length === 0) {
+            self.ringpop.stat('increment', 'full-sync.redundant-reverse');
+        }
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "glob": "^4.3.1",
     "istanbul": "^0.3.5",
     "itape": "^1.5.0",
-    "jshint": "^2.5.6",
+    "jshint": "^2.9.2",
     "leaked-handles": "^5.1.0",
     "opn": "^1.0.1",
     "pre-commit": "^0.0.9",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "check-licence": "uber-licence --dry",
     "cover": "istanbul cover --print detail --report html test/index.js | faucet",
     "jshint": "jshint --verbose *.js lib/**/*.js scripts/*.js server/**/*.js",
-    "travis": "npm run cover -s && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)",
+    "travis": "npm run jshint && npm run cover -s && istanbul report lcov && ((cat coverage/lcov.info | coveralls) || exit 0)",
     "view-cover": "opn coverage/index.html"
   },
   "dependencies": {


### PR DESCRIPTION
The `git pre-commit` hooks are failing on `npm run jshint`. To prevent this happening in the future this PR adds `npm run jshint` to the travis target so CI will complain if source code does not pass `jshint`.

To make sure everything passes the `process` function is now declared before its use in `onJoin`.