### PR TITLE
Read hosts-file async

### DIFF
--- a/discover-providers.js
+++ b/discover-providers.js
@@ -53,11 +53,6 @@ function createJsonFileDiscoverProvider(hostsFile) {
     var fs = require('fs');
 
     return function jsonFileProvider(callback) {
-        if (!fs.existsSync(hostsFile)) {
-            callback(new Error('bootstrap hosts file does not exist', {file: hostsFile}));
-            return;
-        }
-
         fs.readFile(hostsFile, function onFileRead(err, data) {
             if (err) {
                 callback(err);
@@ -65,10 +60,10 @@ function createJsonFileDiscoverProvider(hostsFile) {
             }
 
             try {
-                var hosts =JSON.parse(data.toString());
+                var hosts = JSON.parse(data.toString());
                 callback(null, hosts);
                 return;
-            } catch (e){
+            } catch (e) {
                 callback(e);
                 return;
             }

--- a/discover-providers.js
+++ b/discover-providers.js
@@ -59,14 +59,15 @@ function createJsonFileDiscoverProvider(hostsFile) {
                 return;
             }
 
+            var hosts;
             try {
-                var hosts = JSON.parse(data.toString());
-                callback(null, hosts);
-                return;
+                hosts = JSON.parse(data.toString());
             } catch (e) {
                 callback(e);
                 return;
             }
+            callback(null, hosts);
+            return;
         });
     };
 }

--- a/discover-providers.js
+++ b/discover-providers.js
@@ -58,15 +58,21 @@ function createJsonFileDiscoverProvider(hostsFile) {
             return;
         }
 
-        var hosts;
-        try {
-            hosts = JSON.parse(fs.readFileSync(hostsFile).toString());
-        } catch (e) {
-            callback(e);
-            return;
-        }
+        fs.readFile(hostsFile, function onFileRead(err, data) {
+            if (err) {
+                callback(err);
+                return;
+            }
 
-        return callback(null, hosts);
+            try {
+                var hosts =JSON.parse(data.toString());
+                callback(null, hosts);
+                return;
+            } catch (e){
+                callback(e);
+                return;
+            }
+        });
     };
 }
 


### PR DESCRIPTION
Since discover-providers are using a callback to return the host list, the hosts-file could be able to read the file asynchronously. 