### PR TITLE
PR for farmhash v1.2.0 into the node v4 testing branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: node_js
 node_js:
   - "0.10"
+  - "4.4.7"
 before_install: npm i npm@latest -g
 
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+
 env:
-  - RUN="npm run travis"
-  - RUN="npm run test-shared-integration-tests"
+  - CXX=g++-4.8 RUN="npm run travis"
+  - CXX=g++-4.8 RUN="npm run test-shared-integration-tests"
 
 matrix:
   fast_finish: true

--- a/config.js
+++ b/config.js
@@ -84,6 +84,7 @@ Config.prototype._seed = function _seed(seed) {
     seedOrDefault('autoGossip', true);
 
     seedOrDefault('isCrossPlatform', false);
+    seedOrDefault('useLatestHash32', false);
     seedOrDefault('dampedErrorLoggingEnabled', false);
     seedOrDefault('dampedMaxPercentage', 10);
     seedOrDefault('dampedMemberExpirationInterval', 60000);

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ var _ = require('underscore');
 var EventEmitter = require('events').EventEmitter;
 var farmhash = require('farmhash');
 var timers = require('timers');
-var hammock = require('uber-hammock');
+var hammock = require('hammock');
 var metrics = require('metrics');
 var packageJSON = require('./package.json');
 
@@ -120,7 +120,7 @@ function RingPop(options) {
     this.proxyReqTimeout = options.proxyReqTimeout || 30000;
     this.membershipUpdateFlushInterval = options.membershipUpdateFlushInterval ||
         MEMBERSHIP_UPDATE_FLUSH_INTERVAL;
-    this.maxReverseFullSyncJobs = options.maxReverseFullSyncJobs || 
+    this.maxReverseFullSyncJobs = options.maxReverseFullSyncJobs ||
         MAX_REVERSE_FULL_SYNC_JOBS;
 
     // Initialize Config before all other gossip, membership, forwarding,
@@ -133,8 +133,10 @@ function RingPop(options) {
     // use fingerprint if ringpop needs to function cross different platforms
     if (this.config.get('isCrossPlatform')) {
         this.hashFunc = farmhash.fingerprint32;
-    } else {
+    } else if (this.config.get('useLatestHash32')) {
         this.hashFunc = farmhash.hash32;
+    } else {
+        this.hashFunc = farmhash.hash32v1;
     }
 
     this.lagSampler = new LagSampler({

--- a/lib/lag_sampler.js
+++ b/lib/lag_sampler.js
@@ -43,7 +43,7 @@ LagSampler.prototype.start = function start() {
     }
 
     if (!this.toobusy) {
-        this.toobusy = require('toobusy');
+        this.toobusy = require('toobusy-js');
     }
 
     schedule();

--- a/lib/request-proxy/index.js
+++ b/lib/request-proxy/index.js
@@ -21,7 +21,7 @@
 'use strict';
 
 var body = require('body');
-var hammock = require('uber-hammock');
+var hammock = require('hammock');
 var numOrDefault = require('../util.js').numOrDefault;
 var PassThrough = require('stream').PassThrough;
 var safeParse = require('../util.js').safeParse;

--- a/lib/ring/index.js
+++ b/lib/ring/index.js
@@ -28,7 +28,7 @@ function HashRing(options) {
     this.options = options || {};
 
     this.replicaPoints = this.options.replicaPoints || 100;
-    this.hashFunc = this.options.hashFunc || farmhash.hash32;
+    this.hashFunc = this.options.hashFunc || farmhash.hash32v1;
 
     this.rbtree = new RBTree();
     this.servers = {};

--- a/main.js
+++ b/main.js
@@ -82,6 +82,7 @@ function main(args) {
             trace: false
         }),
         isCrossPlatform: true,
+        useLatestHash32: false,
         stateTimeouts: {
             suspect: program.suspectPeriod,
             faulty: program.faultyPeriod,

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
   "dependencies": {
     "body": "^5.0.0",
     "error": "^5.0.0",
-    "farmhash": "^0.2.0",
+    "farmhash": "^1.1.0",
     "metrics": "^0.1.8",
     "node-uuid": "^1.4.3",
-    "toobusy": "^0.2.4",
+    "toobusy-js": "^0.5.0",
     "uber-hammock": "^1.0.0",
     "underscore": "^1.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   "dependencies": {
     "body": "^5.0.0",
     "error": "^5.0.0",
-    "farmhash": "^1.1.0",
+    "farmhash": "^1.2.0",
     "metrics": "^0.1.8",
     "node-uuid": "^1.4.3",
     "toobusy-js": "^0.5.0",
-    "uber-hammock": "^1.0.0",
+    "hammock": "^1.1.0",
     "underscore": "^1.5.2"
   },
   "devDependencies": {

--- a/test/lib/alloc-request.js
+++ b/test/lib/alloc-request.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var hammock = require('uber-hammock');
+var hammock = require('hammock');
 
 module.exports = allocRequest;
 

--- a/test/lib/alloc-response.js
+++ b/test/lib/alloc-response.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var hammock = require('uber-hammock');
+var hammock = require('hammock');
 var tryIt = require('tryit');
 
 module.exports = allocResponse;

--- a/test/run-shared-integration-tests
+++ b/test/run-shared-integration-tests
@@ -6,7 +6,7 @@ set -eo pipefail
 
 declare project_root="${0%/*}/.."
 declare ringpop_common_dir="${0%/*}/ringpop-common"
-declare ringpop_common_branch="master"
+declare ringpop_common_branch="menno/node-4-compat"
 declare tap_filter="${ringpop_common_dir}/test/tap-filter"
 
 declare test_cluster_sizes="1 2 3 4 5 10"


### PR DESCRIPTION
Have updated to use the legacy implementation of hash32, and have added config flag ‘useLatestHash32’ for those who want to use new version due to increased performance. Defaults to false.