### PR TITLE
Status refactor 2: Refactor make* to use common method

### DIFF
--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -27,10 +27,8 @@ var MemberDampScore = require('./member_damp_score.js');
 var MembershipEvents = require('./events.js');
 var mergeMembershipChangesets = require('./merge.js');
 var timers = require('timers');
-var update = require('./update.js');
+var Update = require('./update.js');
 var util = require('util');
-
-var Update = update.Update;
 
 function Membership(opts) {
     this.ringpop = opts.ringpop; // assumed to be present

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -217,14 +217,14 @@ Membership.prototype.makeLocalAlive = function makeLocalAlive(){
 Membership.prototype._reincarnate = function _reincarnate() {
     this.localMember.incarnationNumber = Date.now();
 
-    return new Update(this.localMember.address, this.localMember.incarnationNumber, this.localMember.status, this.localMember);
+    return new Update(this.localMember, this.localMember);
 };
 
 /**
  * Change the status of the local member. This will also bump the incarnation
  * number of the local member.
  *
- * @param status The new status (@see Member.Status)
+ * @param {Member.Status} status The new status
  */
 Membership.prototype.setLocalStatus = function setLocalStatus(status) {
     if (this.localMember) {
@@ -235,7 +235,11 @@ Membership.prototype.setLocalStatus = function setLocalStatus(status) {
 
         this.localMember.status = status;
     } else {
-        this.localMember = new Member(this.ringpop, new Update(this.ringpop.whoami(), Date.now(), status, null));
+        this.localMember = new Member(this.ringpop, new Update({
+            address: this.ringpop.whoami(),
+            incarnationNumber: Date.now(),
+            status: status
+        }));
         this.members.push(this.localMember);
         this.membersByAddress[this.localMember.address] = this.localMember;
     }
@@ -259,12 +263,21 @@ Membership.prototype._postLocalUpdate = function _postLocalUpdate(update){
  *
  * @param {string} address the address of the member.
  * @param {int} incarnationNumber The incarnationNumber of the member.
- * @param {string} status The (new) status of the member (@see Member.Status).
+ * @param {Member.Status} status The (new) status of the member.
  */
 Membership.prototype.makeChange = function makeChange(address, incarnationNumber, status) {
     this.ringpop.stat('increment', 'make-'+status);
+    var member = this.findMemberByAddress(address);
 
-    var change = new Update(address, incarnationNumber, status, this.localMember);
+    var change = new Update(member, this.localMember);
+
+    // in case member is not (yet) known
+    change.address = address;
+
+    // overwrite with provided state
+    change.incarnationNumber = incarnationNumber;
+    change.status = status;
+
     return this._updateMember(change);
 };
 

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -258,7 +258,7 @@ Membership.prototype._postLocalUpdate = function _postLocalUpdate(update){
  * Make a change to the member list.
  *
  * @param {string} address the address of the member.
- * @param {int} incarnationNumber The incrnationNumber of the member.
+ * @param {int} incarnationNumber The incarnationNumber of the member.
  * @param {string} status The (new) status of the member (@see Member.Status).
  */
 Membership.prototype.makeChange = function makeChange(address, incarnationNumber, status) {

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -281,10 +281,6 @@ Membership.prototype.makeChange = function makeChange(address, incarnationNumber
     return this._updateMember(change);
 };
 
-Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber) {
-    return this.makeChange(address, incarnationNumber, Member.Status.alive);
-};
-
 Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumber*/) {
     //TODO this statter should be removed when this function actually calls makeChange to prevent "double statting"!
     this.ringpop.stat('increment', 'make-damped');
@@ -299,10 +295,6 @@ Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumb
 
 Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber) {
     return this.makeChange(address, incarnationNumber, Member.Status.faulty);
-};
-
-Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber) {
-    return this.makeChange(address, incarnationNumber, Member.Status.leave);
 };
 
 Membership.prototype.makeSuspect = function makeSuspect(address, incarnationNumber) {

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -30,7 +30,6 @@ var timers = require('timers');
 var update = require('./update.js');
 var util = require('util');
 
-var LeaveUpdate = update.LeaveUpdate;
 var Update = update.Update;
 
 function Membership(opts) {
@@ -239,13 +238,26 @@ Membership.prototype._postLocalUpdate = function _postLocalUpdate(){
     this.emit('updated', [update]);
 };
 
+/**
+ * Make a change to the member list.
+ *
+ * @param {string} address the address of the member.
+ * @param {int} incarnationNumber The incrnationNumber of the member.
+ * @param {string} status The (new) status of the member (@see Member.Status).
+ */
+Membership.prototype.makeChange = function makeChange(address, incarnationNumber, status) {
+    this.ringpop.stat('increment', 'make-'+status);
+
+    var change = new Update(address, incarnationNumber, status, this.localMember);
+    return this._updateMember(change);
+};
+
 Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber) {
-    this.ringpop.stat('increment', 'make-alive');
-    return this._updateMember(new Update(address, incarnationNumber,
-        Member.Status.alive, this.localMember));
+    return this.makeChange(address, incarnationNumber, Member.Status.alive);
 };
 
 Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumber*/) {
+    //TODO this statter should be removed when this function actually calls makeChange to prevent "double statting"!
     this.ringpop.stat('increment', 'make-damped');
     var level = this.ringpop.config.get('dampedErrorLoggingEnabled') ? 'error' : 'warn';
     this.ringpop.logger[level]('ringpop member would have been damped', {
@@ -253,32 +265,23 @@ Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumb
         damped: address
     });
     // TODO Apply damped status to member
-    //return this._makeUpdate(address, incarnationNumber, Member.Status.damped);
+    //return this.makeChange(address, incarnationNumber, Member.Status.damped);
 };
 
 Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber) {
-    this.ringpop.stat('increment', 'make-faulty');
-
-    return this._updateMember(new Update(address, incarnationNumber,
-        Member.Status.faulty, this.localMember));
+    return this.makeChange(address, incarnationNumber, Member.Status.faulty);
 };
 
 Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber) {
-    this.ringpop.stat('increment', 'make-leave');
-    return this._updateMember(new LeaveUpdate(address, incarnationNumber,
-        this.localMember));
+    return this.makeChange(address, incarnationNumber, Member.Status.leave);
 };
 
 Membership.prototype.makeSuspect = function makeSuspect(address, incarnationNumber) {
-    this.ringpop.stat('increment', 'make-suspect');
-    return this._updateMember(new Update(address, incarnationNumber,
-        Member.Status.suspect, this.localMember));
+    return this.makeChange(address, incarnationNumber, Member.Status.suspect);
 };
 
 Membership.prototype.makeTombstone = function makeTombstone(address, incarnationNumber) {
-    this.ringpop.stat('increment', 'make-tombstone');
-    return this._updateMember(new Update(address, incarnationNumber,
-        Member.Status.tombstone, this.localMember));
+    return this.makeChange(address, incarnationNumber, Member.Status.tombstone);
 };
 
 Membership.prototype.removeMember = function removeMember(address) {

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -25,6 +25,28 @@ var events = require('./events.js');
 var numOrDefault = require('../util.js').numOrDefault;
 var util = require('util');
 
+/**
+ * @interface IMember
+ *
+ * The interface that defines a member object.
+ *
+ * @property {string} address The address of the member
+ * @property {number} incarnationNumber The incarnation number of the member
+ * @property {Member.Status} status The status of the member
+ */
+
+/**
+ * Create a new member
+ * @param {Ringpop} ringpop the ringpop instance
+ * @param {Update} update the update that returns this member.
+ *
+ * @property {string} address The address of the member
+ * @property {number} incarnationNumber The incarnation number of the member
+ * @property {Member.Status} status The status of the member
+ *
+ * @constructor
+ * @implements IMember
+ */
 function Member(ringpop, update) {
     this.ringpop = ringpop;
     this.id = update.address;
@@ -136,6 +158,11 @@ Member.prototype._applyUpdatePenalty = function _applyUpdatePenalty() {
     }
 };
 
+/**
+ * Enum for member status.
+ *
+ * @enum {string}
+ */
 Member.Status = {
     alive: 'alive',
     faulty: 'faulty',
@@ -194,7 +221,7 @@ Member.statusPrecedence = function statusPrecedence(status) {
 
  * @param {Member} [member] The current member or null when the member is currently
  *  unknown.
- * @param {object} change The incoming update
+ * @param {IMember} change The incoming update
  * @returns {boolean} if the gossip should be processed or can safely be ignored.
  */
 Member.shouldProcessChange = function shouldProcessChange(member, change) {

--- a/lib/membership/update.js
+++ b/lib/membership/update.js
@@ -20,9 +20,7 @@
 
 'use strict';
 
-var Member = require('./member.js');
 var uuid = require('node-uuid');
-var util = require('util');
 
 /**
  * Create a new Update
@@ -49,14 +47,4 @@ function Update(subject, source) {
     this.sourceIncarnationNumber = source.incarnationNumber;
 }
 
-function LeaveUpdate(address, incarnationNumber, localMember) {
-    LeaveUpdate.super_.call(this, address, incarnationNumber, Member.Status.leave,
-        localMember);
-}
-
-util.inherits(LeaveUpdate, Update);
-
-module.exports = {
-    LeaveUpdate: LeaveUpdate,
-    Update: Update
-};
+module.exports = Update;

--- a/lib/membership/update.js
+++ b/lib/membership/update.js
@@ -24,15 +24,29 @@ var Member = require('./member.js');
 var uuid = require('node-uuid');
 var util = require('util');
 
-function Update(address, incarnationNumber, status, localMember) {
-    this.address = address;
-    this.incarnationNumber = incarnationNumber;
-    this.status = status;
+/**
+ * Create a new Update
+ * @param {IMember} subject the subject of the update.
+ * @param {IMember} [source] the source of the update.
+ * @constructor
+ */
+function Update(subject, source) {
+    if (!(this instanceof Update)) {
+        return new Update(subject, source);
+    }
     this.id = uuid.v4();
-    localMember = localMember || {};
-    this.source = localMember.address;
-    this.sourceIncarnationNumber = localMember.incarnationNumber;
     this.timestamp = Date.now();
+
+    // Populate subject
+    subject = subject || {};
+    this.address = subject.address;
+    this.incarnationNumber = subject.incarnationNumber;
+    this.status = subject.status;
+
+    // Populate source
+    source = source || {};
+    this.source = source.address;
+    this.sourceIncarnationNumber = source.incarnationNumber;
 }
 
 function LeaveUpdate(address, incarnationNumber, localMember) {

--- a/test/unit/damper_test.js
+++ b/test/unit/damper_test.js
@@ -25,6 +25,7 @@ var Damper = require('../../lib/gossip/damper.js');
 var DampReqRequest = require('../../request_response.js').DampReqRequest;
 var DampReqResponse = require('../../request_response.js').DampReqResponse;
 var makeTimersMock = require('../lib/timers-mock');
+var Member = require('../../lib/membership/member.js');
 var MemberDampScore = require('../../lib/membership/member_damp_score.js');
 var testRingpop = require('../lib/test-ringpop.js');
 var timers = require('timer-shim');
@@ -39,7 +40,7 @@ function setupMembership(deps, numMembers) {
     var members = [];
     for (var i = 0; i < numMembers; i++) {
         var member = memberGen();
-        membership.makeAlive(member.address, member.incarnationNumber);
+        membership.makeChange(member.address, member.incarnationNumber, Member.Status.alive);
         members.push(member);
     }
     return members;
@@ -238,7 +239,7 @@ testRingpop('damping member starts expiration', function t(deps, assert) {
     assert.false(damper.dampMember(member1.address), 'cannot damp member');
 
     var membership = deps.membership;
-    membership.makeAlive(member1.address, member1.incarnationNumber);
+    membership.makeChange(member1.address, member1.incarnationNumber, Member.Status.alive);
     assert.false(damper.dampMember(member1.address), 'cannot damp member');
 
     assert.false(damper.expirationTimer, 'expiration timer not started');
@@ -266,7 +267,7 @@ testRingpop('expires damped members', function t(deps, assert) {
     assert.false(damper.dampMember(member1.address), 'cannot damp member');
 
     var membership = deps.membership;
-    membership.makeAlive(member1.address, member1.incarnationNumber);
+    membership.makeChange(member1.address, member1.incarnationNumber, Member.Status.alive);
     assert.false(damper.dampMember(member1.address), 'member is not damped');
 
     damper.addFlapper(member1);

--- a/test/unit/discover_provider_healer_test.js
+++ b/test/unit/discover_provider_healer_test.js
@@ -197,7 +197,11 @@ test('DiscoverProviderHeal.heal - only attempt to heal faulty (or worse) nodes',
     for(var i=0; i<statuses.length; i++) {
         var address = '127.0.0.1:'+ (3100 +i);
         var status = statuses[i];
-        ringpop.membership.update(new Update(address, Date.now(), status));
+        ringpop.membership.update(new Update({
+            address: address,
+            incarnationNumber: Date.now(),
+            status: status
+        }));
         nodes[address] = {
             healAllowed: Member.statusPrecedence(status) >= Member.statusPrecedence(Member.Status.faulty),
             status: status

--- a/test/unit/discover_provider_healer_test.js
+++ b/test/unit/discover_provider_healer_test.js
@@ -27,7 +27,7 @@ var DiscoverProviderHealer = require('../../lib/partition_healing/discover_provi
 var Healer = require('../../lib/partition_healing/healer');
 var Ringpop = require('../../index');
 var Member = require('../../lib/membership/member');
-var Update = require('../../lib/membership/update').Update;
+var Update = require('../../lib/membership/update');
 
 /**
  * Small util function to generate a number of fake hosts.

--- a/test/unit/dissemination-test.js
+++ b/test/unit/dissemination-test.js
@@ -20,6 +20,8 @@
 
 'use strict';
 
+var Member = require('../../lib/membership/member.js');
+
 var testRingpop = require('../lib/test-ringpop');
 var mock = require('../mock');
 
@@ -27,8 +29,8 @@ testRingpop('member ship as changes includes all members', function t(deps, asse
     var membership = deps.membership;
     var dissemination = deps.dissemination;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
-    membership.makeAlive('127.0.0.1:3002', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3002', Date.now(), Member.Status.alive);
 
     var membershipAsChanges = dissemination.membershipAsChanges();
     var addrs = membershipAsChanges.map(function mapMember(member) {
@@ -58,7 +60,7 @@ testRingpop('avoids redundant dissemination by filtering changes from source', f
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
 
@@ -87,7 +89,7 @@ testRingpop('raise piggyback counter on issueAsReceiver', function t(deps, asser
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
 
@@ -120,7 +122,7 @@ testRingpop('raise piggyback counter on issueAsSender', function t(deps, assert)
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
 
@@ -166,7 +168,7 @@ testRingpop('tombstone has priority vs other states', function t(deps, assert) {
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
     membership.makeTombstone(addrAlive, incNo);

--- a/test/unit/gossip_test.js
+++ b/test/unit/gossip_test.js
@@ -62,7 +62,7 @@ testRingpop('suspect period for member is started', function t(deps, assert) {
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
     stateTransitions.scheduleSuspectToFaulty(member);
@@ -87,7 +87,7 @@ testRingpop('suspect period cannot be started for local member', function t(deps
 testRingpop('starting the same state transition for a member is a noop', function t(deps, assert) {
     var membership = deps.membership;
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var stateTransitions = deps.stateTransitions;
 
@@ -106,7 +106,7 @@ testRingpop('starting a new state transition for a member stops the previous one
 
     var membership = deps.membership;
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var stateTransitions = deps.stateTransitions;
 
@@ -129,7 +129,7 @@ testRingpop('suspect period can\'t be started until enabled', function t(deps, a
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     stateTransitions.disable();
 
@@ -149,8 +149,8 @@ testRingpop('state transition stop all clears all timers', function t(deps, asse
     var addr2 = '127.0.0.1:3002';
 
     var membership = deps.membership;
-    membership.makeAlive(addr1, Date.now());
-    membership.makeAlive(addr2, Date.now());
+    membership.makeChange(addr1, Date.now(), Member.Status.alive);
+    membership.makeChange(addr2, Date.now(), Member.Status.alive);
 
     var remoteMember = membership.findMemberByAddress(addr1);
     var remoteMember2 = membership.findMemberByAddress(addr2);
@@ -185,7 +185,7 @@ testRingpop({
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
 
@@ -207,7 +207,7 @@ testRingpop({
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
 
@@ -229,7 +229,7 @@ testRingpop({
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
 

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -150,7 +150,7 @@ test('admin leave stops state transitions', function t(assert) {
 
     var ringpop = createRingpop();
     ringpop.membership.makeLocalAlive();
-    ringpop.membership.makeAlive(ringpopRemote.whoami(), Date.now());
+    ringpop.membership.makeChange(ringpopRemote.whoami(), Date.now(), Member.Status.alive);
     ringpop.stateTransitions.scheduleSuspectToFaulty(ringpopRemote.hostPort);
 
     var handleAdminLeave = createAdminLeaveHandler(ringpop);
@@ -322,7 +322,7 @@ test('emits membership changed event', function t(assert) {
 
     var ringpop = createRingpop();
     ringpop.membership.makeLocalAlive();
-    ringpop.membership.makeAlive(node1Addr, Date.now());
+    ringpop.membership.makeChange(node1Addr, Date.now(), Member.Status.alive);
 
     assertChanged();
 
@@ -353,7 +353,7 @@ test('emits ring changed event', function t(assert) {
 
     var ringpop = createRingpop();
     ringpop.membership.makeLocalAlive();
-    ringpop.membership.makeAlive(node1Addr, incNo);
+    ringpop.membership.makeChange(node1Addr, incNo, Member.Status.alive);
 
     function assertChanged(changer, intent) {
         ringpop.once('membershipChanged', function onMembershipChanged() {
@@ -377,21 +377,21 @@ test('emits ring changed event', function t(assert) {
     });
 
     assertChanged(function assertIt() {
-        ringpop.membership.makeAlive(node1Addr, magicIncNo);
+        ringpop.membership.makeChange(node1Addr, magicIncNo, Member.Status.alive);
     }, {
         adding: [node1Addr],
         removing: []
     });
 
     assertChanged(function assertIt() {
-        ringpop.membership.makeLeave(node1Addr, magicIncNo);
+        ringpop.membership.makeChange(node1Addr, magicIncNo, Member.Status.leave);
     }, {
         adding: [],
         removing: [node1Addr]
     });
 
     assertChanged(function assertIt() {
-        ringpop.membership.makeAlive(node2Addr, Date.now());
+        ringpop.membership.makeChange(node2Addr, Date.now(), Member.Status.alive);
     }, {
         adding: [node2Addr],
         removing: []
@@ -434,7 +434,7 @@ testRingpop('max piggyback adjusted on new members', function t(deps, assert) {
 
     var address = '127.0.0.1:3002';
     var incarnationNumber = Date.now();
-    membership.makeAlive(address, incarnationNumber);
+    membership.makeChange(address, incarnationNumber, Member.Status.alive);
 });
 
 test('first time member, not alive', function t(assert) {

--- a/test/unit/membership-iterator-test.js
+++ b/test/unit/membership-iterator-test.js
@@ -18,14 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+var Member = require('../../lib/membership/member.js');
+
 var testRingpop = require('../lib/test-ringpop.js');
 
 testRingpop('iterates over two members correctly', function t(deps, assert) {
     var membership = deps.membership;
     var iterator = deps.iterator;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
-    membership.makeAlive('127.0.0.1:3002', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3002', Date.now(), Member.Status.alive);
 
     var iterated = {};
     iterated[iterator.next().address] = true;
@@ -38,9 +40,9 @@ testRingpop('iterates over three members correctly', function t(deps, assert) {
     var membership = deps.membership;
     var iterator = deps.iterator;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
-    membership.makeAlive('127.0.0.1:3002', Date.now());
-    membership.makeAlive('127.0.0.1:3003', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3002', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3003', Date.now(), Member.Status.alive);
 
     var iterated = {};
     iterated[iterator.next().address] = true;
@@ -54,9 +56,9 @@ testRingpop('skips over faulty member and 1 local member', function t(deps, asse
     var membership = deps.membership;
     var iterator = deps.iterator;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
     membership.makeFaulty('127.0.0.1:3002', Date.now());
-    membership.makeAlive('127.0.0.1:3003', Date.now());
+    membership.makeChange('127.0.0.1:3003', Date.now(), Member.Status.alive);
 
     var iterated = {};
     iterated[iterator.next().address] = true;

--- a/test/unit/membership_test.js
+++ b/test/unit/membership_test.js
@@ -29,7 +29,7 @@ testRingpop('checksum is changed when membership is updated', function t(deps, a
     membership.makeLocalAlive();
     var prevChecksum = membership.checksum;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
 
     assert.doesNotEqual(membership.checksum, prevChecksum, 'checksum is changed');
 });
@@ -124,7 +124,7 @@ testRingpop('member is able to go from alive to faulty without going through sus
     var membership = deps.membership;
 
     var newMemberAddr = '127.0.0.1:3001';
-    membership.makeAlive(newMemberAddr, Date.now());
+    membership.makeChange(newMemberAddr, Date.now(), Member.Status.alive);
 
     var newMember = membership.findMemberByAddress(newMemberAddr);
     assert.equals(newMember.status, Member.Status.alive, 'member starts alive');
@@ -152,13 +152,13 @@ testRingpop('leave does not cause neverending updates', function t(deps, assert)
     var addr = '127.0.0.1:3001';
     var incNo = Date.now();
 
-    var updates = membership.makeAlive(addr, incNo);
+    var updates = membership.makeChange(addr, incNo, Member.Status.alive);
     assert.equals(updates.length, 1, 'alive update applied');
 
-    updates = membership.makeLeave(addr, incNo);
+    updates = membership.makeChange(addr, incNo, Member.Status.leave);
     assert.equals(updates.length, 1, 'leave update applied');
 
-    updates = membership.makeLeave(addr, incNo);
+    updates = membership.makeChange(addr, incNo, Member.Status.leave);
     assert.equals(updates.length, 0, 'no leave update applied');
 });
 
@@ -168,7 +168,7 @@ testRingpop('evict removes a member', function t(deps, assert) {
     var addr = '127.0.0.1:3001';
     var incNo = Date.now();
 
-    membership.makeAlive(addr, incNo);
+    membership.makeChange(addr, incNo, Member.Status.alive);
     assert.ok(membership.getMemberAt(1), 'alive applied');
     assert.ok(membership.findMemberByAddress(addr), 'alive applied');
 
@@ -193,7 +193,7 @@ testRingpop('generate checksums string preserves order of members', function t(d
 
     // Start with 1 to skip over the local (that's already alive) member.
     for (var i = 1; i < 100; i++) {
-        membership.makeAlive('127.0.0.1:' + (3000 + i), Date.now());
+        membership.makeChange('127.0.0.1:' + (3000 + i), Date.now(), Member.Status.alive);
     }
 
     // Make sure they're out of order
@@ -217,7 +217,7 @@ testRingpop('sets previously stashed updates', function t(deps, assert) {
     // Make sure updates are stashed -- make ringpop non-ready.
     ringpop.isReady = false;
 
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
     assert.notok(membership.findMemberByAddress(address), 'member is not found');
 
     membership.set();
@@ -238,7 +238,7 @@ testRingpop('set adds all members', function t(deps, assert) {
 
     // Stash all members
     addresses.forEach(function eachAddr(addr) {
-        membership.makeAlive(addr, Date.now());
+        membership.makeChange(addr, Date.now(), Member.Status.alive);
     });
 
     addresses.forEach(function eachAddr(addr) {
@@ -276,7 +276,7 @@ testRingpop('set emits an event', function t(deps, assert) {
         assert.pass('membership set');
     });
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
     membership.set();
 });
 
@@ -291,7 +291,7 @@ testRingpop('set computes a checksum once', function t(deps, assert) {
         assert.pass('checksum computed');
     });
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
     membership.set();
 });
 
@@ -308,7 +308,7 @@ testRingpop('set does not shuffle member positions', function t(deps, assert) {
         if (addr === ringpop.whoami()) {
             membership.makeLocalAlive();
         } else {
-            membership.makeAlive(addr, Date.now());
+            membership.makeChange(addr, Date.now(), Member.Status.alive);
         }
     });
 

--- a/test/unit/server/protocol/damp_req_test.js
+++ b/test/unit/server/protocol/damp_req_test.js
@@ -23,6 +23,7 @@
 var _ = require('underscore');
 var after = require('after');
 var createDampReqHandler = require('../../../../server/protocol/damp_req.js');
+var Member = require('../../../../lib/membership/member.js');
 var fixtures = require('../../../fixtures.js');
 var testRingpop = require('../../../lib/test-ringpop.js');
 
@@ -64,8 +65,10 @@ testRingpop('responds with damp scores', function t(deps, assert) {
         return genMember();
     });
     members.forEach(function each(member) {
-        ringpop.membership.makeAlive(member.address,
-            member.incarnationNumber);
+        ringpop.membership.makeChange(
+            member.address,
+            member.incarnationNumber,
+            Member.Status.alive);
     });
 
     // Clear changes from the dissemination component to


### PR DESCRIPTION
There’s a lot of code duplication among the different `make{Alive,Faulty,Leave,Suspect,Tombstone}`-functions. This PR adds a `makeChange`-function that does all the work of the previous `make*Status*`-functions.

_Note: this is the second PR of a serie of refactors_