### PR TITLE
Don't use async library in production-code

### DIFF
--- a/lib/partition_healing/discover_provider_healer.js
+++ b/lib/partition_healing/discover_provider_healer.js
@@ -21,7 +21,6 @@
 'use strict';
 
 var _ = require('underscore');
-var async = require('async');
 var globalTimers = require('timers');
 var Member = require('../membership/member');
 var Healer = require('./healer');
@@ -148,47 +147,54 @@ DiscoverProviderHealer.prototype.heal = function heal(callback) {
         var targets = [];
         var numberOfFailures = 0;
 
-        async.whilst(
-            function shouldContinueHealing() {
-                return potentialTargets.length > 0 && numberOfFailures < self.maxNumberOfFailures;
-            },
-            function healTargetIterator(next) {
-                var target = potentialTargets.pop();
+        healNext();
 
-                self.attemptHeal(target, function onHealAttempt(err, reachableNodes) {
-                    if (err) {
-                        numberOfFailures++;
-                        self.logger.warn('ringpop heal attempt failed', {
-                            local: self.ringpop.whoami(),
-                            target: target,
-                            numberOfFailures: numberOfFailures,
-                            maxNumberOfFailures: self.maxNumberOfFailures,
-                            err: err
-                        });
+        function healNext() {
+            if (potentialTargets.length > 0 && numberOfFailures < self.maxNumberOfFailures) {
+                healTarget();
+            } else {
+                healingDone();
+            }
+        }
 
-                        // continue
-                        next();
-                        return;
-                    }
+        function healTarget() {
+            var target = potentialTargets.pop();
 
-                    targets.push(target);
-                    // Remove all reachable nodes from the list of potential targets.
-                    potentialTargets = _.difference(potentialTargets, reachableNodes);
-                    next();
-                });
-            },
-            function healingDone(err) {
-                if (numberOfFailures >= self.maxNumberOfFailures) {
-                    self.logger.warn('ringpop heal reached maximum number of failures', {
+            self.attemptHeal(target, function onHealAttempt(err, reachableNodes) {
+                if (err) {
+                    numberOfFailures++;
+                    self.logger.warn('ringpop heal attempt failed', {
                         local: self.ringpop.whoami(),
-                        failures: numberOfFailures,
-                        successes: targets.length
+                        target: target,
+                        numberOfFailures: numberOfFailures,
+                        maxNumberOfFailures: self.maxNumberOfFailures,
+                        err: err
                     });
+
+                    // continue
+                    healNext();
+                    return;
                 }
 
-                callback(err, targets);
+                targets.push(target);
+                // Remove all reachable nodes from the list of potential targets.
+                potentialTargets = _.difference(potentialTargets, reachableNodes);
+
+                healNext();
+            });
+        }
+
+        function healingDone(err) {
+            if (numberOfFailures >= self.maxNumberOfFailures) {
+                self.logger.warn('ringpop heal reached maximum number of failures', {
+                    local: self.ringpop.whoami(),
+                    failures: numberOfFailures,
+                    successes: targets.length
+                });
             }
-        );
+
+            callback(err, targets);
+        }
     }
 };
 

--- a/lib/partition_healing/healer.js
+++ b/lib/partition_healing/healer.js
@@ -21,7 +21,6 @@
 'use strict';
 
 var _ = require('underscore');
-var async = require('async');
 
 var Member = require('../membership/member');
 var PingSender = require('../gossip/ping-sender');
@@ -60,24 +59,9 @@ Healer.prototype.attemptHeal = function attemptHeal(target, callback) {
 
     var membershipB = null; //The membership of the target-node.
 
-    async.waterfall([
-        sendJoinRequest,
-        generateChanges,
-        processChanges
-    ], function done(err) {
-        if (err) {
-            callback(err);
-            return;
-        }
+    sendJoinRequest();
 
-        var pingableHosts = _.chain(membershipB).filter(function isPingable(change) {
-            return Member.isStatusPingable(change.status);
-        }).pluck('address').value();
-
-        callback(null, pingableHosts);
-    });
-
-    function sendJoinRequest(next) {
+    function sendJoinRequest() {
         self.ringpop.client.protocolJoin({
             host: target,
             retryLimit: self.ringpop.config.get('tchannelRetryLimit'),
@@ -86,10 +70,16 @@ Healer.prototype.attemptHeal = function attemptHeal(target, callback) {
             app: self.ringpop.app,
             source: self.ringpop.whoami(),
             incarnationNumber: self.ringpop.membership.localMember.incarnationNumber
-        }, next);
+        }, function onJoin(err, res) {
+            if (err) {
+                done(err);
+            } else {
+                generateChanges(res);
+            }
+        });
     }
 
-    function generateChanges(joinResponse, next) {
+    function generateChanges(joinResponse) {
         membershipB = joinResponse.membership;
 
         // Index membership of this node by address for faster lookups.
@@ -119,7 +109,7 @@ Healer.prototype.attemptHeal = function attemptHeal(target, callback) {
             }
         }
 
-        next(null, changesForA, changesForB);
+        processChanges(changesForA, changesForB);
     }
 
     function createSuspectChange(member) {
@@ -155,13 +145,13 @@ Healer.prototype.attemptHeal = function attemptHeal(target, callback) {
         return Member.statusPrecedence(newState.status) > Member.statusPrecedence(currentState.status);
     }
 
-    function processChanges(changesForA, changesForB, next) {
+    function processChanges(changesForA, changesForB) {
         if (changesForA.length > 0 || changesForB.length > 0) {
             // reincarnate
-            reincarnate(changesForA, changesForB, next);
+            reincarnate(changesForA, changesForB, done);
         } else {
             // merge
-            merge(membershipB, next);
+            merge(membershipB, done);
         }
     }
 
@@ -185,6 +175,19 @@ Healer.prototype.attemptHeal = function attemptHeal(target, callback) {
 
         // sent full local membership to target
         new PingSender(self.ringpop, target).sendChanges(self.ringpop.dissemination.membershipAsChanges(), next);
+    }
+
+    function done(err) {
+        if (err) {
+            callback(err);
+            return;
+        }
+
+        var pingableHosts = _.chain(membershipB).filter(function isPingable(change) {
+            return Member.isStatusPingable(change.status);
+        }).pluck('address').value();
+
+        callback(null, pingableHosts);
     }
 };
 


### PR DESCRIPTION
Partition healing was by accident using `async`: a dev-dependency. Let's not add an extra dependency and do it without `async`!