### PR TITLE
Fix some timers in gossip unittests

### DIFF
--- a/test/unit/gossip_test.js
+++ b/test/unit/gossip_test.js
@@ -195,5 +195,5 @@ testRingpop({
     setTimeout(function onTimeout() {
         assert.equals(member.status, Member.Status.faulty, 'member is faulty');
         done();
-    }, stateTransitions.period + 1);
+    }, stateTransitions.suspectTimeout + 1);
 });


### PR DESCRIPTION
`period` was renamed to `supectTimeout` in a previous commit.