### PR TITLE
Add requirements to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ shard your application in a way that's scalable and fault tolerant.
 
 # Requirements
 
-* Node 0.10.x
+* Node 0.10 (0.10.32 or higher)
 
 # Installation
 To install Ringpop for usage as a library:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ applications. It maintains a consistent hash ring on top of a membership protoco
 and provides request forwarding as a routing convenience. It can be used to
 shard your application in a way that's scalable and fault tolerant.
 
+# Requirements
+
+* Node 0.10.x
+
 # Installation
 To install Ringpop for usage as a library:
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "version": "10.15.0",
   "engines": {
-    "node": "0.10.x"
+    "node": "^0.10.32"
   },
   "repository": "git://github.com/uber/ringpop.git",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "Mark Yen <mark@uber.com>"
   ],
   "version": "10.15.0",
+  "engines": {
+    "node": "0.10.x"
+  },
   "repository": "git://github.com/uber/ringpop.git",
   "bin": {
     "ringpop": "./main.js"


### PR DESCRIPTION
Add a section to the README documenting the requirements for ringpop-node.

This should help people run into trouble when trying to `npm install` on a newer version of node[1].

[1]: https://github.com/uber/ringpop-node/issues/287