### PR TITLE
Rename Dissemination.fullSync to membershipAsChanges

### DIFF
--- a/lib/gossip/dissemination.js
+++ b/lib/gossip/dissemination.js
@@ -62,7 +62,7 @@ Dissemination.prototype.clearChanges = function clearChanges() {
     this.changes = {};
 };
 
-Dissemination.prototype.fullSync = function fullSync() {
+Dissemination.prototype.membershipAsChanges = function membershipAsChanges() {
     var changes = [];
 
     for (var i = 0; i < this.ringpop.membership.members.length; i++) {
@@ -124,7 +124,7 @@ Dissemination.prototype.issueAsReceiver = function issueAsReceiver(senderAddr, s
         });
 
         fullSync = true;
-        membershipChanges = this.fullSync();
+        membershipChanges = this.membershipAsChanges();
     }
 
     // Note, we blindly raise the piggyback counter because the protocol does

--- a/server/protocol/join.js
+++ b/server/protocol/join.js
@@ -140,7 +140,7 @@ module.exports = function createJoinHandler(ringpop) {
         callback(null, null, {
             app: ringpop.app,
             coordinator: ringpop.whoami(),
-            membership: ringpop.dissemination.fullSync(),
+            membership: ringpop.dissemination.membershipAsChanges(),
             membershipChecksum: ringpop.membership.checksum
         });
     };

--- a/test/integration/join-test.js
+++ b/test/integration/join-test.js
@@ -146,7 +146,7 @@ testRingpopCluster({
                 res.sendOk(null, JSON.stringify({
                     app: 'test',
                     coordinator: cluster[1].whoami(),
-                    membership: cluster[1].dissemination.fullSync()
+                    membership: cluster[1].dissemination.membershipAsChanges()
                 }));
             }, 100);
         });

--- a/test/unit/dissemination-test.js
+++ b/test/unit/dissemination-test.js
@@ -23,19 +23,19 @@
 var testRingpop = require('../lib/test-ringpop');
 var mock = require('../mock');
 
-testRingpop('full sync includes all members', function t(deps, assert) {
+testRingpop('member ship as changes includes all members', function t(deps, assert) {
     var membership = deps.membership;
     var dissemination = deps.dissemination;
 
     membership.makeAlive('127.0.0.1:3001', Date.now());
     membership.makeAlive('127.0.0.1:3002', Date.now());
 
-    var fullSync = dissemination.fullSync();
-    var addrs = fullSync.map(function mapMember(member) {
+    var membershipAsChanges = dissemination.membershipAsChanges();
+    var addrs = membershipAsChanges.map(function mapMember(member) {
         return member.address;
     });
 
-    assert.equals(fullSync.length, 3, 'all 3 members');
+    assert.equals(membershipAsChanges.length, 3, 'all 3 members');
     assert.ok(addrs.indexOf('127.0.0.1:3000') !== -1, 'first member included');
     assert.ok(addrs.indexOf('127.0.0.1:3001') !== -1, 'second member included');
     assert.ok(addrs.indexOf('127.0.0.1:3002') !== -1, 'third member included');
@@ -216,7 +216,7 @@ testRingpop('tryStartReverseFullSync keeps track of running jobs', function t(de
             assert.equal(opts.host, target, 'send join to remote');
 
             callback(null, {
-                membership: dissemination.fullSync(),
+                membership: dissemination.membershipAsChanges(),
                 membershipChecksum: membership.checksum
             });
         },
@@ -248,7 +248,7 @@ testRingpop('tryStartReverseFullSync keeps track of running jobs', function t(de
             }
 
             callback(null, {
-                membership: dissemination.fullSync(),
+                membership: dissemination.membershipAsChanges(),
                 membershipChecksum: membership.checksum
             });
         },
@@ -352,7 +352,7 @@ testRingpop('tryStartReverseFullSync send join request to target node', function
             assert.equal(opts.timeout, timeout, 'send join with correct timeout');
 
             callback(null, {
-                membership: dissemination.fullSync(),
+                membership: dissemination.membershipAsChanges(),
                 membershipChecksum: membership.checksum
             });
         },


### PR DESCRIPTION
In the ringpop-go we renamed fullSync to MembershipAsChanges. This pull-request is doing the same thing in ringpop-node because that's better describing what the function does: returning the full membership as changes.
