### PR TITLE
Implement reaping faulty nodes

### DIFF
--- a/lib/gossip/state_transitions.js
+++ b/lib/gossip/state_transitions.js
@@ -27,6 +27,8 @@ function StateTransitions(options) {
 
     var p = options.periods || {};
     this.suspectTimeout = p.suspect || StateTransitions.Defaults.suspect;
+    this.faultyTimeout = p.faulty || StateTransitions.Defaults.faulty;
+    this.tombstoneTimeout = p.tombstone || StateTransitions.Defaults.tombstone;
 
     this.logger = this.ringpop.loggerFactory.getLogger('statetransitions');
 
@@ -54,6 +56,21 @@ StateTransitions.prototype.scheduleSuspectToFaulty = function scheduleSuspectToF
     this.schedule(member, Member.Status.suspect, this.suspectTimeout, function() {
         self.ringpop.membership.makeFaulty(member.address,
             member.incarnationNumber);
+    });
+};
+
+StateTransitions.prototype.scheduleFaultyToTombstone = function scheduleFaultyToTombstone(member) {
+    var self = this;
+    this.schedule(member, Member.Status.faulty, this.faultyTimeout, function() {
+        self.ringpop.membership.makeTombstone(member.address,
+            member.incarnationNumber);
+    });
+};
+
+StateTransitions.prototype.scheduleTombstoneToEvict = function scheduleTombstoneToEvict(member) {
+    var self = this;
+    this.schedule(member, Member.Status.tombstone, this.tombstoneTimeout, function() {
+        self.ringpop.membership.evict(member.address);
     });
 };
 
@@ -141,7 +158,9 @@ StateTransitions.prototype.disable = function disable() {
 };
 
 StateTransitions.Defaults = {
-    suspect: 5000
+    suspect: 5 * 1000, //5s
+    faulty: 24 * 60 * 60 * 1000, //24h
+    tombstone: 60 * 1000, //60s
 };
 
 module.exports = StateTransitions;

--- a/lib/gossip/state_transitions.js
+++ b/lib/gossip/state_transitions.js
@@ -21,14 +21,15 @@
 'use strict';
 
 var Member = require('../membership/member');
+var _ = require('underscore');
 
 function StateTransitions(options) {
     this.ringpop = options.ringpop;
 
-    var p = options.periods || {};
-    this.suspectTimeout = p.suspect || StateTransitions.Defaults.suspect;
-    this.faultyTimeout = p.faulty || StateTransitions.Defaults.faulty;
-    this.tombstoneTimeout = p.tombstone || StateTransitions.Defaults.tombstone;
+    var p = _.defaults({}, options.periods, StateTransitions.Defaults);
+    this.suspectTimeout = p.suspect;
+    this.faultyTimeout = p.faulty;
+    this.tombstoneTimeout = p.tombstone;
 
     this.logger = this.ringpop.loggerFactory.getLogger('statetransitions');
 
@@ -53,7 +54,7 @@ StateTransitions.prototype.enable = function enable() {
 
 StateTransitions.prototype.scheduleSuspectToFaulty = function scheduleSuspectToFaulty(member) {
     var self = this;
-    this.schedule(member, Member.Status.suspect, this.suspectTimeout, function() {
+    this.schedule(member, Member.Status.suspect, this.suspectTimeout, function suspectToFaulty() {
         self.ringpop.membership.makeFaulty(member.address,
             member.incarnationNumber);
     });
@@ -61,7 +62,7 @@ StateTransitions.prototype.scheduleSuspectToFaulty = function scheduleSuspectToF
 
 StateTransitions.prototype.scheduleFaultyToTombstone = function scheduleFaultyToTombstone(member) {
     var self = this;
-    this.schedule(member, Member.Status.faulty, this.faultyTimeout, function() {
+    this.schedule(member, Member.Status.faulty, this.faultyTimeout, function faultyToTombstone() {
         self.ringpop.membership.makeTombstone(member.address,
             member.incarnationNumber);
     });
@@ -69,7 +70,7 @@ StateTransitions.prototype.scheduleFaultyToTombstone = function scheduleFaultyTo
 
 StateTransitions.prototype.scheduleTombstoneToEvict = function scheduleTombstoneToEvict(member) {
     var self = this;
-    this.schedule(member, Member.Status.tombstone, this.tombstoneTimeout, function() {
+    this.schedule(member, Member.Status.tombstone, this.tombstoneTimeout, function tombstoneToEvict() {
         self.ringpop.membership.evict(member.address);
     });
 };
@@ -158,9 +159,9 @@ StateTransitions.prototype.disable = function disable() {
 };
 
 StateTransitions.Defaults = {
-    suspect: 5 * 1000, //5s
-    faulty: 24 * 60 * 60 * 1000, //24h
-    tombstone: 60 * 1000, //60s
+    suspect: 5 * 1000, // 5s
+    faulty: 24 * 60 * 60 * 1000, // 24h
+    tombstone: 60 * 1000, // 60s
 };
 
 module.exports = StateTransitions;

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -132,6 +132,12 @@ Membership.prototype.generateChecksumString = function generateChecksumString() 
     for (var i = 0; i < sortedMembers.length; ++i) {
         var member = sortedMembers[i];
 
+        // Don't include Tombstone nodes in the checksum to avoid
+        // bringing them back to life through full syncs
+        if (member.status === Member.Status.tombstone) {
+            continue;
+        }
+
         checksumString += member.address +
             member.status +
             member.incarnationNumber + ';';
@@ -230,6 +236,31 @@ Membership.prototype.makeSuspect = function makeSuspect(address, incarnationNumb
         Member.Status.suspect, this.localMember));
 };
 
+Membership.prototype.makeTombstone = function makeTombstone(address, incarnationNumber) {
+    this.ringpop.stat('increment', 'make-tombstone');
+    return this._updateMember(new Update(address, incarnationNumber,
+        Member.Status.tombstone, this.localMember));
+};
+
+Membership.prototype.removeMember = function removeMember(address) {
+    var hasMember = _.has(this.membersByAddress, address);
+    if (!hasMember) {
+        return;
+    }
+    var memberToDelete = this.membersByAddress[address];
+    delete this.membersByAddress[address];
+    this.members = _.without(this.members, memberToDelete);
+    this.computeChecksum();
+};
+
+Membership.prototype.evict = function evict(address) {
+    if (this.localMember.address === address) {
+        this.logger.error('ringpop tried to evict the local member from the memberlist, action has been prevented');
+        return;
+    }
+    this.removeMember(address);
+};
+
 // Sets stashed updates. set() is different from update() in that it bypasses
 // evaluating membership update rules and places new members at the end of the
 // membership list rather than in a random position as defined by
@@ -259,6 +290,9 @@ Membership.prototype.set = function set() {
 
     for (var i = 0; i < updates.length; i++) {
         var update = updates[i];
+        if (update.status === Member.Status.tombstone) {
+            continue;
+        }
         var member = this._createMember(update);
         this.members.push(member);
         this.membersByAddress[member.address] = member;
@@ -304,6 +338,15 @@ Membership.prototype.update = function update(changes, isLocal) {
         var member = this.findMemberByAddress(change.address);
 
         if (!member) {
+            // avoid indefinite tombstones by not creating new nodes
+            // directly in this state
+            if (change.status === Member.Status.tombstone) {
+                self.logger.info('skipping tombstone update:', {
+                    local: self.ringpop.whoami(),
+                    remote: change.source
+                });
+                continue;
+            }
             member = this._createMember(change);
 
             // localMember is carried around as a convenience.

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -290,6 +290,8 @@ Membership.prototype.set = function set() {
 
     for (var i = 0; i < updates.length; i++) {
         var update = updates[i];
+        // avoid indefinite tombstones by not creating new nodes directly in
+        // this state when applying stashed updates
         if (update.status === Member.Status.tombstone) {
             continue;
         }
@@ -341,7 +343,7 @@ Membership.prototype.update = function update(changes, isLocal) {
             // avoid indefinite tombstones by not creating new nodes
             // directly in this state
             if (change.status === Member.Status.tombstone) {
-                self.logger.info('skipping tombstone update:', {
+                self.logger.info('skipping tombstone update', {
                     local: self.ringpop.whoami(),
                     remote: change.source
                 });

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -173,7 +173,7 @@ Member.prototype._applyUpdatePenalty = function _applyUpdatePenalty() {
 Member.prototype._isLocalOverride = function _isLocalOverride(update) {
     var self = this;
 
-    return isLocalFaultyOverride() || isLocalSuspectOverride();
+    return isLocalFaultyOverride() || isLocalSuspectOverride() || isLocalTombstoneOverride();
 
     function isLocalFaultyOverride() {
         return self.ringpop.whoami() === self.address &&
@@ -184,13 +184,18 @@ Member.prototype._isLocalOverride = function _isLocalOverride(update) {
         return self.ringpop.whoami() === self.address &&
             update.status === Member.Status.suspect;
     }
+
+    function isLocalTombstoneOverride() {
+        return self.ringpop.whoami() === self.address &&
+            update.status === Member.Status.tombstone;
+    }
 };
 
 Member.prototype._isOtherOverride = function _isOtherOverride(update) {
     var self = this;
 
     return isAliveOverride() || isSuspectOverride() || isFaultyOverride() ||
-        isLeaveOverride();
+        isLeaveOverride() || isTombstoneOverride();
 
     function isAliveOverride() {
         return update.status === 'alive' &&
@@ -202,6 +207,7 @@ Member.prototype._isOtherOverride = function _isOtherOverride(update) {
         return update.status === 'faulty' &&
             ((self.status === 'suspect' && update.incarnationNumber >= self.incarnationNumber) ||
             (self.status === 'faulty' && update.incarnationNumber > self.incarnationNumber) ||
+            (self.status === 'tombstone' && update.incarnationNumber > self.incarnationNumber) ||
             (self.status === 'alive' && update.incarnationNumber >= self.incarnationNumber));
     }
 
@@ -215,7 +221,17 @@ Member.prototype._isOtherOverride = function _isOtherOverride(update) {
         return update.status === 'suspect' &&
             ((self.status === 'suspect' && update.incarnationNumber > self.incarnationNumber) ||
             (self.status === 'faulty' && update.incarnationNumber > self.incarnationNumber) ||
+            (self.status === 'tombstone' && update.incarnationNumber > self.incarnationNumber) ||
             (self.status === 'alive' && update.incarnationNumber >= self.incarnationNumber));
+    }
+
+    function isTombstoneOverride() {
+        return update.status === 'tombstone' &&
+            ((self.status === 'suspect' && update.incarnationNumber >= self.incarnationNumber) ||
+             (self.status === 'faulty' && update.incarnationNumber >= self.incarnationNumber) ||
+             (self.status === 'tombstone' && update.incarnationNumber > self.incarnationNumber) ||
+             (self.status === 'alive' && update.incarnationNumber >= self.incarnationNumber));
+
     }
 };
 
@@ -223,7 +239,8 @@ Member.Status = {
     alive: 'alive',
     faulty: 'faulty',
     leave: 'leave',
-    suspect: 'suspect'
+    suspect: 'suspect',
+    tombstone: 'tombstone'
 };
 
 module.exports = Member;

--- a/lib/on_membership_event.js
+++ b/lib/on_membership_event.js
@@ -116,12 +116,17 @@ function createUpdatedHandlerForGossip(ringpop) {
             var update = updates[i];
             switch (update.status) {
                 case Member.Status.alive:
-                case Member.Status.faulty:
                 case Member.Status.leave:
                     ringpop.stateTransitions.cancel(update);
                     break;
                 case Member.Status.suspect:
                     ringpop.stateTransitions.scheduleSuspectToFaulty(update);
+                    break;
+                case Member.Status.faulty:
+                    ringpop.stateTransitions.scheduleFaultyToTombstone(update);
+                    break;
+                case Member.Status.tombstone:
+                    ringpop.stateTransitions.scheduleTombstoneToEvict(update);
                     break;
             }
 
@@ -137,10 +142,12 @@ function createUpdatedHandlerForRing(ringpop) {
             var update = updates[i];
             switch (update.status) {
                 case Member.Status.alive:
+                // TODO: Faulty should be here
                     serversToAdd.push(update.address);
                     break;
                 case Member.Status.faulty:
                 case Member.Status.leave:
+                case Member.Status.tombstone:
                     serversToRemove.push(update.address);
                     break;
             }

--- a/lib/on_membership_event.js
+++ b/lib/on_membership_event.js
@@ -142,7 +142,7 @@ function createUpdatedHandlerForRing(ringpop) {
             var update = updates[i];
             switch (update.status) {
                 case Member.Status.alive:
-                // TODO: Faulty should be here
+                case Member.Status.suspect:
                     serversToAdd.push(update.address);
                     break;
                 case Member.Status.faulty:

--- a/main.js
+++ b/main.js
@@ -49,7 +49,11 @@ function main(args) {
             serviceName: 'ringpop',
             trace: false
         }),
-        isCrossPlatform: true
+        isCrossPlatform: true,
+        stateTimeouts: {
+            faulty: 5 * 1000, //5s
+            tombstone: 5 * 1000 //5s
+        }
     });
 
     ringpop.setupChannel();

--- a/main.js
+++ b/main.js
@@ -51,8 +51,8 @@ function main(args) {
         }),
         isCrossPlatform: true,
         stateTimeouts: {
-            faulty: 5 * 1000, //5s
-            tombstone: 5 * 1000 //5s
+            faulty: 5 * 1000, // 5s
+            tombstone: 5 * 1000 // 5s
         }
     });
 

--- a/server/admin/member.js
+++ b/server/admin/member.js
@@ -108,14 +108,16 @@ function createReapHandler(ringpop) {
             return;
         }
 
+        var reaped = 0;
         ringpop.membership.members.forEach(function(member) {
             if (member.status === Member.Status.faulty) {
+                reaped++;
                 ringpop.membership.makeTombstone(member.address, member.incarnationNumber);
             }
         });
 
         process.nextTick(function() {
-            callback(null, null, JSON.stringify({'status': 'ok'}));
+            callback(null, null, JSON.stringify({'reaped': reaped}));
         });
     };
 }

--- a/server/admin/member.js
+++ b/server/admin/member.js
@@ -99,6 +99,27 @@ function createLeaveHandler(ringpop) {
     };
 }
 
+function createReapHandler(ringpop) {
+    return function handleReap(arg1, arg2, hostInfo, callback) {
+        if (!ringpop.membership.localMember) {
+            process.nextTick(function() {
+                callback(errors.InvalidLocalMemberError());
+            });
+            return;
+        }
+
+        ringpop.membership.members.forEach(function(member) {
+            if (member.status === Member.Status.faulty) {
+                ringpop.membership.makeTombstone(member.address, member.incarnationNumber);
+            }
+        });
+
+        process.nextTick(function() {
+            callback(null, null, JSON.stringify({'status': 'ok'}));
+        });
+    };
+}
+
 module.exports = {
     memberJoin: {
         endpoint: '/admin/member/join',
@@ -107,5 +128,9 @@ module.exports = {
     memberLeave: {
         endpoint: '/admin/member/leave',
         handler: createLeaveHandler
+    },
+    reap: {
+        endpoint: '/admin/reap',
+        handler: createReapHandler
     }
 };

--- a/server/admin/member.js
+++ b/server/admin/member.js
@@ -102,22 +102,22 @@ function createLeaveHandler(ringpop) {
 function createReapHandler(ringpop) {
     return function handleReap(arg1, arg2, hostInfo, callback) {
         if (!ringpop.membership.localMember) {
-            process.nextTick(function() {
+            process.nextTick(function sendError() {
                 callback(errors.InvalidLocalMemberError());
             });
             return;
         }
 
         var reaped = 0;
-        ringpop.membership.members.forEach(function(member) {
+        ringpop.membership.members.forEach(function reapMember(member) {
             if (member.status === Member.Status.faulty) {
                 reaped++;
                 ringpop.membership.makeTombstone(member.address, member.incarnationNumber);
             }
         });
 
-        process.nextTick(function() {
-            callback(null, null, JSON.stringify({'reaped': reaped}));
+        process.nextTick(function sendResponse() {
+            callback(null, null, JSON.stringify({'status': 'ok', 'reaped': reaped}));
         });
     };
 }

--- a/test/run-shared-integration-tests
+++ b/test/run-shared-integration-tests
@@ -78,7 +78,7 @@ run-test-for-cluster-size() {
     # Run the tests and buffer the output to a log file. We'll display it later
     # if the test fails. This avoids interleaving of output to the terminal
     # when tests are running in parallel.
-    node "${ringpop_common_dir}/test/it-tests.js" \
+    node "${ringpop_common_dir}/test/it-tests.js" --enable-feature reaping-faulty-nodes \
         -s "[$1]" "${project_root}/main.js" &>$output_file || err=$?
 
     if [ $PIPESTATUS -gt 0 ]; then

--- a/test/unit/dissemination-test.js
+++ b/test/unit/dissemination-test.js
@@ -173,9 +173,6 @@ testRingpop('tombstone has priority vs other states', function t(deps, assert) {
     membership.makeTombstone(addrSuspect, incNo);
     membership.makeTombstone(addrFaulty, incNo);
 
-    // Number of expected changes
-    var expectedNumberOfChanges = membership.getMemberCount() - 1;
-
     assert.plan(3);
     dissemination.issueAsSender(function issue(changes, onIssue) {
         changes.forEach(function(change) {

--- a/test/unit/dissemination-test.js
+++ b/test/unit/dissemination-test.js
@@ -153,6 +153,38 @@ testRingpop('raise piggyback counter on issueAsSender', function t(deps, assert)
 
 });
 
+testRingpop('tombstone has priority vs other states', function t(deps, assert) {
+    var membership = deps.membership;
+    var dissemination = deps.dissemination;
+
+    var addrAlive = '127.0.0.1:3001';
+    var addrSuspect = '127.0.0.1:3002';
+    var addrFaulty = '127.0.0.1:3003';
+    var incNo = Date.now();
+
+    // Clear changes to start fresh, otherwise local member changes
+    // recorded during bootstrap phase would have been issued.
+    dissemination.clearChanges();
+
+    membership.makeAlive(addrAlive, incNo);
+    membership.makeSuspect(addrSuspect, incNo);
+    membership.makeFaulty(addrFaulty, incNo);
+    membership.makeTombstone(addrAlive, incNo);
+    membership.makeTombstone(addrSuspect, incNo);
+    membership.makeTombstone(addrFaulty, incNo);
+
+    // Number of expected changes
+    var expectedNumberOfChanges = membership.getMemberCount() - 1;
+
+    assert.plan(3);
+    dissemination.issueAsSender(function issue(changes, onIssue) {
+        changes.forEach(function(change) {
+            assert.equal('tombstone', change.status, 'state should be tombstone');
+        });
+    });
+});
+
+
 testRingpop('issueAsReceiver returns whether a full sync is made', function t(deps, assert) {
     var membership = deps.membership;
     var dissemination = deps.dissemination;

--- a/test/unit/gossip_test.js
+++ b/test/unit/gossip_test.js
@@ -197,3 +197,47 @@ testRingpop({
         done();
     }, stateTransitions.period + 1);
 });
+
+testRingpop({
+    async: true
+}, 'marks member tombstone after faulty period', function t(deps, assert, done) {
+    assert.plan(1);
+
+    var membership = deps.membership;
+    var stateTransitions = deps.stateTransitions;
+
+    var address = '127.0.0.1:3001';
+    membership.makeAlive(address, Date.now());
+
+    var member = membership.findMemberByAddress(address);
+
+    stateTransitions.faultyTimeout = 1;
+    stateTransitions.scheduleFaultyToTombstone(member);
+
+    setTimeout(function onTimeout() {
+        assert.equals(member.status, Member.Status.tombstone, 'member is tombstone');
+        done();
+    }, stateTransitions.period + 1);
+});
+
+testRingpop({
+    async: true
+}, 'evict member after tombstone period', function t(deps, assert, done) {
+    assert.plan(1);
+
+    var membership = deps.membership;
+    var stateTransitions = deps.stateTransitions;
+
+    var address = '127.0.0.1:3001';
+    membership.makeAlive(address, Date.now());
+
+    var member = membership.findMemberByAddress(address);
+
+    stateTransitions.tombstoneTimeout = 1;
+    stateTransitions.scheduleTombstoneToEvict(member);
+
+    setTimeout(function onTimeout() {
+        assert.notOk(membership.findMemberByAddress(address), 'member was evicted');
+        done();
+    }, stateTransitions.period + 1);
+});

--- a/test/unit/gossip_test.js
+++ b/test/unit/gossip_test.js
@@ -217,7 +217,7 @@ testRingpop({
     setTimeout(function onTimeout() {
         assert.equals(member.status, Member.Status.tombstone, 'member is tombstone');
         done();
-    }, stateTransitions.period + 1);
+    }, stateTransitions.faultyTimeout + 1);
 });
 
 testRingpop({
@@ -239,5 +239,5 @@ testRingpop({
     setTimeout(function onTimeout() {
         assert.notOk(membership.findMemberByAddress(address), 'member was evicted');
         done();
-    }, stateTransitions.period + 1);
+    }, stateTransitions.tombstoneTimeout + 1);
 });

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -443,7 +443,7 @@ testRingpop('max piggyback not adjusted on membership update', function t(deps, 
 
     var address = '127.0.0.1:3002';
     var incarnationNumber = Date.now();
-    membership.makeSuspect(address, incarnationNumber);
+    membership.makeFaulty(address, incarnationNumber);
 });
 
 testRingpop('max piggyback adjusted on new members', function t(deps, assert) {

--- a/test/unit/membership_test.js
+++ b/test/unit/membership_test.js
@@ -146,6 +146,33 @@ testRingpop('leave does not cause neverending updates', function t(deps, assert)
     assert.equals(updates.length, 0, 'no leave update applied');
 });
 
+testRingpop('evict removes a member', function t(deps, assert) {
+    var membership = deps.membership;
+
+    var addr = '127.0.0.1:3001';
+    var incNo = Date.now();
+
+    membership.makeAlive(addr, incNo);
+    assert.ok(membership.getMemberAt(1), 'alive applied');
+    assert.ok(membership.findMemberByAddress(addr), 'alive applied');
+
+    membership.evict(addr);
+    assert.notOk(membership.getMemberAt(1), 'evict applied');
+    assert.notOk(membership.findMemberByAddress(addr), 'evict applied');
+});
+
+testRingpop('cannot evict self', function t(deps, assert) {
+    var membership = deps.membership;
+
+    var localAddr = '127.0.0.1:3000';
+    var incNo = Date.now();
+
+    membership.makeAlive(localAddr, incNo);
+    membership.evict(localAddr);
+    assert.ok(membership.getMemberAt(0), 'evict not applied');
+    assert.ok(membership.findMemberByAddress(localAddr), 'evict not applied');
+});
+
 testRingpop('generate checksums string preserves order of members', function t(deps, assert) {
     var membership = deps.membership;
 


### PR DESCRIPTION
This adds the reaping faulty nodes on top of the tombstone wire compatibility (which is landed). It's very similar to the [Go implementation](https://github.com/uber/ringpop-go/pull/132) and includes the admin endpoint.