### PR TITLE
Status refactor 1: Refactor membership to use localMember as the source of truth

### DIFF
--- a/index.js
+++ b/index.js
@@ -324,7 +324,7 @@ RingPop.prototype.bootstrap = function bootstrap(opts, callback) {
         checkForHostnameIpMismatch();
 
         // Add local member to membership.
-        self.membership.makeAlive(self.whoami(), Date.now());
+        self.membership.makeLocalAlive();
 
         var joinTime = Date.now();
 

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -44,9 +44,7 @@ function Membership(opts) {
     this.checksum = null;
     this.stashedUpdates = [];
     this.decayTimer = null;
-    this.localMember = new Member(this.ringpop, new Update(this.ringpop.whoami(), Date.now(), Member.Status.alive, null));
-    this.members.push(this.localMember);
-    this.membersByAddress[this.localMember.address] = this.localMember;
+    this.localMember = null;
 }
 
 util.inherits(Membership, EventEmitter);
@@ -217,14 +215,19 @@ Membership.prototype.makeLocalAlive = function makeLocalAlive(){
  * @param status The new status (@see Member.Status)
  */
 Membership.prototype.setLocalStatus = function setLocalStatus(status) {
-    if (status === Member.Status.leave) {
-        this.emit('event',
-            new MembershipEvents.LocalMemberLeaveEvent(this.localMember, this.localMember.status));
+    if (this.localMember) {
+        if (status === Member.Status.leave) {
+            this.emit('event',
+                new MembershipEvents.LocalMemberLeaveEvent(this.localMember, this.localMember.status));
+        }
+
+        this.localMember.status = status;
+        this.localMember.incarnationNumber = Date.now();
+    } else {
+        this.localMember = new Member(this.ringpop, new Update(this.ringpop.whoami(), Date.now(), status, null));
+        this.members.push(this.localMember);
+        this.membersByAddress[this.localMember.address] = this.localMember;
     }
-
-    this.localMember.status = status;
-    this.localMember.incarnationNumber = Date.now();
-
     this._postLocalUpdate();
 };
 

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -201,10 +201,21 @@ Membership.prototype.isPingable = function isPingable(member) {
             Member.isStatusPingable(member.status);
 };
 
+/**
+ * Change the status of the local member to alive
+ * @see Membership#setLocalStatus
+ * @see Member.Status.alive
+ */
 Membership.prototype.makeLocalAlive = function makeLocalAlive(){
     this.setLocalStatus(Member.Status.alive);
 };
 
+/**
+ * Change the status of the local member. This will also bump the incarnation
+ * number of the local member.
+ *
+ * @param status The new status (@see Member.Status)
+ */
 Membership.prototype.setLocalStatus = function setLocalStatus(status) {
     if (status === Member.Status.leave) {
         this.emit('event',
@@ -217,6 +228,11 @@ Membership.prototype.setLocalStatus = function setLocalStatus(status) {
     this._postLocalUpdate();
 };
 
+/**
+ * Post an 'updated' event describing the local member's current state and
+ * recompute the membership checksum.
+ * @private
+ */
 Membership.prototype._postLocalUpdate = function _postLocalUpdate(){
     var update = new Update(this.localMember.address, this.localMember.incarnationNumber, this.localMember.status, this.localMember);
     this.computeChecksum();

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -209,6 +209,19 @@ Membership.prototype.makeLocalAlive = function makeLocalAlive(){
 };
 
 /**
+ * Bump the incarnation number of the local member and return an update that
+ * described the current state of the local member.
+ *
+ * @returns {Update} The update to gossip around
+ * @private
+ */
+Membership.prototype._reincarnate = function _reincarnate() {
+    this.localMember.incarnationNumber = Date.now();
+
+    return new Update(this.localMember.address, this.localMember.incarnationNumber, this.localMember.status, this.localMember);
+};
+
+/**
  * Change the status of the local member. This will also bump the incarnation
  * number of the local member.
  *
@@ -222,13 +235,14 @@ Membership.prototype.setLocalStatus = function setLocalStatus(status) {
         }
 
         this.localMember.status = status;
-        this.localMember.incarnationNumber = Date.now();
     } else {
         this.localMember = new Member(this.ringpop, new Update(this.ringpop.whoami(), Date.now(), status, null));
         this.members.push(this.localMember);
         this.membersByAddress[this.localMember.address] = this.localMember;
     }
-    this._postLocalUpdate();
+
+    var update = this._reincarnate();
+    this._postLocalUpdate(update);
 };
 
 /**
@@ -236,8 +250,7 @@ Membership.prototype.setLocalStatus = function setLocalStatus(status) {
  * recompute the membership checksum.
  * @private
  */
-Membership.prototype._postLocalUpdate = function _postLocalUpdate(){
-    var update = new Update(this.localMember.address, this.localMember.incarnationNumber, this.localMember.status, this.localMember);
+Membership.prototype._postLocalUpdate = function _postLocalUpdate(update){
     this.computeChecksum();
     this.emit('updated', [update]);
 };
@@ -256,7 +269,7 @@ Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumb
         damped: address
     });
     // TODO Apply damped status to member
-    //return this._makeUpdate(address, incarnationNumber, Member.Status.damped);
+    //return this._updateMember(new Update(address, incarnationNumber, Member.Status.damped, this.localMember));
 };
 
 Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber) {
@@ -384,25 +397,18 @@ Membership.prototype.update = function update(changes) {
         if (Member.shouldProcessChange(member, change)) {
             if (change.address === self.localMember.address) {
                 self.ringpop.stat('increment', 'refuted-update');
-                var newIncNumber = Date.now();
-                change = {
-                    source: self.ringpop.whoami(),
-                    sourceIncarnationNumber: newIncNumber,
-                    address: self.localMember.address,
-                    status: self.localMember.status,
-                    incarnationNumber: newIncNumber
-                };
-            }
 
-            if (!member) {
-                member = this._createMember(change);
-
-                this.members.splice(this.getJoinPosition(), 0, member);
-                this.membersByAddress[member.address] = member;
+                change = self._reincarnate();
             } else {
-                member.applyUpdate(change);
-            }
+                if (!member) {
+                    member = this._createMember(change);
 
+                    this.members.splice(this.getJoinPosition(), 0, member);
+                    this.membersByAddress[member.address] = member;
+                } else {
+                    member.applyUpdate(change);
+                }
+            }
             if (change.source !== self.ringpop.whoami()) {
                 self.logger.debug('ringpop applied remote update', {
                     local: self.ringpop.whoami(),

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -27,11 +27,8 @@ var MemberDampScore = require('./member_damp_score.js');
 var MembershipEvents = require('./events.js');
 var mergeMembershipChangesets = require('./merge.js');
 var timers = require('timers');
-var update = require('./update.js');
+var Update = require('./update.js');
 var util = require('util');
-
-var LeaveUpdate = update.LeaveUpdate;
-var Update = update.Update;
 
 function Membership(opts) {
     this.ringpop = opts.ringpop; // assumed to be present
@@ -218,14 +215,14 @@ Membership.prototype.makeLocalAlive = function makeLocalAlive(){
 Membership.prototype._reincarnate = function _reincarnate() {
     this.localMember.incarnationNumber = Date.now();
 
-    return new Update(this.localMember.address, this.localMember.incarnationNumber, this.localMember.status, this.localMember);
+    return new Update(this.localMember, this.localMember);
 };
 
 /**
  * Change the status of the local member. This will also bump the incarnation
  * number of the local member.
  *
- * @param status The new status (@see Member.Status)
+ * @param {Member.Status} status The new status
  */
 Membership.prototype.setLocalStatus = function setLocalStatus(status) {
     if (this.localMember) {
@@ -236,7 +233,11 @@ Membership.prototype.setLocalStatus = function setLocalStatus(status) {
 
         this.localMember.status = status;
     } else {
-        this.localMember = new Member(this.ringpop, new Update(this.ringpop.whoami(), Date.now(), status, null));
+        this.localMember = new Member(this.ringpop, new Update({
+            address: this.ringpop.whoami(),
+            incarnationNumber: Date.now(),
+            status: status
+        }));
         this.members.push(this.localMember);
         this.membersByAddress[this.localMember.address] = this.localMember;
     }
@@ -255,13 +256,31 @@ Membership.prototype._postLocalUpdate = function _postLocalUpdate(update){
     this.emit('updated', [update]);
 };
 
-Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber) {
-    this.ringpop.stat('increment', 'make-alive');
-    return this._updateMember(new Update(address, incarnationNumber,
-        Member.Status.alive, this.localMember));
+/**
+ * Make a change to the member list.
+ *
+ * @param {string} address the address of the member.
+ * @param {int} incarnationNumber The incarnationNumber of the member.
+ * @param {Member.Status} status The (new) status of the member.
+ */
+Membership.prototype.makeChange = function makeChange(address, incarnationNumber, status) {
+    this.ringpop.stat('increment', 'make-'+status);
+    var member = this.findMemberByAddress(address);
+
+    var change = new Update(member, this.localMember);
+
+    // in case member is not (yet) known
+    change.address = address;
+
+    // overwrite with provided state
+    change.incarnationNumber = incarnationNumber;
+    change.status = status;
+
+    return this._updateMember(change);
 };
 
 Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumber*/) {
+    //TODO this statter should be removed when this function actually calls makeChange to prevent "double statting"!
     this.ringpop.stat('increment', 'make-damped');
     var level = this.ringpop.config.get('dampedErrorLoggingEnabled') ? 'error' : 'warn';
     this.ringpop.logger[level]('ringpop member would have been damped', {
@@ -269,32 +288,19 @@ Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumb
         damped: address
     });
     // TODO Apply damped status to member
-    //return this._updateMember(new Update(address, incarnationNumber, Member.Status.damped, this.localMember));
+    //return this.makeChange(address, incarnationNumber, Member.Status.damped);
 };
 
 Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber) {
-    this.ringpop.stat('increment', 'make-faulty');
-
-    return this._updateMember(new Update(address, incarnationNumber,
-        Member.Status.faulty, this.localMember));
-};
-
-Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber) {
-    this.ringpop.stat('increment', 'make-leave');
-    return this._updateMember(new LeaveUpdate(address, incarnationNumber,
-        this.localMember));
+    return this.makeChange(address, incarnationNumber, Member.Status.faulty);
 };
 
 Membership.prototype.makeSuspect = function makeSuspect(address, incarnationNumber) {
-    this.ringpop.stat('increment', 'make-suspect');
-    return this._updateMember(new Update(address, incarnationNumber,
-        Member.Status.suspect, this.localMember));
+    return this.makeChange(address, incarnationNumber, Member.Status.suspect);
 };
 
 Membership.prototype.makeTombstone = function makeTombstone(address, incarnationNumber) {
-    this.ringpop.stat('increment', 'make-tombstone');
-    return this._updateMember(new Update(address, incarnationNumber,
-        Member.Status.tombstone, this.localMember));
+    return this.makeChange(address, incarnationNumber, Member.Status.tombstone);
 };
 
 Membership.prototype.removeMember = function removeMember(address) {

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -400,7 +400,7 @@ Membership.prototype.update = function update(changes) {
 
         var member = this.findMemberByAddress(change.address);
 
-        if (Member.shouldProcessChange(member, change)) {
+        if (Member.shouldProcessGossip(member, change)) {
             if (change.address === self.localMember.address) {
                 self.ringpop.stat('increment', 'refuted-update');
 

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -44,7 +44,9 @@ function Membership(opts) {
     this.checksum = null;
     this.stashedUpdates = [];
     this.decayTimer = null;
-    this.localMember = null;
+    this.localMember = new Member(this.ringpop, new Update(this.ringpop.whoami(), Date.now(), Member.Status.alive, null));
+    this.members.push(this.localMember);
+    this.membersByAddress[this.localMember.address] = this.localMember;
 }
 
 util.inherits(Membership, EventEmitter);
@@ -199,11 +201,32 @@ Membership.prototype.isPingable = function isPingable(member) {
             Member.isStatusPingable(member.status);
 };
 
+Membership.prototype.makeLocalAlive = function makeLocalAlive(){
+    this.setLocalStatus(Member.Status.alive);
+};
+
+Membership.prototype.setLocalStatus = function setLocalStatus(status) {
+    if (status === Member.Status.leave) {
+        this.emit('event',
+            new MembershipEvents.LocalMemberLeaveEvent(this.localMember, this.localMember.status));
+    }
+
+    this.localMember.status = status;
+    this.localMember.incarnationNumber = Date.now();
+
+    this._postLocalUpdate();
+};
+
+Membership.prototype._postLocalUpdate = function _postLocalUpdate(){
+    var update = new Update(this.localMember.address, this.localMember.incarnationNumber, this.localMember.status, this.localMember);
+    this.computeChecksum();
+    this.emit('updated', [update]);
+};
+
 Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber) {
     this.ringpop.stat('increment', 'make-alive');
-    var isLocal = address === this.ringpop.whoami();
     return this._updateMember(new Update(address, incarnationNumber,
-        Member.Status.alive, this.localMember), isLocal);
+        Member.Status.alive, this.localMember));
 };
 
 Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumber*/) {
@@ -219,6 +242,7 @@ Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumb
 
 Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber) {
     this.ringpop.stat('increment', 'make-faulty');
+
     return this._updateMember(new Update(address, incarnationNumber,
         Member.Status.faulty, this.localMember));
 };
@@ -310,7 +334,7 @@ Membership.prototype.set = function set() {
     }
 };
 
-Membership.prototype.update = function update(changes, isLocal) {
+Membership.prototype.update = function update(changes) {
     changes = Array.isArray(changes) ? changes : [changes];
 
     this.ringpop.stat('gauge', 'changes.apply', changes.length);
@@ -320,7 +344,7 @@ Membership.prototype.update = function update(changes, isLocal) {
     }
 
     // Buffer updates until ready.
-    if (!isLocal && !this.ringpop.isReady) {
+    if (!this.ringpop.isReady) {
         if (Array.isArray(this.stashedUpdates)) {
             this.stashedUpdates.push(changes);
         }
@@ -338,42 +362,38 @@ Membership.prototype.update = function update(changes, isLocal) {
 
         var member = this.findMemberByAddress(change.address);
 
-        if (!member) {
-            // avoid indefinite tombstones by not creating new nodes
-            // directly in this state
-            if (change.status === Member.Status.tombstone) {
-                self.logger.info('skipping tombstone update', {
+        if (Member.shouldProcessChange(member, change)) {
+            if (change.address === self.localMember.address) {
+                self.ringpop.stat('increment', 'refuted-update');
+                var newIncNumber = Date.now();
+                change = {
+                    source: self.ringpop.whoami(),
+                    sourceIncarnationNumber: newIncNumber,
+                    address: self.localMember.address,
+                    status: self.localMember.status,
+                    incarnationNumber: newIncNumber
+                };
+            }
+
+            if (!member) {
+                member = this._createMember(change);
+
+                this.members.splice(this.getJoinPosition(), 0, member);
+                this.membersByAddress[member.address] = member;
+            } else {
+                member.applyUpdate(change);
+            }
+
+            if (change.source !== self.ringpop.whoami()) {
+                self.logger.debug('ringpop applied remote update', {
                     local: self.ringpop.whoami(),
-                    remote: change.source
+                    remote: change.source,
+                    updateId: change.id
                 });
-                continue;
-            }
-            member = this._createMember(change);
-
-            // localMember is carried around as a convenience.
-            if (member.address === this.ringpop.whoami()) {
-                this.localMember = member;
             }
 
-            this.members.splice(this.getJoinPosition(), 0, member);
-            this.membersByAddress[member.address] = member;
-
-            // Note that I am invoking the 'updated' event handler here. There
-            // are two reasons for that. Firstly, what the handler does is
-            // necessary here too. Secondly, it is convenient to reuse it.
-            onMemberUpdated(change);
-
-            continue;
+            updates.push(change);
         }
-
-        // One-time subscription for batching applied updates. Make
-        // sure to unsubscribe immediately after evaluating the update.
-        // Events are expected to be emitted synchronously and are not
-        // guaranteed if the update is determined to be invalid or
-        // redundant.
-        member.once('updated', onMemberUpdated);
-        member.evaluateUpdate(change);
-        member.removeListener('updated', onMemberUpdated);
     }
 
     if (updates.length > 0) {
@@ -382,18 +402,6 @@ Membership.prototype.update = function update(changes, isLocal) {
     }
 
     return updates;
-
-    function onMemberUpdated(update) {
-        if (update.source !== self.ringpop.whoami()) {
-            self.logger.debug('ringpop applied remote update', {
-                local: self.ringpop.whoami(),
-                remote: update.source,
-                updateId: update.id
-            });
-        }
-
-        updates.push(update);
-    }
 };
 
 Membership.prototype.shuffle = function shuffle() {
@@ -448,8 +456,8 @@ Membership.prototype._decayMembersDampScore = function _decayMembersDampScore() 
     }
 };
 
-Membership.prototype._updateMember = function _updateMember(update, isLocal) {
-    var updates = this.update(update, isLocal);
+Membership.prototype._updateMember = function _updateMember(update) {
+    var updates = this.update(update);
 
     if (updates.length > 0) {
         this.logger.debug('ringpop member declares other member ' +

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -79,40 +79,10 @@ Member.prototype.decayDampScore = function decayDampScore() {
     this.emit('dampScoreDecayed', this.dampScore, oldDampScore);
 };
 
-// This function is named with the word "evaluate" because it is not
-// guaranteed that the update will be applied. Naming it "update()"
-// would have been misleading.
-Member.prototype.evaluateUpdate = function evaluateUpdate(update) {
-    // The local override and "other" override rules that are evaluated
-    // here stem from the rules defined in the SWIM paper. They deviate
-    // a bit from that literature since Ringpop has added the "leave"
-    // status and retains faulty members in its membership list.
-    if (this._isLocalOverride(update)) {
-        // Override intended update. Assert aliveness!
-        this.ringpop.stat('increment', 'refuted-update');
-        var newIncNumber = this.Date.now();
-        update = {
-            source: this.ringpop.whoami(),
-            sourceIncarnationNumber: newIncNumber,
-            address: this.address,
-            status: Member.Status.alive,
-            incarnationNumber: newIncNumber
-        };
-    } else if (!this._isOtherOverride(update)) {
-        return;
-    }
-
-    // We've got an update. Apply all-the-things.
-    var oldStatus = this.status;
+// We've got an update. Apply all-the-things.
+Member.prototype.applyUpdate = function applyUpdate(update) {
     if (this.status !== update.status) {
         this.status = update.status;
-
-        if (this.address === this.ringpop.whoami()) {
-            if (this.status === Member.Status.leave) {
-                this.ringpop.membership.emit('event',
-                    new events.LocalMemberLeaveEvent(this, oldStatus));
-            }
-        }
     }
 
     if (this.incarnationNumber !== update.incarnationNumber) {
@@ -136,8 +106,6 @@ Member.prototype.evaluateUpdate = function evaluateUpdate(update) {
     // because decaying the damp score uses the last timestamp to calculate
     // the rate of decay.
     this.lastUpdateTimestamp = this.Date.now();
-
-    return true;
 };
 
 Member.prototype.getStats = function getStats() {
@@ -171,35 +139,6 @@ Member.prototype._applyUpdatePenalty = function _applyUpdatePenalty() {
             suppressLimit: suppressLimit
         });
     }
-};
-
-Member.prototype._isLocalOverride = function _isLocalOverride(update) {
-    if (this.ringpop.whoami() !== this.address) {
-        return false;
-    }
-
-    if (this.incarnationNumber > update.incarnationNumber) {
-        return false;
-    }
-
-    return update.status === Member.Status.faulty ||
-        update.status === Member.Status.suspect ||
-        update.status === Member.Status.tombstone;
-};
-
-Member.prototype._isOtherOverride = function _isOtherOverride(update) {
-    var self = this;
-
-    // update is newer than current member
-    if (update.incarnationNumber > self.incarnationNumber) {
-        return true;
-    }
-    // update is older than current member
-    if (update.incarnationNumber < self.incarnationNumber) {
-        return false;
-    }
-
-    return Member.statusPrecedence(update.status) > Member.statusPrecedence(self.status);
 };
 
 Member.Status = {
@@ -248,6 +187,35 @@ Member.statusPrecedence = function statusPrecedence(status) {
             // unknown states will never have precedence
             return -1;
     }
+};
+
+Member.shouldProcessChange = function shouldProcessChange(member, change) {
+    // don't accept tombstone update on unknown member
+    if (change.status === Member.Status.tombstone && !member) {
+        return false;
+    }
+
+    // accept changes on new members
+    if (!member) {
+        return true;
+    }
+
+    // change is older than current member
+    if (change.incarnationNumber < member.incarnationNumber) {
+        return false;
+    }
+
+    // change is newer than current member
+    if (change.incarnationNumber > member.incarnationNumber) {
+        return true;
+    }
+
+    // change takes precedence over current member
+    if (Member.statusPrecedence(change.status) > Member.statusPrecedence(member.status) ){
+        return true;
+    }
+
+    return false;
 };
 
 module.exports = Member;

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -189,6 +189,19 @@ Member.statusPrecedence = function statusPrecedence(status) {
     }
 };
 
+/**
+ * Determine if the incoming change should be processed or not.
+ * The update should be processed if:
+ *  - the update is about an unknown member and the status is not 'tombstone'
+ *  - the new status takes precedence over the current known status
+ *    (@see Member~statusPrecedence)
+ *  - the incarnation number is newer
+
+ * @param {Member} [member] The current member or null when the member is currently
+ *  unknown.
+ * @param {object} change The incoming update
+ * @returns {boolean} if the gossip should be processed or can safely be ignored.
+ */
 Member.shouldProcessChange = function shouldProcessChange(member, change) {
     // don't accept tombstone update on unknown member
     if (change.status === Member.Status.tombstone && !member) {

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -81,13 +81,8 @@ Member.prototype.decayDampScore = function decayDampScore() {
 
 // We've got an update. Apply all-the-things.
 Member.prototype.applyUpdate = function applyUpdate(update) {
-    if (this.status !== update.status) {
-        this.status = update.status;
-    }
-
-    if (this.incarnationNumber !== update.incarnationNumber) {
-        this.incarnationNumber = update.incarnationNumber;
-    }
+    this.status = update.status;
+    this.incarnationNumber = update.incarnationNumber;
 
     // For damping. Also, you are not allowed to penalize yourself.
     if (this.ringpop.config.get('dampScoringEnabled') &&

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -212,7 +212,7 @@ Member.statusPrecedence = function statusPrecedence(status) {
 };
 
 /**
- * Determine if the incoming change should be processed or not.
+ * Determine if the incoming gossip should be processed or not.
  * The update should be processed if:
  *  - the update is about an unknown member and the status is not 'tombstone'
  *  - the new status takes precedence over the current known status
@@ -224,7 +224,7 @@ Member.statusPrecedence = function statusPrecedence(status) {
  * @param {IMember} change The incoming update
  * @returns {boolean} if the gossip should be processed or can safely be ignored.
  */
-Member.shouldProcessChange = function shouldProcessChange(member, change) {
+Member.shouldProcessGossip = function shouldProcessGossip(member, change) {
     // don't accept tombstone update on unknown member
     if (change.status === Member.Status.tombstone && !member) {
         return false;

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -221,12 +221,12 @@ Member.statusPrecedence = function statusPrecedence(status) {
 
  * @param {Member} [member] The current member or null when the member is currently
  *  unknown.
- * @param {IMember} change The incoming update
+ * @param {IMember} gossip The incoming update
  * @returns {boolean} if the gossip should be processed or can safely be ignored.
  */
-Member.shouldProcessGossip = function shouldProcessGossip(member, change) {
+Member.shouldProcessGossip = function shouldProcessGossip(member, gossip) {
     // don't accept tombstone update on unknown member
-    if (change.status === Member.Status.tombstone && !member) {
+    if (gossip.status === Member.Status.tombstone && !member) {
         return false;
     }
 
@@ -235,18 +235,18 @@ Member.shouldProcessGossip = function shouldProcessGossip(member, change) {
         return true;
     }
 
-    // change is older than current member
-    if (change.incarnationNumber < member.incarnationNumber) {
+    // gossip is older than current member
+    if (gossip.incarnationNumber < member.incarnationNumber) {
         return false;
     }
 
-    // change is newer than current member
-    if (change.incarnationNumber > member.incarnationNumber) {
+    // gossip is newer than current member
+    if (gossip.incarnationNumber > member.incarnationNumber) {
         return true;
     }
 
-    // change takes precedence over current member
-    if (Member.statusPrecedence(change.status) > Member.statusPrecedence(member.status) ){
+    // gossip takes precedence over current member
+    if (Member.statusPrecedence(gossip.status) > Member.statusPrecedence(member.status) ){
         return true;
     }
 

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -25,6 +25,28 @@ var events = require('./events.js');
 var numOrDefault = require('../util.js').numOrDefault;
 var util = require('util');
 
+/**
+ * @interface IMember
+ *
+ * The interface that defines a member object.
+ *
+ * @property {string} address The address of the member
+ * @property {number} incarnationNumber The incarnation number of the member
+ * @property {Member.Status} status The status of the member
+ */
+
+/**
+ * Create a new member
+ * @param {Ringpop} ringpop the ringpop instance
+ * @param {Update} update the update that returns this member.
+ *
+ * @property {string} address The address of the member
+ * @property {number} incarnationNumber The incarnation number of the member
+ * @property {Member.Status} status The status of the member
+ *
+ * @constructor
+ * @implements IMember
+ */
 function Member(ringpop, update) {
     this.ringpop = ringpop;
     this.id = update.address;
@@ -136,6 +158,11 @@ Member.prototype._applyUpdatePenalty = function _applyUpdatePenalty() {
     }
 };
 
+/**
+ * Enum for member status.
+ *
+ * @enum {string}
+ */
 Member.Status = {
     alive: 'alive',
     faulty: 'faulty',
@@ -194,7 +221,7 @@ Member.statusPrecedence = function statusPrecedence(status) {
 
  * @param {Member} [member] The current member or null when the member is currently
  *  unknown.
- * @param {object} change The incoming update
+ * @param {IMember} change The incoming update
  * @returns {boolean} if the gossip should be processed or can safely be ignored.
  */
 Member.shouldProcessChange = function shouldProcessChange(member, change) {

--- a/lib/membership/update.js
+++ b/lib/membership/update.js
@@ -20,29 +20,31 @@
 
 'use strict';
 
-var Member = require('./member.js');
 var uuid = require('node-uuid');
-var util = require('util');
 
-function Update(address, incarnationNumber, status, localMember) {
-    this.address = address;
-    this.incarnationNumber = incarnationNumber;
-    this.status = status;
+/**
+ * Create a new Update
+ * @param {IMember} subject the subject of the update.
+ * @param {IMember} [source] the source of the update.
+ * @constructor
+ */
+function Update(subject, source) {
+    if (!(this instanceof Update)) {
+        return new Update(subject, source);
+    }
     this.id = uuid.v4();
-    localMember = localMember || {};
-    this.source = localMember.address;
-    this.sourceIncarnationNumber = localMember.incarnationNumber;
     this.timestamp = Date.now();
+
+    // Populate subject
+    subject = subject || {};
+    this.address = subject.address;
+    this.incarnationNumber = subject.incarnationNumber;
+    this.status = subject.status;
+
+    // Populate source
+    source = source || {};
+    this.source = source.address;
+    this.sourceIncarnationNumber = source.incarnationNumber;
 }
 
-function LeaveUpdate(address, incarnationNumber, localMember) {
-    LeaveUpdate.super_.call(this, address, incarnationNumber, Member.Status.leave,
-        localMember);
-}
-
-util.inherits(LeaveUpdate, Update);
-
-module.exports = {
-    LeaveUpdate: LeaveUpdate,
-    Update: Update
-};
+module.exports = Update;

--- a/test/integration/proxy_test.js
+++ b/test/integration/proxy_test.js
@@ -1003,7 +1003,6 @@ test('handle tchannel failures', function t(assert) {
             assert.ifError(err);
 
             assert.equal(resp.statusCode, 500);
-            console.log(resp.body);
             assert.ok(/^tchannel: socket closed/.test(resp.body));
 
             cluster.destroy();

--- a/test/integration/proxy_test.js
+++ b/test/integration/proxy_test.js
@@ -1003,6 +1003,7 @@ test('handle tchannel failures', function t(assert) {
             assert.ifError(err);
 
             assert.equal(resp.statusCode, 500);
+            console.log(resp.body);
             assert.ok(/^tchannel: socket closed/.test(resp.body));
 
             cluster.destroy();

--- a/test/lib/test-ringpop.js
+++ b/test/lib/test-ringpop.js
@@ -38,7 +38,7 @@ function testRingpop(opts, name, test) {
 
         ringpop.isReady = true;
 
-        ringpop.membership.makeAlive(ringpop.whoami(), Date.now());
+        ringpop.membership.makeLocalAlive();
 
         // These are made top-level dependencies as a mere
         // convenience to users of the test suite.

--- a/test/unit/damper_test.js
+++ b/test/unit/damper_test.js
@@ -25,6 +25,7 @@ var Damper = require('../../lib/gossip/damper.js');
 var DampReqRequest = require('../../request_response.js').DampReqRequest;
 var DampReqResponse = require('../../request_response.js').DampReqResponse;
 var makeTimersMock = require('../lib/timers-mock');
+var Member = require('../../lib/membership/member.js');
 var MemberDampScore = require('../../lib/membership/member_damp_score.js');
 var testRingpop = require('../lib/test-ringpop.js');
 var timers = require('timer-shim');
@@ -39,7 +40,7 @@ function setupMembership(deps, numMembers) {
     var members = [];
     for (var i = 0; i < numMembers; i++) {
         var member = memberGen();
-        membership.makeAlive(member.address, member.incarnationNumber);
+        membership.makeChange(member.address, member.incarnationNumber, Member.Status.alive);
         members.push(member);
     }
     return members;
@@ -238,7 +239,7 @@ testRingpop('damping member starts expiration', function t(deps, assert) {
     assert.false(damper.dampMember(member1.address), 'cannot damp member');
 
     var membership = deps.membership;
-    membership.makeAlive(member1.address, member1.incarnationNumber);
+    membership.makeChange(member1.address, member1.incarnationNumber, Member.Status.alive);
     assert.false(damper.dampMember(member1.address), 'cannot damp member');
 
     assert.false(damper.expirationTimer, 'expiration timer not started');
@@ -266,7 +267,7 @@ testRingpop('expires damped members', function t(deps, assert) {
     assert.false(damper.dampMember(member1.address), 'cannot damp member');
 
     var membership = deps.membership;
-    membership.makeAlive(member1.address, member1.incarnationNumber);
+    membership.makeChange(member1.address, member1.incarnationNumber, Member.Status.alive);
     assert.false(damper.dampMember(member1.address), 'member is not damped');
 
     damper.addFlapper(member1);

--- a/test/unit/discover_provider_healer_test.js
+++ b/test/unit/discover_provider_healer_test.js
@@ -27,7 +27,7 @@ var DiscoverProviderHealer = require('../../lib/partition_healing/discover_provi
 var Healer = require('../../lib/partition_healing/healer');
 var Ringpop = require('../../index');
 var Member = require('../../lib/membership/member');
-var Update = require('../../lib/membership/update').Update;
+var Update = require('../../lib/membership/update');
 
 /**
  * Small util function to generate a number of fake hosts.
@@ -197,7 +197,11 @@ test('DiscoverProviderHeal.heal - only attempt to heal faulty (or worse) nodes',
     for(var i=0; i<statuses.length; i++) {
         var address = '127.0.0.1:'+ (3100 +i);
         var status = statuses[i];
-        ringpop.membership.update(new Update(address, Date.now(), status));
+        ringpop.membership.update(new Update({
+            address: address,
+            incarnationNumber: Date.now(),
+            status: status
+        }));
         nodes[address] = {
             healAllowed: Member.statusPrecedence(status) >= Member.statusPrecedence(Member.Status.faulty),
             status: status

--- a/test/unit/discover_provider_healer_test.js
+++ b/test/unit/discover_provider_healer_test.js
@@ -188,7 +188,7 @@ test('DiscoverProviderHeal.heal - only attempt to heal faulty (or worse) nodes',
         hostPort: '127.0.0.1:3000',
         discoverProviderHealerMaxFailures: maxFailures
     });
-    ringpop.membership.makeLocalAlive(ringpop.whoami(), Date.now());
+    ringpop.membership.makeLocalAlive();
     ringpop.isReady = true;
 
     var statuses = _.values(Member.Status);

--- a/test/unit/discover_provider_healer_test.js
+++ b/test/unit/discover_provider_healer_test.js
@@ -188,6 +188,7 @@ test('DiscoverProviderHeal.heal - only attempt to heal faulty (or worse) nodes',
         hostPort: '127.0.0.1:3000',
         discoverProviderHealerMaxFailures: maxFailures
     });
+    ringpop.membership.makeLocalAlive(ringpop.whoami(), Date.now());
     ringpop.isReady = true;
 
     var statuses = _.values(Member.Status);

--- a/test/unit/dissemination-test.js
+++ b/test/unit/dissemination-test.js
@@ -20,6 +20,8 @@
 
 'use strict';
 
+var Member = require('../../lib/membership/member.js');
+
 var testRingpop = require('../lib/test-ringpop');
 var mock = require('../mock');
 
@@ -27,8 +29,8 @@ testRingpop('member ship as changes includes all members', function t(deps, asse
     var membership = deps.membership;
     var dissemination = deps.dissemination;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
-    membership.makeAlive('127.0.0.1:3002', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3002', Date.now(), Member.Status.alive);
 
     var membershipAsChanges = dissemination.membershipAsChanges();
     var addrs = membershipAsChanges.map(function mapMember(member) {
@@ -58,7 +60,7 @@ testRingpop('avoids redundant dissemination by filtering changes from source', f
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
 
@@ -87,7 +89,7 @@ testRingpop('raise piggyback counter on issueAsReceiver', function t(deps, asser
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
 
@@ -120,7 +122,7 @@ testRingpop('raise piggyback counter on issueAsSender', function t(deps, assert)
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
 
@@ -166,7 +168,7 @@ testRingpop('tombstone has priority vs other states', function t(deps, assert) {
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
     membership.makeTombstone(addrAlive, incNo);

--- a/test/unit/gossip_test.js
+++ b/test/unit/gossip_test.js
@@ -62,7 +62,7 @@ testRingpop('suspect period for member is started', function t(deps, assert) {
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
     stateTransitions.scheduleSuspectToFaulty(member);
@@ -87,7 +87,7 @@ testRingpop('suspect period cannot be started for local member', function t(deps
 testRingpop('starting the same state transition for a member is a noop', function t(deps, assert) {
     var membership = deps.membership;
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var stateTransitions = deps.stateTransitions;
 
@@ -106,7 +106,7 @@ testRingpop('starting a new state transition for a member stops the previous one
 
     var membership = deps.membership;
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var stateTransitions = deps.stateTransitions;
 
@@ -129,7 +129,7 @@ testRingpop('suspect period can\'t be started until enabled', function t(deps, a
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     stateTransitions.disable();
 
@@ -149,8 +149,8 @@ testRingpop('state transition stop all clears all timers', function t(deps, asse
     var addr2 = '127.0.0.1:3002';
 
     var membership = deps.membership;
-    membership.makeAlive(addr1, Date.now());
-    membership.makeAlive(addr2, Date.now());
+    membership.makeChange(addr1, Date.now(), Member.Status.alive);
+    membership.makeChange(addr2, Date.now(), Member.Status.alive);
 
     var remoteMember = membership.findMemberByAddress(addr1);
     var remoteMember2 = membership.findMemberByAddress(addr2);
@@ -185,7 +185,7 @@ testRingpop({
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
 
@@ -207,7 +207,7 @@ testRingpop({
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
 
@@ -229,7 +229,7 @@ testRingpop({
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
 

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -150,7 +150,7 @@ test('admin leave stops state transitions', function t(assert) {
 
     var ringpop = createRingpop();
     ringpop.membership.makeLocalAlive();
-    ringpop.membership.makeAlive(ringpopRemote.whoami(), Date.now());
+    ringpop.membership.makeChange(ringpopRemote.whoami(), Date.now(), Member.Status.alive);
     ringpop.stateTransitions.scheduleSuspectToFaulty(ringpopRemote.hostPort);
 
     var handleAdminLeave = createAdminLeaveHandler(ringpop);
@@ -322,7 +322,7 @@ test('emits membership changed event', function t(assert) {
 
     var ringpop = createRingpop();
     ringpop.membership.makeLocalAlive();
-    ringpop.membership.makeAlive(node1Addr, Date.now());
+    ringpop.membership.makeChange(node1Addr, Date.now(), Member.Status.alive);
 
     assertChanged();
 
@@ -353,7 +353,7 @@ test('emits ring changed event', function t(assert) {
 
     var ringpop = createRingpop();
     ringpop.membership.makeLocalAlive();
-    ringpop.membership.makeAlive(node1Addr, incNo);
+    ringpop.membership.makeChange(node1Addr, incNo, Member.Status.alive);
 
     function assertChanged(changer, intent) {
         ringpop.once('membershipChanged', function onMembershipChanged() {
@@ -377,21 +377,21 @@ test('emits ring changed event', function t(assert) {
     });
 
     assertChanged(function assertIt() {
-        ringpop.membership.makeAlive(node1Addr, magicIncNo);
+        ringpop.membership.makeChange(node1Addr, magicIncNo, Member.Status.alive);
     }, {
         adding: [node1Addr],
         removing: []
     });
 
     assertChanged(function assertIt() {
-        ringpop.membership.makeLeave(node1Addr, magicIncNo);
+        ringpop.membership.makeChange(node1Addr, magicIncNo, Member.Status.leave);
     }, {
         adding: [],
         removing: [node1Addr]
     });
 
     assertChanged(function assertIt() {
-        ringpop.membership.makeAlive(node2Addr, Date.now());
+        ringpop.membership.makeChange(node2Addr, Date.now(), Member.Status.alive);
     }, {
         adding: [node2Addr],
         removing: []
@@ -434,7 +434,7 @@ testRingpop('max piggyback adjusted on new members', function t(deps, assert) {
 
     var address = '127.0.0.1:3002';
     var incarnationNumber = Date.now();
-    membership.makeAlive(address, incarnationNumber);
+    membership.makeChange(address, incarnationNumber, Member.Status.alive);
 });
 
 test('first time member, not alive', function t(assert) {

--- a/test/unit/member_status_test.js
+++ b/test/unit/member_status_test.js
@@ -93,10 +93,10 @@ function testShouldProcessChange(currentState, expectedOverridingStatuses) {
 
         for (var i = 0; i < ALL_STATUSES.length; i++) {
             var status = ALL_STATUSES[i];
-            if(Member.shouldProcessChange(member, {incarnationNumber: 1, status: status})){
+            if(Member.shouldProcessGossip(member, {incarnationNumber: 1, status: status})){
                 overridingStatuses.push(status);
             }
-            assert.true(Member.shouldProcessChange(member, {incarnationNumber: 2, status: status}), 'newer incarnation should always be processed');
+            assert.true(Member.shouldProcessGossip(member, {incarnationNumber: 2, status: status}), 'newer incarnation should always be processed');
         }
 
         assert.deepEqual(overridingStatuses.sort(), expectedOverridingStatuses.sort());

--- a/test/unit/member_status_test.js
+++ b/test/unit/member_status_test.js
@@ -80,7 +80,7 @@ test('status precedence with unknown state never takes precedence', function t(a
     assert.end()
 });
 
-function testOtherOverride(currentState, expectedOverridingStatuses) {
+function testShouldProcessChange(currentState, expectedOverridingStatuses) {
     test('test other override (' + currentState + ')', function t(assert) {
         var ringpop = new Ringpop({app: 'test', hostPort: '127.0.0.1:3000'});
 
@@ -93,10 +93,10 @@ function testOtherOverride(currentState, expectedOverridingStatuses) {
 
         for (var i = 0; i < ALL_STATUSES.length; i++) {
             var status = ALL_STATUSES[i];
-            if(member._isOtherOverride({incarnationNumber: 1, status: status})){
+            if(Member.shouldProcessChange(member, {incarnationNumber: 1, status: status})){
                 overridingStatuses.push(status);
             }
-            assert.true(member._isOtherOverride({incarnationNumber: 2, status: status}), 'newer incarnation always overrides');
+            assert.true(Member.shouldProcessChange(member, {incarnationNumber: 2, status: status}), 'newer incarnation should always be processed');
         }
 
         assert.deepEqual(overridingStatuses.sort(), expectedOverridingStatuses.sort());
@@ -106,8 +106,8 @@ function testOtherOverride(currentState, expectedOverridingStatuses) {
     });
 }
 
-testOtherOverride('alive', ['suspect', 'faulty', 'leave', 'tombstone']);
-testOtherOverride('suspect', ['faulty', 'leave', 'tombstone']);
-testOtherOverride('faulty', ['leave', 'tombstone']);
-testOtherOverride('leave', ['tombstone']);
-testOtherOverride('tombstone', []);
+testShouldProcessChange('alive', ['suspect', 'faulty', 'leave', 'tombstone']);
+testShouldProcessChange('suspect', ['faulty', 'leave', 'tombstone']);
+testShouldProcessChange('faulty', ['leave', 'tombstone']);
+testShouldProcessChange('leave', ['tombstone']);
+testShouldProcessChange('tombstone', []);

--- a/test/unit/member_test.js
+++ b/test/unit/member_test.js
@@ -208,33 +208,3 @@ testRingpop('member ID is its address', function t(deps, assert) {
     });
     assert.equals(member.id, address, 'ID is address');
 });
-
-// testRingpop('update happens synchronously or not at all', function t(deps, assert) {
-//     var address = '127.0.0.1:3001';
-//     var incarnationNumber = Date.now();
-//     var member = new Member(deps.ringpop, {
-//         address: address,
-//         incarnationNumber: incarnationNumber,
-//         status: Member.Status.alive
-//     });
-//
-//     var emitted = false;
-//     member.on('updated', function onUpdated() {
-//         emitted = true;
-//     });
-//     makeUpdate();
-//     assert.true(emitted, 'event is emitted');
-//
-//     // Reset and try the same (redundant) update again
-//     emitted = false;
-//     makeUpdate();
-//     assert.false(emitted, 'event is not emitted');
-//
-//     function makeUpdate() {
-//         member.applyUpdate({
-//             address: address,
-//             status: Member.Status.suspect,
-//             incarnationNumber: incarnationNumber + 1
-//         });
-//     }
-// });

--- a/test/unit/member_test.js
+++ b/test/unit/member_test.js
@@ -44,7 +44,7 @@ testRingpop('damp score intialized', function t(deps, assert) {
 testRingpop('penalized for update', function t(deps, assert) {
     var membership = deps.membership;
     var member2 = addSecondMember(membership, '127.0.0.1:3001');
-    member2.evaluateUpdate({
+    member2.applyUpdate({
         status: Member.Status.suspect,
         incarnationNumber: Date.now() + 1
     });
@@ -64,11 +64,11 @@ testRingpop('flaps until exceeds suppress limit', function t(deps, assert) {
     var membership = deps.membership;
     var member2 = addSecondMember(membership, '127.0.0.1:3001');
     member2.on('memberSuppressLimitExceeded', onExceeded);
-    member2.evaluateUpdate({
+    member2.applyUpdate({
         status: Member.Status.suspect,
         incarnationNumber: Date.now() + 1
     });
-    member2.evaluateUpdate({
+    member2.applyUpdate({
         status: Member.Status.faulty,
         incarnationNumber: Date.now() + 2
     });
@@ -88,7 +88,7 @@ testRingpop('damp score never exceeds max', function t(deps, assert) {
 
     var membership = deps.membership;
     var member2 = addSecondMember(membership, '127.0.0.1:3001');
-    member2.evaluateUpdate({
+    member2.applyUpdate({
         status: Member.Status.suspect,
         incarnationNumber: Date.now() + 1
     });
@@ -105,7 +105,7 @@ testRingpop('penalized in penalty increments', function t(deps, assert) {
     var member2 = addSecondMember(membership, '127.0.0.1:3001');
 
     // First penalty
-    member2.evaluateUpdate({
+    member2.applyUpdate({
         status: Member.Status.suspect,
         incarnationNumber: Date.now() + 1
     });
@@ -113,7 +113,7 @@ testRingpop('penalized in penalty increments', function t(deps, assert) {
         'damp score is penalty');
 
     // Second
-    member2.evaluateUpdate({
+    member2.applyUpdate({
         status: Member.Status.suspect,
         incarnationNumber: Date.now() + 2
     });
@@ -121,7 +121,7 @@ testRingpop('penalized in penalty increments', function t(deps, assert) {
         'damp score is multiple of penalty');
 
     // Third
-    member2.evaluateUpdate({
+    member2.applyUpdate({
         status: Member.Status.suspect,
         incarnationNumber: Date.now() + 3
     });
@@ -143,7 +143,7 @@ function decayBy(member, term) {
 testRingpop('decays by some arbitrary amount', function t(deps, assert) {
     var membership = deps.membership;
     var member2 = addSecondMember(membership, '127.0.0.1:3001');
-    member2.evaluateUpdate({
+    member2.applyUpdate({
         status: Member.Status.suspect,
         incarnationNumber: Date.now() + 1
     });
@@ -158,7 +158,7 @@ testRingpop('decays by some arbitrary amount', function t(deps, assert) {
 testRingpop('decayed by half', function t(deps, assert) {
     var membership = deps.membership;
     var member2 = addSecondMember(membership, '127.0.0.1:3001');
-    member2.evaluateUpdate({
+    member2.applyUpdate({
         status: Member.Status.suspect,
         incarnationNumber: Date.now() + 1
     });
@@ -179,7 +179,7 @@ testRingpop('never decays below min', function t(deps, assert) {
 
     var membership = deps.membership;
     var member2 = addSecondMember(membership, '127.0.0.1:3001');
-    member2.evaluateUpdate({
+    member2.applyUpdate({
         status: Member.Status.suspect,
         incarnationNumber: Date.now() + 1
     });
@@ -187,7 +187,7 @@ testRingpop('never decays below min', function t(deps, assert) {
     // Penalize until max reached
     var i = 1;
     while (member2.dampScore < config.get('dampScoringMax')) {
-        member2.evaluateUpdate({
+        member2.applyUpdate({
             status: Member.Status.suspect,
             incarnationNumber: Date.now() + i
         });
@@ -209,31 +209,32 @@ testRingpop('member ID is its address', function t(deps, assert) {
     assert.equals(member.id, address, 'ID is address');
 });
 
-testRingpop('update happens synchronously or not at all', function t(deps, assert) {
-    var address = '127.0.0.1:3001';
-    var incarnationNumber = Date.now();
-    var member = new Member(deps.ringpop, {
-        address: address,
-        incarnationNumber: incarnationNumber,
-        status: Member.Status.alive
-    });
-    var emitted = false;
-    member.on('updated', function onUpdated() {
-        emitted = true;
-    });
-    makeUpdate();
-    assert.true(emitted, 'event is emitted');
-
-    // Reset and try the same (redundant) update again
-    emitted = false;
-    makeUpdate();
-    assert.false(emitted, 'event is not emitted');
-
-    function makeUpdate() {
-        member.evaluateUpdate({
-            address: address,
-            status: Member.Status.suspect,
-            incarnationNumber: incarnationNumber + 1
-        });
-    }
-});
+// testRingpop('update happens synchronously or not at all', function t(deps, assert) {
+//     var address = '127.0.0.1:3001';
+//     var incarnationNumber = Date.now();
+//     var member = new Member(deps.ringpop, {
+//         address: address,
+//         incarnationNumber: incarnationNumber,
+//         status: Member.Status.alive
+//     });
+//
+//     var emitted = false;
+//     member.on('updated', function onUpdated() {
+//         emitted = true;
+//     });
+//     makeUpdate();
+//     assert.true(emitted, 'event is emitted');
+//
+//     // Reset and try the same (redundant) update again
+//     emitted = false;
+//     makeUpdate();
+//     assert.false(emitted, 'event is not emitted');
+//
+//     function makeUpdate() {
+//         member.applyUpdate({
+//             address: address,
+//             status: Member.Status.suspect,
+//             incarnationNumber: incarnationNumber + 1
+//         });
+//     }
+// });

--- a/test/unit/membership-iterator-test.js
+++ b/test/unit/membership-iterator-test.js
@@ -18,14 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+var Member = require('../../lib/membership/member.js');
+
 var testRingpop = require('../lib/test-ringpop.js');
 
 testRingpop('iterates over two members correctly', function t(deps, assert) {
     var membership = deps.membership;
     var iterator = deps.iterator;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
-    membership.makeAlive('127.0.0.1:3002', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3002', Date.now(), Member.Status.alive);
 
     var iterated = {};
     iterated[iterator.next().address] = true;
@@ -38,9 +40,9 @@ testRingpop('iterates over three members correctly', function t(deps, assert) {
     var membership = deps.membership;
     var iterator = deps.iterator;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
-    membership.makeAlive('127.0.0.1:3002', Date.now());
-    membership.makeAlive('127.0.0.1:3003', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3002', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3003', Date.now(), Member.Status.alive);
 
     var iterated = {};
     iterated[iterator.next().address] = true;
@@ -54,9 +56,9 @@ testRingpop('skips over faulty member and 1 local member', function t(deps, asse
     var membership = deps.membership;
     var iterator = deps.iterator;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
     membership.makeFaulty('127.0.0.1:3002', Date.now());
-    membership.makeAlive('127.0.0.1:3003', Date.now());
+    membership.makeChange('127.0.0.1:3003', Date.now(), Member.Status.alive);
 
     var iterated = {};
     iterated[iterator.next().address] = true;

--- a/test/unit/membership_test.js
+++ b/test/unit/membership_test.js
@@ -191,6 +191,7 @@ testRingpop('cannot evict self', function t(deps, assert) {
 testRingpop('generate checksums string preserves order of members', function t(deps, assert) {
     var membership = deps.membership;
 
+    // Start with 1 to skip over the local (that's already alive) member.
     for (var i = 1; i < 100; i++) {
         membership.makeAlive('127.0.0.1:' + (3000 + i), Date.now());
     }

--- a/test/unit/membership_test.js
+++ b/test/unit/membership_test.js
@@ -29,7 +29,7 @@ testRingpop('checksum is changed when membership is updated', function t(deps, a
     membership.makeLocalAlive();
     var prevChecksum = membership.checksum;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
 
     assert.doesNotEqual(membership.checksum, prevChecksum, 'checksum is changed');
 });
@@ -124,7 +124,7 @@ testRingpop('member is able to go from alive to faulty without going through sus
     var membership = deps.membership;
 
     var newMemberAddr = '127.0.0.1:3001';
-    membership.makeAlive(newMemberAddr, Date.now());
+    membership.makeChange(newMemberAddr, Date.now(), Member.Status.alive);
 
     var newMember = membership.findMemberByAddress(newMemberAddr);
     assert.equals(newMember.status, Member.Status.alive, 'member starts alive');
@@ -152,13 +152,13 @@ testRingpop('leave does not cause neverending updates', function t(deps, assert)
     var addr = '127.0.0.1:3001';
     var incNo = Date.now();
 
-    var updates = membership.makeAlive(addr, incNo);
+    var updates = membership.makeChange(addr, incNo, Member.Status.alive);
     assert.equals(updates.length, 1, 'alive update applied');
 
-    updates = membership.makeLeave(addr, incNo);
+    updates = membership.makeChange(addr, incNo, Member.Status.leave);
     assert.equals(updates.length, 1, 'leave update applied');
 
-    updates = membership.makeLeave(addr, incNo);
+    updates = membership.makeChange(addr, incNo, Member.Status.leave);
     assert.equals(updates.length, 0, 'no leave update applied');
 });
 
@@ -168,7 +168,7 @@ testRingpop('evict removes a member', function t(deps, assert) {
     var addr = '127.0.0.1:3001';
     var incNo = Date.now();
 
-    membership.makeAlive(addr, incNo);
+    membership.makeChange(addr, incNo, Member.Status.alive);
     assert.ok(membership.getMemberAt(1), 'alive applied');
     assert.ok(membership.findMemberByAddress(addr), 'alive applied');
 
@@ -193,7 +193,7 @@ testRingpop('generate checksums string preserves order of members', function t(d
 
     // Start with 1 to skip over the local (that's already alive) member.
     for (var i = 1; i < 100; i++) {
-        membership.makeAlive('127.0.0.1:' + (3000 + i), Date.now());
+        membership.makeChange('127.0.0.1:' + (3000 + i), Date.now(), Member.Status.alive);
     }
 
     // Make sure they're out of order
@@ -217,7 +217,7 @@ testRingpop('sets previously stashed updates', function t(deps, assert) {
     // Make sure updates are stashed -- make ringpop non-ready.
     ringpop.isReady = false;
 
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
     assert.notok(membership.findMemberByAddress(address), 'member is not found');
 
     membership.set();
@@ -238,7 +238,7 @@ testRingpop('set adds all members', function t(deps, assert) {
 
     // Stash all members
     addresses.forEach(function eachAddr(addr) {
-        membership.makeAlive(addr, Date.now());
+        membership.makeChange(addr, Date.now(), Member.Status.alive);
     });
 
     addresses.forEach(function eachAddr(addr) {
@@ -276,7 +276,7 @@ testRingpop('set emits an event', function t(deps, assert) {
         assert.pass('membership set');
     });
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
     membership.set();
 });
 
@@ -291,7 +291,7 @@ testRingpop('set computes a checksum once', function t(deps, assert) {
         assert.pass('checksum computed');
     });
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
     membership.set();
 });
 
@@ -308,7 +308,7 @@ testRingpop('set does not shuffle member positions', function t(deps, assert) {
         if (addr === ringpop.whoami()) {
             membership.makeLocalAlive();
         } else {
-            membership.makeAlive(addr, Date.now());
+            membership.makeChange(addr, Date.now(), Member.Status.alive);
         }
     });
 

--- a/test/unit/server/protocol/damp_req_test.js
+++ b/test/unit/server/protocol/damp_req_test.js
@@ -23,6 +23,7 @@
 var _ = require('underscore');
 var after = require('after');
 var createDampReqHandler = require('../../../../server/protocol/damp_req.js');
+var Member = require('../../../../lib/membership/member.js');
 var fixtures = require('../../../fixtures.js');
 var testRingpop = require('../../../lib/test-ringpop.js');
 
@@ -64,8 +65,10 @@ testRingpop('responds with damp scores', function t(deps, assert) {
         return genMember();
     });
     members.forEach(function each(member) {
-        ringpop.membership.makeAlive(member.address,
-            member.incarnationNumber);
+        ringpop.membership.makeChange(
+            member.address,
+            member.incarnationNumber,
+            Member.Status.alive);
     });
 
     // Clear changes from the dissemination component to


### PR DESCRIPTION
Use a in-memory object to represent once local state. This makes the code path that updates the local state more robust. Instead of changing the state of the current node by updating it using updates, we just change the `localMember`. 
Whenever a gossip comes in changing the current state, we can always "counter-gossip" with the current state.

_Note: this is the first PR of a serie of refactors:_

- [x] Use a local member object to maintain local state:  #291 (this PR)
- [x] Use a common method for status updates: #292
- [x] Remove `LeaveUpdate`-object: #293
- [x] Remove "unsupported" state update methods: #294
- [x] Add a `populate{Subject,Source}` to the Change Object: #296
- [x] Add a `_reincarnate`-method to centralize reincarnation logic: #291 (this PR)