### PR TITLE
Status refactor 4: Remove makeLeave and makeAlive

### DIFF
--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -252,10 +252,6 @@ Membership.prototype.makeChange = function makeChange(address, incarnationNumber
     return this._updateMember(change);
 };
 
-Membership.prototype.makeAlive = function makeAlive(address, incarnationNumber) {
-    return this.makeChange(address, incarnationNumber, Member.Status.alive);
-};
-
 Membership.prototype.makeDamped = function makeDamped(address/*, incarnationNumber*/) {
     //TODO this statter should be removed when this function actually calls makeChange to prevent "double statting"!
     this.ringpop.stat('increment', 'make-damped');

--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -268,10 +268,6 @@ Membership.prototype.makeFaulty = function makeFaulty(address, incarnationNumber
     return this.makeChange(address, incarnationNumber, Member.Status.faulty);
 };
 
-Membership.prototype.makeLeave = function makeLeave(address, incarnationNumber) {
-    return this.makeChange(address, incarnationNumber, Member.Status.leave);
-};
-
 Membership.prototype.makeSuspect = function makeSuspect(address, incarnationNumber) {
     return this.makeChange(address, incarnationNumber, Member.Status.suspect);
 };

--- a/test/unit/damper_test.js
+++ b/test/unit/damper_test.js
@@ -25,6 +25,7 @@ var Damper = require('../../lib/gossip/damper.js');
 var DampReqRequest = require('../../request_response.js').DampReqRequest;
 var DampReqResponse = require('../../request_response.js').DampReqResponse;
 var makeTimersMock = require('../lib/timers-mock');
+var Member = require('../../lib/membership/member.js');
 var MemberDampScore = require('../../lib/membership/member_damp_score.js');
 var testRingpop = require('../lib/test-ringpop.js');
 var timers = require('timer-shim');
@@ -39,7 +40,7 @@ function setupMembership(deps, numMembers) {
     var members = [];
     for (var i = 0; i < numMembers; i++) {
         var member = memberGen();
-        membership.makeAlive(member.address, member.incarnationNumber);
+        membership.makeChange(member.address, member.incarnationNumber, Member.Status.alive);
         members.push(member);
     }
     return members;
@@ -238,7 +239,7 @@ testRingpop('damping member starts expiration', function t(deps, assert) {
     assert.false(damper.dampMember(member1.address), 'cannot damp member');
 
     var membership = deps.membership;
-    membership.makeAlive(member1.address, member1.incarnationNumber);
+    membership.makeChange(member1.address, member1.incarnationNumber, Member.Status.alive);
     assert.false(damper.dampMember(member1.address), 'cannot damp member');
 
     assert.false(damper.expirationTimer, 'expiration timer not started');
@@ -266,7 +267,7 @@ testRingpop('expires damped members', function t(deps, assert) {
     assert.false(damper.dampMember(member1.address), 'cannot damp member');
 
     var membership = deps.membership;
-    membership.makeAlive(member1.address, member1.incarnationNumber);
+    membership.makeChange(member1.address, member1.incarnationNumber, Member.Status.alive);
     assert.false(damper.dampMember(member1.address), 'member is not damped');
 
     damper.addFlapper(member1);

--- a/test/unit/dissemination-test.js
+++ b/test/unit/dissemination-test.js
@@ -20,6 +20,8 @@
 
 'use strict';
 
+var Member = require('../../lib/membership/member.js');
+
 var testRingpop = require('../lib/test-ringpop');
 var mock = require('../mock');
 
@@ -27,8 +29,8 @@ testRingpop('member ship as changes includes all members', function t(deps, asse
     var membership = deps.membership;
     var dissemination = deps.dissemination;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
-    membership.makeAlive('127.0.0.1:3002', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3002', Date.now(), Member.Status.alive);
 
     var membershipAsChanges = dissemination.membershipAsChanges();
     var addrs = membershipAsChanges.map(function mapMember(member) {
@@ -58,7 +60,7 @@ testRingpop('avoids redundant dissemination by filtering changes from source', f
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
 
@@ -87,7 +89,7 @@ testRingpop('raise piggyback counter on issueAsReceiver', function t(deps, asser
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
 
@@ -120,7 +122,7 @@ testRingpop('raise piggyback counter on issueAsSender', function t(deps, assert)
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
 
@@ -166,7 +168,7 @@ testRingpop('tombstone has priority vs other states', function t(deps, assert) {
     // recorded during bootstrap phase would have been issued.
     dissemination.clearChanges();
 
-    membership.makeAlive(addrAlive, incNo);
+    membership.makeChange(addrAlive, incNo, Member.Status.alive);
     membership.makeSuspect(addrSuspect, incNo);
     membership.makeFaulty(addrFaulty, incNo);
     membership.makeTombstone(addrAlive, incNo);

--- a/test/unit/gossip_test.js
+++ b/test/unit/gossip_test.js
@@ -62,7 +62,7 @@ testRingpop('suspect period for member is started', function t(deps, assert) {
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
     stateTransitions.scheduleSuspectToFaulty(member);
@@ -87,7 +87,7 @@ testRingpop('suspect period cannot be started for local member', function t(deps
 testRingpop('starting the same state transition for a member is a noop', function t(deps, assert) {
     var membership = deps.membership;
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var stateTransitions = deps.stateTransitions;
 
@@ -106,7 +106,7 @@ testRingpop('starting a new state transition for a member stops the previous one
 
     var membership = deps.membership;
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var stateTransitions = deps.stateTransitions;
 
@@ -129,7 +129,7 @@ testRingpop('suspect period can\'t be started until enabled', function t(deps, a
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     stateTransitions.disable();
 
@@ -149,8 +149,8 @@ testRingpop('state transition stop all clears all timers', function t(deps, asse
     var addr2 = '127.0.0.1:3002';
 
     var membership = deps.membership;
-    membership.makeAlive(addr1, Date.now());
-    membership.makeAlive(addr2, Date.now());
+    membership.makeChange(addr1, Date.now(), Member.Status.alive);
+    membership.makeChange(addr2, Date.now(), Member.Status.alive);
 
     var remoteMember = membership.findMemberByAddress(addr1);
     var remoteMember2 = membership.findMemberByAddress(addr2);
@@ -185,7 +185,7 @@ testRingpop({
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
 
@@ -207,7 +207,7 @@ testRingpop({
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
 
@@ -229,7 +229,7 @@ testRingpop({
     var stateTransitions = deps.stateTransitions;
 
     var address = '127.0.0.1:3001';
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
 
     var member = membership.findMemberByAddress(address);
 

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -150,7 +150,7 @@ test('admin leave stops state transitions', function t(assert) {
 
     var ringpop = createRingpop();
     ringpop.membership.makeLocalAlive();
-    ringpop.membership.makeAlive(ringpopRemote.whoami(), Date.now());
+    ringpop.membership.makeChange(ringpopRemote.whoami(), Date.now(), Member.Status.alive);
     ringpop.stateTransitions.scheduleSuspectToFaulty(ringpopRemote.hostPort);
 
     var handleAdminLeave = createAdminLeaveHandler(ringpop);
@@ -322,7 +322,7 @@ test('emits membership changed event', function t(assert) {
 
     var ringpop = createRingpop();
     ringpop.membership.makeLocalAlive();
-    ringpop.membership.makeAlive(node1Addr, Date.now());
+    ringpop.membership.makeChange(node1Addr, Date.now(), Member.Status.alive);
 
     assertChanged();
 
@@ -353,7 +353,7 @@ test('emits ring changed event', function t(assert) {
 
     var ringpop = createRingpop();
     ringpop.membership.makeLocalAlive();
-    ringpop.membership.makeAlive(node1Addr, incNo);
+    ringpop.membership.makeChange(node1Addr, incNo, Member.Status.alive);
 
     function assertChanged(changer, intent) {
         ringpop.once('membershipChanged', function onMembershipChanged() {
@@ -377,7 +377,7 @@ test('emits ring changed event', function t(assert) {
     });
 
     assertChanged(function assertIt() {
-        ringpop.membership.makeAlive(node1Addr, magicIncNo);
+        ringpop.membership.makeChange(node1Addr, magicIncNo, Member.Status.alive);
     }, {
         adding: [node1Addr],
         removing: []
@@ -391,7 +391,7 @@ test('emits ring changed event', function t(assert) {
     });
 
     assertChanged(function assertIt() {
-        ringpop.membership.makeAlive(node2Addr, Date.now());
+        ringpop.membership.makeChange(node2Addr, Date.now(), Member.Status.alive);
     }, {
         adding: [node2Addr],
         removing: []
@@ -434,7 +434,7 @@ testRingpop('max piggyback adjusted on new members', function t(deps, assert) {
 
     var address = '127.0.0.1:3002';
     var incarnationNumber = Date.now();
-    membership.makeAlive(address, incarnationNumber);
+    membership.makeChange(address, incarnationNumber, Member.Status.alive);
 });
 
 test('first time member, not alive', function t(assert) {

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -384,7 +384,7 @@ test('emits ring changed event', function t(assert) {
     });
 
     assertChanged(function assertIt() {
-        ringpop.membership.makeLeave(node1Addr, magicIncNo);
+        ringpop.membership.makeChange(node1Addr, magicIncNo, Member.Status.leave);
     }, {
         adding: [],
         removing: [node1Addr]

--- a/test/unit/membership-iterator-test.js
+++ b/test/unit/membership-iterator-test.js
@@ -18,14 +18,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+var Member = require('../../lib/membership/member.js');
+
 var testRingpop = require('../lib/test-ringpop.js');
 
 testRingpop('iterates over two members correctly', function t(deps, assert) {
     var membership = deps.membership;
     var iterator = deps.iterator;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
-    membership.makeAlive('127.0.0.1:3002', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3002', Date.now(), Member.Status.alive);
 
     var iterated = {};
     iterated[iterator.next().address] = true;
@@ -38,9 +40,9 @@ testRingpop('iterates over three members correctly', function t(deps, assert) {
     var membership = deps.membership;
     var iterator = deps.iterator;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
-    membership.makeAlive('127.0.0.1:3002', Date.now());
-    membership.makeAlive('127.0.0.1:3003', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3002', Date.now(), Member.Status.alive);
+    membership.makeChange('127.0.0.1:3003', Date.now(), Member.Status.alive);
 
     var iterated = {};
     iterated[iterator.next().address] = true;
@@ -54,9 +56,9 @@ testRingpop('skips over faulty member and 1 local member', function t(deps, asse
     var membership = deps.membership;
     var iterator = deps.iterator;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
     membership.makeFaulty('127.0.0.1:3002', Date.now());
-    membership.makeAlive('127.0.0.1:3003', Date.now());
+    membership.makeChange('127.0.0.1:3003', Date.now(), Member.Status.alive);
 
     var iterated = {};
     iterated[iterator.next().address] = true;

--- a/test/unit/membership_test.js
+++ b/test/unit/membership_test.js
@@ -155,10 +155,10 @@ testRingpop('leave does not cause neverending updates', function t(deps, assert)
     var updates = membership.makeChange(addr, incNo, Member.Status.alive);
     assert.equals(updates.length, 1, 'alive update applied');
 
-    updates = membership.makeLeave(addr, incNo);
+    updates = membership.makeChange(addr, incNo, Member.Status.leave);
     assert.equals(updates.length, 1, 'leave update applied');
 
-    updates = membership.makeLeave(addr, incNo);
+    updates = membership.makeChange(addr, incNo, Member.Status.leave);
     assert.equals(updates.length, 0, 'no leave update applied');
 });
 

--- a/test/unit/membership_test.js
+++ b/test/unit/membership_test.js
@@ -29,7 +29,7 @@ testRingpop('checksum is changed when membership is updated', function t(deps, a
     membership.makeLocalAlive();
     var prevChecksum = membership.checksum;
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
 
     assert.doesNotEqual(membership.checksum, prevChecksum, 'checksum is changed');
 });
@@ -124,7 +124,7 @@ testRingpop('member is able to go from alive to faulty without going through sus
     var membership = deps.membership;
 
     var newMemberAddr = '127.0.0.1:3001';
-    membership.makeAlive(newMemberAddr, Date.now());
+    membership.makeChange(newMemberAddr, Date.now(), Member.Status.alive);
 
     var newMember = membership.findMemberByAddress(newMemberAddr);
     assert.equals(newMember.status, Member.Status.alive, 'member starts alive');
@@ -152,7 +152,7 @@ testRingpop('leave does not cause neverending updates', function t(deps, assert)
     var addr = '127.0.0.1:3001';
     var incNo = Date.now();
 
-    var updates = membership.makeAlive(addr, incNo);
+    var updates = membership.makeChange(addr, incNo, Member.Status.alive);
     assert.equals(updates.length, 1, 'alive update applied');
 
     updates = membership.makeLeave(addr, incNo);
@@ -168,7 +168,7 @@ testRingpop('evict removes a member', function t(deps, assert) {
     var addr = '127.0.0.1:3001';
     var incNo = Date.now();
 
-    membership.makeAlive(addr, incNo);
+    membership.makeChange(addr, incNo, Member.Status.alive);
     assert.ok(membership.getMemberAt(1), 'alive applied');
     assert.ok(membership.findMemberByAddress(addr), 'alive applied');
 
@@ -192,7 +192,7 @@ testRingpop('generate checksums string preserves order of members', function t(d
     var membership = deps.membership;
 
     for (var i = 1; i < 100; i++) {
-        membership.makeAlive('127.0.0.1:' + (3000 + i), Date.now());
+        membership.makeChange('127.0.0.1:' + (3000 + i), Date.now(), Member.Status.alive);
     }
 
     // Make sure they're out of order
@@ -216,7 +216,7 @@ testRingpop('sets previously stashed updates', function t(deps, assert) {
     // Make sure updates are stashed -- make ringpop non-ready.
     ringpop.isReady = false;
 
-    membership.makeAlive(address, Date.now());
+    membership.makeChange(address, Date.now(), Member.Status.alive);
     assert.notok(membership.findMemberByAddress(address), 'member is not found');
 
     membership.set();
@@ -237,7 +237,7 @@ testRingpop('set adds all members', function t(deps, assert) {
 
     // Stash all members
     addresses.forEach(function eachAddr(addr) {
-        membership.makeAlive(addr, Date.now());
+        membership.makeChange(addr, Date.now(), Member.Status.alive);
     });
 
     addresses.forEach(function eachAddr(addr) {
@@ -275,7 +275,7 @@ testRingpop('set emits an event', function t(deps, assert) {
         assert.pass('membership set');
     });
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
     membership.set();
 });
 
@@ -290,7 +290,7 @@ testRingpop('set computes a checksum once', function t(deps, assert) {
         assert.pass('checksum computed');
     });
 
-    membership.makeAlive('127.0.0.1:3001', Date.now());
+    membership.makeChange('127.0.0.1:3001', Date.now(), Member.Status.alive);
     membership.set();
 });
 
@@ -307,7 +307,7 @@ testRingpop('set does not shuffle member positions', function t(deps, assert) {
         if (addr === ringpop.whoami()) {
             membership.makeLocalAlive();
         } else {
-            membership.makeAlive(addr, Date.now());
+            membership.makeChange(addr, Date.now(), Member.Status.alive);
         }
     });
 

--- a/test/unit/server/protocol/damp_req_test.js
+++ b/test/unit/server/protocol/damp_req_test.js
@@ -23,6 +23,7 @@
 var _ = require('underscore');
 var after = require('after');
 var createDampReqHandler = require('../../../../server/protocol/damp_req.js');
+var Member = require('../../../../lib/membership/member.js');
 var fixtures = require('../../../fixtures.js');
 var testRingpop = require('../../../lib/test-ringpop.js');
 
@@ -64,8 +65,10 @@ testRingpop('responds with damp scores', function t(deps, assert) {
         return genMember();
     });
     members.forEach(function each(member) {
-        ringpop.membership.makeAlive(member.address,
-            member.incarnationNumber);
+        ringpop.membership.makeChange(
+            member.address,
+            member.incarnationNumber,
+            Member.Status.alive);
     });
 
     // Clear changes from the dissemination component to


### PR DESCRIPTION
Since it's not allowed by the SWIM protocol for a node to change a member's status to `alive` or `leave`,  let's remove these methods. Tests can use the generic `makeChange`-function.

