### PR TITLE
Status refactor 5: Change update constructor

### DIFF
--- a/lib/membership/index.js
+++ b/lib/membership/index.js
@@ -217,14 +217,14 @@ Membership.prototype.makeLocalAlive = function makeLocalAlive(){
 Membership.prototype._reincarnate = function _reincarnate() {
     this.localMember.incarnationNumber = Date.now();
 
-    return new Update(this.localMember.address, this.localMember.incarnationNumber, this.localMember.status, this.localMember);
+    return new Update(this.localMember, this.localMember);
 };
 
 /**
  * Change the status of the local member. This will also bump the incarnation
  * number of the local member.
  *
- * @param status The new status (@see Member.Status)
+ * @param {Member.Status} status The new status
  */
 Membership.prototype.setLocalStatus = function setLocalStatus(status) {
     if (this.localMember) {
@@ -235,7 +235,11 @@ Membership.prototype.setLocalStatus = function setLocalStatus(status) {
 
         this.localMember.status = status;
     } else {
-        this.localMember = new Member(this.ringpop, new Update(this.ringpop.whoami(), Date.now(), status, null));
+        this.localMember = new Member(this.ringpop, new Update({
+            address: this.ringpop.whoami(),
+            incarnationNumber: Date.now(),
+            status: status
+        }));
         this.members.push(this.localMember);
         this.membersByAddress[this.localMember.address] = this.localMember;
     }
@@ -259,12 +263,21 @@ Membership.prototype._postLocalUpdate = function _postLocalUpdate(update){
  *
  * @param {string} address the address of the member.
  * @param {int} incarnationNumber The incrnationNumber of the member.
- * @param {string} status The (new) status of the member (@see Member.Status).
+ * @param {Member.Status} status The (new) status of the member.
  */
 Membership.prototype.makeChange = function makeChange(address, incarnationNumber, status) {
     this.ringpop.stat('increment', 'make-'+status);
+    var member = this.findMemberByAddress(address);
 
-    var change = new Update(address, incarnationNumber, status, this.localMember);
+    var change = new Update(member, this.localMember);
+
+    // in case member is not (yet) known
+    change.address = address;
+
+    // overwrite with provided state
+    change.incarnationNumber = incarnationNumber;
+    change.status = status;
+
     return this._updateMember(change);
 };
 

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -221,7 +221,7 @@ Member.statusPrecedence = function statusPrecedence(status) {
 
  * @param {Member} [member] The current member or null when the member is currently
  *  unknown.
- * @param {object} change The incoming update
+ * @param {IMember} change The incoming update
  * @returns {boolean} if the gossip should be processed or can safely be ignored.
  */
 Member.shouldProcessChange = function shouldProcessChange(member, change) {

--- a/lib/membership/member.js
+++ b/lib/membership/member.js
@@ -25,6 +25,28 @@ var events = require('./events.js');
 var numOrDefault = require('../util.js').numOrDefault;
 var util = require('util');
 
+/**
+ * @interface IMember
+ *
+ * The interface that defines a member object.
+ *
+ * @property {string} address The address of the member
+ * @property {number} incarnationNumber The incarnation number of the member
+ * @property {Member.Status} status The status of the member
+ */
+
+/**
+ * Create a new member
+ * @param {Ringpop} ringpop the ringpop instance
+ * @param {Update} update the update that returns this member.
+ *
+ * @property {string} address The address of the member
+ * @property {number} incarnationNumber The incarnation number of the member
+ * @property {Member.Status} status The status of the member
+ *
+ * @constructor
+ * @implements IMember
+ */
 function Member(ringpop, update) {
     this.ringpop = ringpop;
     this.id = update.address;
@@ -136,6 +158,11 @@ Member.prototype._applyUpdatePenalty = function _applyUpdatePenalty() {
     }
 };
 
+/**
+ * Enum for member status.
+ *
+ * @enum {string}
+ */
 Member.Status = {
     alive: 'alive',
     faulty: 'faulty',

--- a/lib/membership/update.js
+++ b/lib/membership/update.js
@@ -24,15 +24,29 @@ var Member = require('./member.js');
 var uuid = require('node-uuid');
 var util = require('util');
 
-function Update(address, incarnationNumber, status, localMember) {
-    this.address = address;
-    this.incarnationNumber = incarnationNumber;
-    this.status = status;
+/**
+ * Create a new Update
+ * @param {IMember} subject the subject of the update.
+ * @param {IMember} [source] the source of the update.
+ * @constructor
+ */
+function Update(subject, source) {
+    if (!(this instanceof Update)) {
+        return new Update(subject, source);
+    }
     this.id = uuid.v4();
-    localMember = localMember || {};
-    this.source = localMember.address;
-    this.sourceIncarnationNumber = localMember.incarnationNumber;
     this.timestamp = Date.now();
+
+    // Populate subject
+    subject = subject || {};
+    this.address = subject.address;
+    this.incarnationNumber = subject.incarnationNumber;
+    this.status = subject.status;
+
+    // Populate source
+    source = source || {};
+    this.source = source.address;
+    this.sourceIncarnationNumber = source.incarnationNumber;
 }
 
 function LeaveUpdate(address, incarnationNumber, localMember) {

--- a/test/unit/discover_provider_healer_test.js
+++ b/test/unit/discover_provider_healer_test.js
@@ -197,7 +197,11 @@ test('DiscoverProviderHeal.heal - only attempt to heal faulty (or worse) nodes',
     for(var i=0; i<statuses.length; i++) {
         var address = '127.0.0.1:'+ (3100 +i);
         var status = statuses[i];
-        ringpop.membership.update(new Update(address, Date.now(), status));
+        ringpop.membership.update(new Update({
+            address: address,
+            incarnationNumber: Date.now(),
+            status: status
+        }));
         nodes[address] = {
             healAllowed: Member.statusPrecedence(status) >= Member.statusPrecedence(Member.Status.faulty),
             status: status


### PR DESCRIPTION
Change the update-constructor to take a subject and source.
To be able to document everything correctly, I had to:
- add `@enum` to `Member.Status`,
- Add an interface for member (`IMember`)