### PR TITLE
add suspect, faulty and tombstone period flags

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,9 +41,9 @@ function main(args) {
         process.exit(1);
     }
 
-    program.suspect = parseInt(program.suspect) || 5;
-    program.faulty = parseInt(program.faulty) || 24*60*60;
-    program.tombstone = parseInt(program.tombstone) || 5;
+    program.suspect = parseInt(program.suspect, 10) || 5;
+    program.faulty = parseInt(program.faulty, 10) || 24*60*60;
+    program.tombstone = parseInt(program.tombstone, 10) || 5;
 
     var tchannel = new TChannel({
     });

--- a/main.js
+++ b/main.js
@@ -29,6 +29,9 @@ function main(args) {
         .usage('[options]')
         .option('-l, --listen <listen>', 'Host and port on which server listens (also node\'s identity in cluster)')
         .option('-h, --hosts <hosts>', 'Seed file of list of hosts to join')
+        .option('--suspect [suspect]', 'Suspect period in seconds')
+        .option('--faulty [faulty]', 'Faulty period in seconds')
+        .option('--tombstone [tombstone]', 'Tombstone period in seconds')
         .parse(args);
 
     var listen = program.listen;
@@ -37,6 +40,10 @@ function main(args) {
         program.outputHelp();
         process.exit(1);
     }
+
+    program.suspect = parseInt(program.suspect) || 5;
+    program.faulty = parseInt(program.faulty) || 24*60*60;
+    program.tombstone = parseInt(program.tombstone) || 5;
 
     var tchannel = new TChannel({
     });
@@ -51,8 +58,9 @@ function main(args) {
         }),
         isCrossPlatform: true,
         stateTimeouts: {
-            faulty: 5 * 1000, // 5s
-            tombstone: 5 * 1000 // 5s
+            suspect: program.suspect * 1000,
+            faulty: program.faulty * 1000,
+            tombstone: program.tombstone * 1000,
         }
     });
 

--- a/main.js
+++ b/main.js
@@ -29,9 +29,9 @@ function main(args) {
         .usage('[options]')
         .option('-l, --listen <listen>', 'Host and port on which server listens (also node\'s identity in cluster)')
         .option('-h, --hosts <hosts>', 'Seed file of list of hosts to join')
-        .option('--suspect [suspect]', 'Suspect period in seconds')
-        .option('--faulty [faulty]', 'Faulty period in seconds')
-        .option('--tombstone [tombstone]', 'Tombstone period in seconds')
+        .option('--suspect-period <suspectPeriod>', 'Suspect period in ms', parseInt10, 5000)
+        .option('--faulty-period <faultyPeriod>', 'Faulty period in ms', parseInt10, 24*60*60*1000) // 24h
+        .option('--tombstone-period <tombstonePeriod>', 'Tombstone period in ms', parseInt10, 5000)
         .parse(args);
 
     var listen = program.listen;
@@ -40,10 +40,6 @@ function main(args) {
         program.outputHelp();
         process.exit(1);
     }
-
-    program.suspect = parseInt(program.suspect, 10) || 5;
-    program.faulty = parseInt(program.faulty, 10) || 24*60*60;
-    program.tombstone = parseInt(program.tombstone, 10) || 5;
 
     var tchannel = new TChannel({
     });
@@ -58,9 +54,9 @@ function main(args) {
         }),
         isCrossPlatform: true,
         stateTimeouts: {
-            suspect: program.suspect * 1000,
-            faulty: program.faulty * 1000,
-            tombstone: program.tombstone * 1000,
+            suspect: program.suspectPeriod,
+            faulty: program.faultyPeriod,
+            tombstone: program.tombstonePeriod,
         }
     });
 
@@ -74,6 +70,10 @@ function main(args) {
     function onListening() {
         ringpop.bootstrap(program.hosts);
     }
+}
+
+function parseInt10(str) {
+    return parseInt(str, 10)
 }
 
 function createLogger(name) {

--- a/main.js
+++ b/main.js
@@ -26,12 +26,27 @@ var TChannel = require('tchannel');
 function main(args) {
     program
         .version(require('./package.json').version)
+
         .usage('[options]')
-        .option('-l, --listen <listen>', 'Host and port on which server listens (also node\'s identity in cluster)')
-        .option('-h, --hosts <hosts>', 'Seed file of list of hosts to join')
-        .option('--suspect-period <suspectPeriod>', 'Suspect period in ms', parseInt10, 5000)
-        .option('--faulty-period <faultyPeriod>', 'Faulty period in ms', parseInt10, 24*60*60*1000) // 24h
-        .option('--tombstone-period <tombstonePeriod>', 'Tombstone period in ms', parseInt10, 5000)
+
+        .option('-l, --listen <listen>',
+            'Host and port on which server listens (also node\'s identity in cluster)')
+
+        .option('-h, --hosts <hosts>',
+            'Seed file of list of hosts to join')
+
+        .option('--suspect-period <suspectPeriod>',
+            'The lifetime of a suspect member in ms. After that the member becomes faulty.',
+            parseInt10, 5000)
+
+        .option('--faulty-period <faultyPeriod>',
+            'The lifetime of a faulty member in ms. After that the member becomes a tombstone.',
+            parseInt10, 24*60*60*1000) // 24hours
+
+        .option('--tombstone-period <tombstonePeriod>',
+            'The lifetime of a tombstone member in ms. After that the member is removed from the membership.',
+            parseInt10, 5000)
+
         .parse(args);
 
     var listen = program.listen;
@@ -73,7 +88,7 @@ function main(args) {
 }
 
 function parseInt10(str) {
-    return parseInt(str, 10)
+    return parseInt(str, 10);
 }
 
 function createLogger(name) {


### PR DESCRIPTION
Add suspect, faulty and tombstone period flags so that integration tests can set a small faulty->tombstone period of 5 seconds while having a big faulty->tombstone period when running from tickcluster.