### PR TITLE
Periodical partition healing

### DIFF
--- a/config.js
+++ b/config.js
@@ -132,7 +132,17 @@ Config.prototype._seed = function _seed(seed) {
     seedOrDefault('inflightClientRequestsLimit', 100);
 
     // Healer config
+    // Maximum number of heal failures in one period.
     seedOrDefault('discoverProviderHealerMaxFailures', 10);
+    // The time of a period in ms.
+    seedOrDefault('discoverProviderHealerPeriod', 30000);
+    // The base probability of a node to run in a period: the average number
+    // of nodes in each period that will perform the heal algorithm in a period.
+    // E.g. if there are 100 nodes and the base probability is 3, there is a
+    // chance of 3/100 that a node will run.
+    seedOrDefault('discoverProviderHealerBaseProbability', 3);
+    // Enable the period healer.
+    seedOrDefault('discoverProviderHealerPeriodicEnabled', true);
 
     function seedOrDefault(name, defaultVal, validator, reason) {
         var seedVal = seed[name];

--- a/lib/on_ringpop_event.js
+++ b/lib/on_ringpop_event.js
@@ -25,6 +25,7 @@ function createDestroyedHandler(ringpop) {
         ringpop.lagSampler.stop();
         ringpop.membership.stopDampScoreDecayer();
         ringpop.damper.destroy();
+        ringpop.healer.stop();
     };
 }
 
@@ -36,6 +37,10 @@ function createReadyHandler(ringpop) {
 
         if (ringpop.config.get('backpressureEnabled')) {
             ringpop.lagSampler.start();
+        }
+
+        if (ringpop.config.get('discoverProviderHealerPeriodicEnabled')) {
+            ringpop.healer.start();
         }
     };
 }

--- a/lib/partition_healing/discover_provider_healer.js
+++ b/lib/partition_healing/discover_provider_healer.js
@@ -22,6 +22,7 @@
 
 var _ = require('underscore');
 var async = require('async');
+var globalTimers = require('timers');
 var Member = require('../membership/member');
 var Healer = require('./healer');
 var TypedError = require('error/typed');
@@ -43,9 +44,62 @@ var Errors = {
  */
 function DiscoverProviderHealer(ringpop) {
     DiscoverProviderHealer.super_.call(this, ringpop);
+    this.timers = ringpop.timers || globalTimers;
+
     this.maxNumberOfFailures = ringpop.config.get('discoverProviderHealerMaxFailures');
+    this.healPeriod = ringpop.config.get('discoverProviderHealerPeriod');
+    this.baseProbability = ringpop.config.get('discoverProviderHealerBaseProbability');
+
+    this.previousHostListSize = 0;
+    this.healTimer = null;
+    this.isStopped = true;
 }
 require('util').inherits(DiscoverProviderHealer, Healer);
+
+DiscoverProviderHealer.prototype.start = function start() {
+    if (this.healTimer) {
+        return;
+    }
+    this.isStopped = false;
+    this._run();
+};
+
+DiscoverProviderHealer.prototype.stop = function stop() {
+    this.isStopped = true;
+    if (this.healTimer) {
+        this.timers.clearTimeout(this.healTimer);
+        this.healTimer = null;
+    }
+};
+
+DiscoverProviderHealer.prototype._run = function _run() {
+    var self = this;
+
+    if (self.isStopped) {
+        return;
+    }
+
+    if (self.healTimer && Math.random() < probability()) {
+        self.heal(function onHeal() {
+            scheduleNext();
+        });
+    } else {
+        scheduleNext();
+    }
+
+    function scheduleNext() {
+        self.healTimer = self.timers.setTimeout(function onHealTimer() {
+            self._run();
+        }, self.healPeriod);
+    }
+
+    function probability() {
+        var membership = self.ringpop.membership;
+        var pingableMembers = _.filter(membership.members, membership.isPingable.bind(membership)).length;
+
+        return self.baseProbability / Math.max(1, pingableMembers, self.previousHostListSize);
+    }
+};
 
 /**
  * Perform a heal-operation using the discover provider (@see RingPop#discoverProvider).
@@ -88,6 +142,7 @@ DiscoverProviderHealer.prototype.heal = function heal(callback) {
             });
             return callback(err);
         }
+        self.previousHostListSize = hosts.length;
 
         var potentialTargets = self._getTargets(hosts);
         var targets = [];

--- a/test/unit/server/admin/partition_healing_test.js
+++ b/test/unit/server/admin/partition_healing_test.js
@@ -32,11 +32,9 @@ test('healing via discovery provider', function t(assert) {
         hostPort: '127.0.0.1:3000'
     });
 
-    ringpop.healer = {
-        heal: function heal(cb) {
-            assert.pass('endpoint calls heal');
-            cb(null);
-        }
+    ringpop.healer.heal = function heal(cb) {
+        assert.pass('endpoint calls heal');
+        cb(null);
     };
 
     var handleHeal = partitionHealingHandlers.healViaDiscoverProvider.handler(ringpop);
@@ -55,11 +53,9 @@ test('healing via discovery provider - error path', function t(assert) {
         hostPort: '127.0.0.1:3000'
     });
 
-    ringpop.healer = {
-        heal: function heal(cb) {
-            assert.pass('endpoint calls heal');
-            cb('error'); 
-        }
+    ringpop.healer.heal = function heal(cb) {
+        assert.pass('endpoint calls heal');
+        cb('error');
     };
 
     var handleHeal = partitionHealingHandlers.healViaDiscoverProvider.handler(ringpop);


### PR DESCRIPTION
Try to heal partitions periodically. By using a probability variable, on average `x` amount of nodes will try to perform the heal every `y` seconds (where `x` = `discoverProviderHealerBaseProbability`, and `y` = `discoverProviderHealerPeriod`). 
The defaults are 3 nodes every 30 seconds. 