### PR TITLE
Status refactor 3: Remove the now unused “LeaveUpdate”

### DIFF
--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -27,10 +27,8 @@ var MemberDampScore = require('./member_damp_score.js');
 var MembershipEvents = require('./events.js');
 var mergeMembershipChangesets = require('./merge.js');
 var timers = require('timers');
-var update = require('./update.js');
+var Update = require('./update.js');
 var util = require('util');
-
-var Update = update.Update;
 
 function Membership(opts) {
     this.ringpop = opts.ringpop; // assumed to be present

--- a/lib/membership/update.js
+++ b/lib/membership/update.js
@@ -20,9 +20,7 @@
 
 'use strict';
 
-var Member = require('./member.js');
 var uuid = require('node-uuid');
-var util = require('util');
 
 function Update(address, incarnationNumber, status, localMember) {
     this.address = address;
@@ -35,14 +33,4 @@ function Update(address, incarnationNumber, status, localMember) {
     this.timestamp = Date.now();
 }
 
-function LeaveUpdate(address, incarnationNumber, localMember) {
-    LeaveUpdate.super_.call(this, address, incarnationNumber, Member.Status.leave,
-        localMember);
-}
-
-util.inherits(LeaveUpdate, Update);
-
-module.exports = {
-    LeaveUpdate: LeaveUpdate,
-    Update: Update
-};
+module.exports = Update;

--- a/test/unit/discover_provider_healer_test.js
+++ b/test/unit/discover_provider_healer_test.js
@@ -27,7 +27,7 @@ var DiscoverProviderHealer = require('../../lib/partition_healing/discover_provi
 var Healer = require('../../lib/partition_healing/healer');
 var Ringpop = require('../../index');
 var Member = require('../../lib/membership/member');
-var Update = require('../../lib/membership/update').Update;
+var Update = require('../../lib/membership/update');
 
 /**
  * Small util function to generate a number of fake hosts.


### PR DESCRIPTION
Due to the `makeChange`-refactor, `LeaveUpdate` isn't used anymore: it's a normal update with a leave-status. Let's remove this now obsolete update.