### PR TITLE
Update dependencies

### DIFF
--- a/lib/lag_sampler.js
+++ b/lib/lag_sampler.js
@@ -43,7 +43,7 @@ LagSampler.prototype.start = function start() {
     }
 
     if (!this.toobusy) {
-        this.toobusy = require('toobusy');
+        this.toobusy = require('toobusy-js');
     }
 
     schedule();

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
   "dependencies": {
     "body": "^5.0.0",
     "error": "^5.0.0",
-    "farmhash": "^0.2.0",
+    "farmhash": "^1.1.0",
     "metrics": "^0.1.8",
     "node-uuid": "^1.4.3",
-    "toobusy": "^0.2.4",
+    "toobusy-js": "^0.5.0",
     "uber-hammock": "^1.0.0",
     "underscore": "^1.5.2"
   },


### PR DESCRIPTION
Updated the dependencies to use newer version of farmhash and the pure javascript version of toobusy, which enables ringpop to run on the latest stable node (v4.4.7) whilst also remaining compatible with node v0.10.41.