### PR TITLE
Deprecate "admin/reload"-endpoint

### DIFF
--- a/server/admin/index.js
+++ b/server/admin/index.js
@@ -50,6 +50,7 @@ var baseEndpointHandlers = {
         endpoint: '/admin/lookup',
         handler: require('./lookup.js')
     },
+    // Deprecated!
     reload: {
         endpoint: '/admin/reload',
         handler: require('./reload.js')

--- a/server/admin/reload.js
+++ b/server/admin/reload.js
@@ -24,6 +24,7 @@ var safeParse = require('../../lib/util.js').safeParse;
 
 module.exports = function createReloadHandler(ringpop) {
     return function handleReload(arg1, arg2, hostInfo, callback) {
+        ringpop.logger.warn('endpoint is deprecated: /admin/reload', {hostInfo: hostInfo});
         var body = safeParse(arg2.toString());
         if (body && body.file) {
             ringpop.reload(body.file, function(err) {

--- a/server/admin/reload.js
+++ b/server/admin/reload.js
@@ -24,7 +24,10 @@ var safeParse = require('../../lib/util.js').safeParse;
 
 module.exports = function createReloadHandler(ringpop) {
     return function handleReload(arg1, arg2, hostInfo, callback) {
-        ringpop.logger.warn('endpoint is deprecated: /admin/reload', {hostInfo: hostInfo});
+        ringpop.logger.warn('ringpop endpoint is deprecated: /admin/reload', {
+            local: ringpop.whoami(),
+            hostInfo: hostInfo
+        });
         var body = safeParse(arg2.toString());
         if (body && body.file) {
             ringpop.reload(body.file, function(err) {


### PR DESCRIPTION
Part of the feedback on #253 was to deprecate the `admin/reload`-endpoint.
The endpoint isn't used by ringpop-admin and, according to our internal metrics, has never been called in production.
Triggering a reload was probably useful during testing when the bootstrap file changed. With partition healing, we achieve a similar result in that the discover provider will be re-queried, except that it's automatic.