### PR TITLE
When creating the change for reincarnation use your self as the source.

### DIFF
--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -94,7 +94,7 @@ Member.prototype.evaluateUpdate = function evaluateUpdate(update) {
         update = {
             source: this.ringpop.whoami(),
             sourceIncarnationNumber: newIncNumber,
-            address: this.id,
+            address: this.address,
             status: Member.Status.alive,
             incarnationNumber: newIncNumber
         };

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -20,7 +20,6 @@
 
 'use strict';
 
-var _ = require('underscore');
 var EventEmitter = require('events').EventEmitter;
 var events = require('./events.js');
 var numOrDefault = require('../util.js').numOrDefault;
@@ -91,10 +90,14 @@ Member.prototype.evaluateUpdate = function evaluateUpdate(update) {
     if (this._isLocalOverride(update)) {
         // Override intended update. Assert aliveness!
         this.ringpop.stat('increment', 'refuted-update');
-        update = _.defaults({
+        var newIncNumber = this.Date.now();
+        update = {
+            source: this.ringpop.whoami(),
+            sourceIncarnationNumber: newIncNumber,
+            address: this.id,
             status: Member.Status.alive,
-            incarnationNumber: this.Date.now()
-        }, update);
+            incarnationNumber: newIncNumber
+        };
     } else if (!this._isOtherOverride(update)) {
         return;
     }

--- a/test/unit/membership_test.js
+++ b/test/unit/membership_test.js
@@ -75,12 +75,15 @@ testRingpop('change with higher incarnation number results in leave override', f
 testRingpop('change that overrides the local status should be overwritten to a change that reincarnates the node', function t(deps, assert) {
     var ringpop = deps.ringpop;
     var membership = deps.membership;
+    var source = "192.0.2.1:1234";
+
+    assert.doesNotEqual(ringpop.whoami(), source, 'this test relies on the source and the target of the change to be different');
 
     var member = membership.findMemberByAddress(ringpop.whoami());
     assert.equals(member.status, Member.Status.alive, 'member starts alive');
 
     var applied = membership.update([{
-        source: "192.0.2.1:1234",
+        source: source,
         sourceIncarnationNumber: 1337,
 
         address: ringpop.whoami(),

--- a/test/unit/membership_test.js
+++ b/test/unit/membership_test.js
@@ -72,6 +72,33 @@ testRingpop('change with higher incarnation number results in leave override', f
     assert.equals(member.status, Member.Status.leave, 'results in leave');
 });
 
+testRingpop('change that overrides the local status should be overwritten to a change that reincarnates the node', function t(deps, assert) {
+    var ringpop = deps.ringpop;
+    var membership = deps.membership;
+
+    var member = membership.findMemberByAddress(ringpop.whoami());
+    assert.equals(member.status, Member.Status.alive, 'member starts alive');
+
+    var applied = membership.update([{
+        source: "192.0.2.1:1234",
+        sourceIncarnationNumber: 1337,
+
+        address: ringpop.whoami(),
+        status: Member.Status.suspect,
+        incarnationNumber: member.incarnationNumber
+    }]);
+
+    member = membership.findMemberByAddress(ringpop.whoami());
+
+    assert.equals(applied.length, 1, 'expected 1 applied update');
+    var change = applied[0];
+    assert.equals(change.status, Member.Status.alive, 'expected the status of the applied update to be overriden to alive');
+    assert.equals(change.incarnationNumber, member.incarnationNumber, 'expected the incarnation number of the change be equal to the incarnation number of the local member');
+    assert.equals(change.sourceIncarnationNumber, member.incarnationNumber, 'expected the source incarnation number be equal the the incarnation number of the local member');
+    assert.equals(change.source, ringpop.whoami(), 'expected the source to be the address of the local node');
+    assert.equals(member.status, Member.Status.alive, 'the status of the member should stay alive');
+});
+
 testRingpop('change with same incarnation number does not result in leave override', function t(deps, assert) {
     var ringpop = deps.ringpop;
     var membership = deps.membership;


### PR DESCRIPTION
When a gossip was received that would overwrite the state of the local node we overwrite this change with a reincarnated version of our self. However we used the source of the original change as the source for this change making it harder for the reincarnated change to reach the node that declared it a suspect in the first place.

This change will use the source and new reincarnation number of the local node for this new change. This prevents the reincarnation change to be filtered out in pings to the original source causing convergence to speedup and potentially prevent fullsyncs from happening.