### PR TITLE
Run tests in sub-directories of unit and integration as well

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -18,4 +18,4 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-require('glob').sync(__dirname + '/{unit,integration}/*{_test,-test}.js').forEach(require);
+require('glob').sync(__dirname + '/{unit,integration}/**/*{_test,-test}.js').forEach(require);


### PR DESCRIPTION
Due to an incorrect glob-syntax, the tests in `tests/unit/server` were not running.