### PR TITLE
Fix double reincarnation

### DIFF
--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -178,6 +178,10 @@ Member.prototype._isLocalOverride = function _isLocalOverride(update) {
         return false;
     }
 
+    if (this.incarnationNumber > update.incarnationNumber) {
+        return false;
+    }
+
     return update.status === Member.Status.faulty ||
         update.status === Member.Status.suspect ||
         update.status === Member.Status.tombstone;

--- a/test/run-shared-integration-tests
+++ b/test/run-shared-integration-tests
@@ -6,7 +6,7 @@ set -eo pipefail
 
 declare project_root="${0%/*}/.."
 declare ringpop_common_dir="${0%/*}/ringpop-common"
-declare ringpop_common_branch="master"
+declare ringpop_common_branch="fix/double-reincarnation"
 declare tap_filter="${ringpop_common_dir}/test/tap-filter"
 
 declare test_cluster_sizes="1 2 3 4 5 10"

--- a/test/run-shared-integration-tests
+++ b/test/run-shared-integration-tests
@@ -6,7 +6,7 @@ set -eo pipefail
 
 declare project_root="${0%/*}/.."
 declare ringpop_common_dir="${0%/*}/ringpop-common"
-declare ringpop_common_branch="fix/double-reincarnation"
+declare ringpop_common_branch="master"
 declare tap_filter="${ringpop_common_dir}/test/tap-filter"
 
 declare test_cluster_sizes="1 2 3 4 5 10"

--- a/test/unit/membership_test.js
+++ b/test/unit/membership_test.js
@@ -102,12 +102,9 @@ testRingpop('change that overrides the local status should be overwritten to a c
     assert.equals(member.status, Member.Status.alive, 'the status of the member should stay alive');
 });
 
-testRingpop('change that does not overrides the local status should not cause a reincarnation', function t(deps, assert) {
+testRingpop('change that does not override the local status should not cause a reincarnation', function t(deps, assert) {
     var ringpop = deps.ringpop;
     var membership = deps.membership;
-    var source = "192.0.2.1:1234";
-
-    assert.doesNotEqual(ringpop.whoami(), source, 'this test relies on the source and the target of the change to be different');
 
     var member = membership.findMemberByAddress(ringpop.whoami());
     assert.equals(member.status, Member.Status.alive, 'member starts alive');


### PR DESCRIPTION
This change will add a check for the incarnation number before reincarnating a node by incrementing its incarnation number. This reduces the number of gossips being sent in the case of reincarnation. Which will result in faster memberlist convergence.