### PR TITLE
Refactor ping-sender to support sendPingWithChanges

### DIFF
--- a/lib/gossip/index.js
+++ b/lib/gossip/index.js
@@ -22,7 +22,7 @@
 
 var metrics = require('metrics');
 var GossipEvents = require('./events.js');
-var sendPing = require('./ping-sender.js');
+var sendPing = require('./ping-sender.js').sendPing;
 var sendPingReqs = require('./ping-req-sender.js');
 
 var util = require('util');

--- a/lib/gossip/ping-sender.js
+++ b/lib/gossip/ping-sender.js
@@ -61,6 +61,11 @@ PingSender.prototype.onPing = function onPing(err, res, callback) {
 PingSender.prototype.sendChanges = function sendChanges(changes, callback) {
     var self = this;
 
+    self.gossipLogger.info('ringpop ping send', {
+        local: self.ring.whoami(),
+        member: self.address,
+        changes: changes
+    });
     self.ring.client.protocolPing({
         host: self.address,
         retryLimit: self.ring.config.get('tchannelRetryLimit'),
@@ -77,7 +82,7 @@ PingSender.prototype.send = function send(callback) {
     var self = this;
 
     self.ring.dissemination.issueAsSender(function issues(changes, onIssue) {
-        self.sendChanges(changes, function onPing(err, res) {
+        self.sendChanges(changes, function changesSent(err, res) {
             onIssue(err);
             self.onPing(err, res, callback);
         });

--- a/lib/gossip/ping-sender.js
+++ b/lib/gossip/ping-sender.js
@@ -20,15 +20,14 @@
 
 'use strict';
 
-function PingSender(ring, member, callback) {
+function PingSender(ring, member) {
     this.ring = ring;
     this.address = member.address || member;
-    this.callback = callback;
     this.gossipLogger = this.ring.loggerFactory.getLogger('gossip');
 }
 
-PingSender.prototype.onPing = function onPing(err, res) {
-    if (!this.callback) {
+PingSender.prototype.onPing = function onPing(err, res, callback) {
+    if (!callback) {
         return;
     }
 
@@ -38,15 +37,13 @@ PingSender.prototype.onPing = function onPing(err, res) {
             member: this.address,
             err: err
         });
-        this.callback(err);
-        this.callback = null;
+        callback(err);
         return;
     }
 
     if (!res || !res.changes) {
         this.gossipLogger.warn('ping failed member=' + this.address + ' bad response body=' + res);
-        this.callback(new Error('Ping failed: no response'));
-        this.callback = null;
+        callback(new Error('Ping failed: no response'));
         return;
     }
 
@@ -57,40 +54,41 @@ PingSender.prototype.onPing = function onPing(err, res) {
         res: res
     });
     this.ring.membership.update(res.changes);
-    this.callback(err, res);
-    this.callback = null;
+    callback(err, res);
     return;
 };
 
-PingSender.prototype.send = function send() {
+PingSender.prototype.sendChanges = function sendChanges(changes, callback) {
     var self = this;
 
-    self.ring.dissemination.issueAsSender(function issue(changes, onIssue) {
-        self.gossipLogger.info('ringpop ping send', {
-            local: self.ring.whoami(),
-            member: self.address,
-            changes: changes
-        });
+    self.ring.client.protocolPing({
+        host: self.address,
+        retryLimit: self.ring.config.get('tchannelRetryLimit'),
+        timeout: self.ring.pingTimeout
+    }, {
+        checksum: self.ring.membership.checksum,
+        changes: changes,
+        source: self.ring.whoami(),
+        sourceIncarnationNumber: self.ring.membership.getIncarnationNumber()
+    }, callback);
+};
 
-        self.ring.client.protocolPing({
-            host: self.address,
-            retryLimit: self.ring.config.get('tchannelRetryLimit'),
-            timeout: self.ring.pingTimeout
-        }, {
-            checksum: self.ring.membership.checksum,
-            changes: changes,
-            source: self.ring.whoami(),
-            sourceIncarnationNumber: self.ring.membership.getIncarnationNumber()
-        }, function onPing(err, res) {
+PingSender.prototype.send = function send(callback) {
+    var self = this;
+
+    self.ring.dissemination.issueAsSender(function issues(changes, onIssue) {
+        self.sendChanges(changes, function onPing(err, res) {
             onIssue(err);
-            self.onPing(err, res);
+            self.onPing(err, res, callback);
         });
     });
 };
 
-module.exports = function sendPing(opts, callback) {
+PingSender.sendPing = function sendPing(opts, callback) {
     opts.ringpop.stat('increment', 'ping.send');
 
-    var sender = new PingSender(opts.ringpop, opts.target, callback);
-    sender.send();
+    var sender = new PingSender(opts.ringpop, opts.target);
+    sender.send(callback);
 };
+
+module.exports = PingSender;

--- a/server/protocol/ping-req.js
+++ b/server/protocol/ping-req.js
@@ -21,7 +21,7 @@
 'use strict';
 
 var errors = require('../../lib/errors.js');
-var sendPing = require('../../lib/gossip/ping-sender.js');
+var sendPing = require('../../lib/gossip/ping-sender.js').sendPing;
 
 module.exports = function createPingReqHandler(ringpop) {
     var gossipLogger = ringpop.loggerFactory.getLogger('gossip');

--- a/test/integration/not-ready-test.js
+++ b/test/integration/not-ready-test.js
@@ -21,7 +21,7 @@
 'use strict';
 
 var testRingpopCluster = require('../lib/test-ringpop-cluster.js');
-var sendPing = require('../../lib/gossip/ping-sender.js');
+var sendPing = require('../../lib/gossip/ping-sender.js').sendPing;
 var sendPingReqs = require('../../lib/gossip/ping-req-sender.js');
 
 // If a node has bad bootstrap hosts it will be unable to join. We use this


### PR DESCRIPTION
To support partition healing we need to manually specify the changes sent during a ping-request (instead of gossiping the changes from `dissemination`). In this case we also don't need to update the membership-list.
Both changes are required to be able to send and retrieve changes without marking all the members as faulty before merging partitions.