### PR TITLE
[self-evict 1] Support self eviction as a way of graceful shutdown

### DIFF
--- a/config.js
+++ b/config.js
@@ -145,6 +145,12 @@ Config.prototype._seed = function _seed(seed) {
     // Enable the period healer.
     seedOrDefault('discoverProviderHealerPeriodicEnabled', true);
 
+    // Self Eviction config
+    // Enable pinging
+    seedOrDefault('selfEvictionPingEnabled', true);
+    // Ping a maximum ratio of the pingable members on self eviction
+    seedOrDefault('selfEvictionMaxPingRatio', 0.4);
+
     function seedOrDefault(name, defaultVal, validator, reason) {
         var seedVal = seed[name];
         if (typeof seedVal === 'undefined') {

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ var RingpopClient = require('./client.js');
 var RingpopServer = require('./server');
 var validateHostPort = require('./lib/util').validateHostPort;
 var sendJoin = require('./lib/gossip/joiner.js').joinCluster;
+var SelfEvict = require('./lib/self-evict');
 var TracerStore = require('./lib/trace/store.js');
 var middleware = require('./lib/middleware');
 var DiscoverProviderHealer = require('./lib/partition_healing').DiscoverProviderHealer;
@@ -208,6 +209,8 @@ function RingPop(options) {
     this.ringpopVersion = packageJSON.version;
 
     this.healer = new DiscoverProviderHealer(this);
+
+    this.selfEvicter = new SelfEvict(this);
 }
 
 require('util').inherits(RingPop, EventEmitter);
@@ -703,6 +706,14 @@ RingPop.prototype.handleOrProxyAll =
             }
         }
     };
+
+RingPop.prototype.registerSelfEvictHook = function registerSelfEvictHook(hook) {
+    this.selfEvicter.registerHooks(hook);
+};
+
+RingPop.prototype.selfEvict = function selfEvict(cb) {
+    this.selfEvicter.initiate(cb);
+};
 
 // This function is defined for testing purposes only.
 RingPop.prototype.allowJoins = function allowJoins() {

--- a/lib/self-evict.js
+++ b/lib/self-evict.js
@@ -1,0 +1,319 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var _ = require('underscore');
+var TypedError = require('error/typed');
+
+var errors = require('./errors');
+var Member = require('./membership/member');
+
+
+/**
+ * @typedef {Object} Phase
+ * @property {SelfEvict.PhaseNames} phase the name of the phase.
+ * @property {number} ts the unix timestamp in milliseconds when the phase started.
+ * @property {number} [duration] the duration in milliseconds of the phase.
+ */
+
+/**
+ * This object defines the hooks. At least one of hook-methods (i.e.
+ * preEvict or postEvict, or both) should be defined.
+ * @typedef {Object} SelfEvictHooks
+ * @property {string} name The name of the hook
+ * @property {SelfEvict~Hook} [preEvict] The preEvict hook to register.
+ * @property {SelfEvict~Hook} [postEvict] The postEvict hook to register.
+ */
+/**
+ * A pre or post self eviction hook.
+ * @callback SelfEvict~Hook
+ * @param {SelfEvict~HookCallback} cb the callback to be called when the hook completes
+ */
+
+/**
+ * A callback used when calling Hooks
+ * @callback SelfEvict~HookCallback
+ */
+
+/**
+ * Self eviction provides a way to graceful shut down a ringpop service.
+ * A self eviction consists of the following phases:
+ * 1. PreEvict: the preEvict hooks are invoked;
+ * 2. Evict: The node will mark  itself as faulty causing an eviction out of the membership;
+ * 3. PostEvict: the postEvict hooks are invoked;
+ * 4. Done: self eviction is done and ringpop is ready to be shut down.
+ *
+ * @param {RingPop} ringpop
+ * @return {SelfEvict}
+ * @constructor
+ */
+function SelfEvict(ringpop) {
+    if (!(this instanceof SelfEvict)) {
+        return new SelfEvict(ringpop);
+    }
+
+    /**
+     * The ringpop instance
+     * @type {RingPop}
+     * @private
+     */
+    this.ringpop = ringpop;
+
+    /**
+     *
+     * @type {Object.<string, SelfEvictHooks>}
+     */
+    this.hooks = {};
+
+    /**
+     * The callback to be called after self eviction is complete.
+     * @type {SelfEvict~callback}
+     * @private
+     */
+    this.callback = null;
+
+    /**
+     * The history of phases
+     * @type {[Phase]}
+     */
+    this.phases = [];
+}
+
+/**
+ * Get the current phase or null when self eviction isn't initiated
+ * @return {?Phase}
+ */
+SelfEvict.prototype.currentPhase = function currentPhase() {
+    if (this.phases.length > 0) {
+        return this.phases[this.phases.length - 1];
+    }
+    return null;
+};
+
+/**
+ * Register hooks in the eviction sequence. The hooks are invoked in parallel
+ * and the order is undefined.
+ *
+ * @param {SelfEvictHooks} hooks the hooks
+ */
+SelfEvict.prototype.registerHooks = function registerHooks(hooks) {
+    if (!hooks) {
+        throw errors.ArgumentRequiredError({argument: 'hooks'});
+    }
+
+    if (!hooks.name) {
+        throw errors.FieldRequiredError({argument: 'hooks', field: 'name'});
+    }
+    var name = hooks.name;
+
+    if (this.hooks[name]) {
+        throw errors.DuplicateHookError({name: name});
+    }
+
+    if (!hooks.preEvict && !hooks.postEvict) {
+        throw errors.MethodRequiredError({
+            argument: 'hooks',
+            method: 'preEvict and/or postEvict'
+        });
+    }
+
+    this.hooks[name] = hooks;
+};
+
+/**
+ * This callback is called after self eviction is complete. When the callback is
+ * invoked, it's safe to shut down the ringpop service or destroy ringpop.
+ *
+ * @callback SelfEvict~callback
+ * @param {Error} [err] The error if one occurred
+ * @see Ringpop#destroy
+ */
+
+/**
+ * Initiate the self eviction sequence.
+ * @param {SelfEvict~callback} callback called when self eviction is complete.
+ */
+SelfEvict.prototype.initiate = function initiate(callback) {
+    if (this.currentPhase() !== null) {
+        var error = RingpopIsAlreadyShuttingDownError({phase: this.currentPhase()});
+        this.ringpop.logger.warn('ringpop is already shutting down', {
+            local: this.ringpop.whoami(),
+            error: error
+        });
+        callback(error);
+        return;
+    }
+    this.ringpop.logger.info('ringpop is initiating self eviction sequence', {
+        local: this.ringpop.whoami()
+    });
+    this.callback = callback;
+
+    this._preEvict();
+};
+
+SelfEvict.prototype._preEvict = function _preEvict() {
+    this._transitionTo(PhaseNames.PreEvict);
+
+    var self = this;
+    this._runHooks('preEvict', function hooksDone() {
+        process.nextTick(self._evict.bind(self));
+    });
+};
+
+SelfEvict.prototype._evict = function _evict() {
+    this._transitionTo(PhaseNames.Evicting);
+
+    this.ringpop.membership.setLocalStatus(Member.Status.faulty);
+    process.nextTick(this._postEvict.bind(this));
+};
+
+SelfEvict.prototype._postEvict = function _postEvict() {
+    this._transitionTo(PhaseNames.PostEvict);
+
+    var self = this;
+    this._runHooks('postEvict', function hooksDone() {
+        process.nextTick(self._done.bind(self));
+    });
+};
+
+SelfEvict.prototype._done = function _done() {
+    this._transitionTo(PhaseNames.Done);
+
+    var duration = this.currentPhase().ts - this.phases[0].ts;
+    this.ringpop.stat('timing', 'self-eviction', duration);
+    this.callback();
+};
+
+/**
+ * Transition to a new Phase.
+ * @param {SelfEvict.PhaseNames} phaseName
+ * @private
+ */
+SelfEvict.prototype._transitionTo = function _transitionTo(phaseName) {
+    var phase = {
+        phase: phaseName,
+        ts: Date.now()
+    };
+
+    var previousPhase = this.currentPhase();
+    this.phases.push(phase);
+
+    if (previousPhase) {
+        previousPhase.duration = phase.ts - previousPhase.ts;
+    }
+
+    this.ringpop.logger.debug('ringpop self eviction phase-transitioning', {
+        local: this.ringpop.whoami(),
+        phases: this.phases
+    });
+};
+
+/**
+ * Run the registered hooks in parallel.
+ * @param {string} type The hook type (preEvict or postEvict).
+ * @param {Function} done the callback to call when all hooks are completed.
+ * @private
+ */
+SelfEvict.prototype._runHooks = function _runHooks(type, done) {
+    var self = this;
+    var ringpop = self.ringpop;
+
+    var names = _.filter(_.keys(this.hooks), function filter(name) {
+        return _.has(self.hooks[name], type);
+    });
+
+    if (names.length === 0) {
+        done();
+        return;
+    }
+
+    var logger = this.ringpop.logger;
+
+    var start = Date.now();
+
+    var afterHook = _.after(names.length, function afterHooks() {
+        logger.debug('ringpop self eviction done running hooks', {
+            local: ringpop.whoami(),
+            totalDuration: Date.now() - start,
+            phase: self.currentPhase()
+        });
+        process.nextTick(done);
+    });
+
+    logger.debug('ringpop self eviction running hooks', {
+        local: ringpop.whoami(),
+        phase: self.currentPhase(),
+        hooks: names
+    });
+
+    for (var i = 0; i < names.length; i++) {
+        var name = names[i];
+        var hook = this.hooks[name];
+
+        runHook(hook);
+    }
+
+    function runHook(hook) {
+        process.nextTick(function() {
+            var name = hook.name;
+            logger.debug('ringpop self eviction running hook', {
+                    local: ringpop.whoami(),
+                    hook: name
+                }
+            );
+
+            var hookStart = Date.now();
+            hook[type](function hookDone() {
+                logger.debug('ringpop self eviction hook done', {
+                        local: ringpop.whoami(),
+                        hook: name,
+                        duration: Date.now() - hookStart
+                    }
+                );
+                afterHook();
+            });
+        })
+    }
+};
+
+
+/**
+ * Enum for SelfEvict phases
+ * @readonly
+ * @enum {string}
+ */
+SelfEvict.PhaseNames = {
+    PreEvict: 'pre_evict',
+    Evicting: 'evicting',
+    PostEvict: 'post_evict',
+    Done: 'done'
+};
+var PhaseNames = SelfEvict.PhaseNames;
+
+
+/**
+ * @returns {Error}
+ */
+var RingpopIsAlreadyShuttingDownError = TypedError({
+    type: 'ringpop.self-evict.already-evicting',
+    message: 'ringpop is already evicting itself. currentPhase={phase}',
+    phase: null
+});
+
+module.exports = SelfEvict;

--- a/lib/self-evict.js
+++ b/lib/self-evict.js
@@ -23,6 +23,7 @@ var TypedError = require('error/typed');
 
 var errors = require('./errors');
 var Member = require('./membership/member');
+var sendPing = require('./gossip/ping-sender.js').sendPing;
 
 
 /**
@@ -64,6 +65,7 @@ var Member = require('./membership/member');
  * @constructor
  */
 function SelfEvict(ringpop) {
+    /* istanbul ignore if */
     if (!(this instanceof SelfEvict)) {
         return new SelfEvict(ringpop);
     }
@@ -176,11 +178,60 @@ SelfEvict.prototype._preEvict = function _preEvict() {
     });
 };
 
-SelfEvict.prototype._evict = function _evict() {
-    this._transitionTo(PhaseNames.Evicting);
+SelfEvict.prototype._getMembersToPing = function() {
+    var ringpop = this.ringpop;
+    var selfEvictionMaxPingRatio = ringpop.config.get('selfEvictionMaxPingRatio');
+    var membership = ringpop.membership;
 
-    this.ringpop.membership.setLocalStatus(Member.Status.faulty);
-    process.nextTick(this._postEvict.bind(this));
+    var pingableMembers = _.filter(membership.members, membership.isPingable.bind(membership));
+    var numberOfPingableMembers = pingableMembers.length;
+    var maxNumberOfPings = Math.ceil(numberOfPingableMembers * selfEvictionMaxPingRatio);
+
+    // Never ping more than the maximum piggyback counter and/or number of pingable members.
+    var numberOfPings = Math.min(
+        ringpop.dissemination.maxPiggybackCount,
+        maxNumberOfPings,
+        numberOfPingableMembers
+    );
+
+    return pingableMembers.slice(0, numberOfPings);
+};
+
+SelfEvict.prototype._evict = function _evict() {
+    var self = this;
+    var ringpop = self.ringpop;
+    var phase = this._transitionTo(PhaseNames.Evicting);
+
+    ringpop.membership.setLocalStatus(Member.Status.faulty);
+
+    var pingEnabled = ringpop.config.get('selfEvictionPingEnabled');
+    var membersToPing = this._getMembersToPing();
+
+    phase.numberOfPings = membersToPing.length;
+    phase.numberOfSuccessfulPings = 0;
+
+    if (pingEnabled && membersToPing.length > 0) {
+        var pinged = _.after(membersToPing.length, evictDone);
+
+        _.each(membersToPing, ping);
+        function ping(member) {
+            sendPing({
+                target: member,
+                ringpop: ringpop
+            }, function afterPing(err) {
+                if (!err) {
+                    phase.numberOfSuccessfulPings++;
+                }
+                pinged();
+            });
+        }
+    } else {
+        evictDone();
+    }
+
+    function evictDone() {
+        process.nextTick(self._postEvict.bind(self));
+    }
 };
 
 SelfEvict.prototype._postEvict = function _postEvict() {
@@ -197,12 +248,18 @@ SelfEvict.prototype._done = function _done() {
 
     var duration = this.currentPhase().ts - this.phases[0].ts;
     this.ringpop.stat('timing', 'self-eviction', duration);
+    this.ringpop.logger.info('ringpop self eviction done!', {
+        local: this.ringpop.whoami(),
+        totalDuration: duration,
+        phases: this.phases
+    });
     this.callback();
 };
 
 /**
  * Transition to a new Phase.
  * @param {SelfEvict.PhaseNames} phaseName
+ * @returns {Phase} The new phase.
  * @private
  */
 SelfEvict.prototype._transitionTo = function _transitionTo(phaseName) {
@@ -222,6 +279,8 @@ SelfEvict.prototype._transitionTo = function _transitionTo(phaseName) {
         local: this.ringpop.whoami(),
         phases: this.phases
     });
+
+    return phase;
 };
 
 /**

--- a/test/run-shared-integration-tests
+++ b/test/run-shared-integration-tests
@@ -78,8 +78,10 @@ run-test-for-cluster-size() {
     # Run the tests and buffer the output to a log file. We'll display it later
     # if the test fails. This avoids interleaving of output to the terminal
     # when tests are running in parallel.
-    node "${ringpop_common_dir}/test/it-tests.js" --enable-feature reaping-faulty-nodes \
+    node "${ringpop_common_dir}/test/it-tests.js" \
+		--enable-feature reaping-faulty-nodes \
 		--enable-feature partition-healing \
+		--enable-feature self-eviction \
         -s "[$1]" "${project_root}/main.js" &>$output_file || err=$?
 
     if [ $PIPESTATUS -gt 0 ]; then

--- a/test/unit/index-test.js
+++ b/test/unit/index-test.js
@@ -481,3 +481,39 @@ test('suspicionTimeout backward compatibility', function t(assert) {
     ringpop.destroy();
     assert.end();
 });
+
+test('registerSelfEvictHook registers hook in self evicter', function t(assert) {
+    var ringpop = createRingpop();
+
+    var hookFixture = {};
+
+    ringpop.selfEvicter= {
+        registerHooks: function(hook) {
+            assert.pass('registerHooks called');
+            assert.equal(hook, hookFixture);
+        }
+    };
+    assert.plan(2);
+    ringpop.registerSelfEvictHook(hookFixture);
+
+    ringpop.destroy();
+    assert.end();
+});
+
+test('selfEvict initiates self evict sequence', function t(assert) {
+    var ringpop = createRingpop();
+
+    var cbFixture = function(){};
+
+    ringpop.selfEvicter= {
+        initiate: function(cb) {
+            assert.pass('initiate');
+            assert.equal(cb, cbFixture);
+        }
+    };
+    assert.plan(2);
+    ringpop.selfEvict(cbFixture);
+
+    ringpop.destroy();
+    assert.end();
+});

--- a/test/unit/self-evict-test.js
+++ b/test/unit/self-evict-test.js
@@ -1,0 +1,212 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+var testRingpop = require('../lib/test-ringpop');
+var test = require('tape');
+var SelfEvict = require('../../lib/self-evict');
+var RingPop = require('../../index.js');
+var _ = require('underscore');
+var Member = require('../../lib/membership/member');
+
+test('constructor', function t(assert) {
+    var ringpopMock = {};
+
+    var selfEvict = new SelfEvict(ringpopMock);
+    assert.ok(selfEvict instanceof SelfEvict, 'instance of');
+
+    assert.end();
+});
+
+function assertError(assert, thowIt, expected, msg) {
+    var error;
+    try {
+        thowIt();
+    } catch (e) {
+        error = e;
+    }
+
+    assert.ok(error, msg);
+    _.each(expected, function(value, key) {
+        assert.equal(error[key], value, msg);
+    });
+}
+
+test('register hooks', function t(assert) {
+    var ringpop = new RingPop({
+        app: 'test',
+        hostPort: '127.0.0.1:3000'
+    });
+
+    var selfEvict = ringpop.selfEvicter;
+
+    var testTable = [
+        [null, {type: 'ringpop.argument-required', argument: 'hooks'}],
+        [{}, {type: 'ringpop.field-required', field: 'name', argument: 'hooks'}],
+        [{name:'test'}, {type: 'ringpop.method-required', argument: 'hooks', method: 'preEvict and/or postEvict'}]
+    ];
+
+    // assert all the errors
+    _.each(testTable, function(testCase) {
+        assertError(
+            assert,
+            selfEvict.registerHooks.bind(selfEvict, testCase[0]),
+            testCase[1]
+        );
+    });
+
+
+    var hooks = {
+        name: 'test',
+        preEvict: function preEvict() {},
+        postEvict: function postEvict() {}
+    };
+
+    assert.doesNotThrow(selfEvict.registerHooks.bind(selfEvict, hooks));
+
+
+    assertError(
+        assert,
+        selfEvict.registerHooks.bind(selfEvict, hooks),
+        {type: 'ringpop.duplicate-hook', name: 'test'}
+    );
+
+    ringpop.destroy();
+    assert.end();
+});
+
+testRingpop({async: true}, 'self evict sequence without hooks', function t(deps, assert, cleanup) {
+    var ringpop = deps.ringpop;
+    var selfEvict = new SelfEvict(ringpop);
+
+    assert.equal(selfEvict.currentPhase(), null, 'initial phase is null');
+
+    selfEvict.initiate(after);
+
+    function after(err) {
+        assert.notok(err);
+
+        var phases = selfEvict.phases;
+        var phaseNames = _.pluck(phases, 'phase');
+        assert.deepEqual(phaseNames, [
+            SelfEvict.PhaseNames.PreEvict,
+            SelfEvict.PhaseNames.Evicting,
+            SelfEvict.PhaseNames.PostEvict,
+            SelfEvict.PhaseNames.Done
+        ]);
+
+        for (var i = 0; i < phases.length; i++) {
+            var phase = phases[i];
+
+            if (i < phases.length - 1) {
+                assert.notEqual(phase.duration, undefined, 'duration is set');
+                assert.equal(phase.duration, phases[i + 1].ts - phase.ts, 'duration is correct');
+                assert.ok(phase.ts <= phases[i + 1].ts, 'sorted correctly');
+            } else {
+                assert.equal(phase.duration, undefined, 'duration is undefined');
+            }
+        }
+
+        assert.equal(ringpop.membership.localMember.status, Member.Status.faulty, 'local member is declared faulty');
+
+        cleanup();
+    }
+});
+
+testRingpop({async: true}, 'self evict sequence invokes hooks', function t(deps, assert, cleanup) {
+    var ringpop = deps.ringpop;
+    var selfEvict = new SelfEvict(ringpop);
+
+    assert.plan(10);
+
+    selfEvict.registerHooks({
+        name: 'onlyPreEvictHook',
+        preEvict: function(cb){
+            assert.pass('onlyPreEvictHook.preEvict called');
+            cb();
+        }
+    });
+
+    selfEvict.registerHooks({
+        name: 'onlyPostEvictHook',
+        postEvict: function(cb){
+            assert.pass('onlyPostEvictHook.postEvict called');
+            cb();
+        }
+    });
+
+    selfEvict.registerHooks({
+        name: 'bothHook',
+        preEvict: function(cb){
+            assert.pass('bothHook.preEvict called');
+            cb();
+        },
+        postEvict: function(cb){
+            assert.pass('bothHook.postEvict called');
+            cb();
+        }
+    });
+
+    var ExampleHook = function ExampleHook(name){
+        this.name = name;
+
+        var self = this;
+        this.preEvict = function preEvict(cb){
+            assert.equal(selfEvict.currentPhase().phase, SelfEvict.PhaseNames.PreEvict);
+            assert.pass('exampleHook.preEvict called');
+            assert.equal(this, self, 'context is correct');
+            cb();
+        };
+
+        this.postEvict = function(cb){
+            assert.equal(selfEvict.currentPhase().phase, SelfEvict.PhaseNames.PostEvict);
+            assert.pass('exampleHook.postEvict called');
+            assert.equal(this, self, 'context is correct');
+
+            cb();
+        };
+    };
+
+    selfEvict.registerHooks(new ExampleHook('InstanceExample'));
+
+    selfEvict.initiate(cleanup);
+});
+
+testRingpop({async: true}, 'initiate multiple times returns error', function t(deps, assert, cleanup) {
+    var ringpop = deps.ringpop;
+    var selfEvict = new SelfEvict(ringpop);
+
+    cleanup = _.after(2, cleanup);
+
+    selfEvict.initiate(first);
+    selfEvict.initiate(next);
+
+    function first(err) {
+        assert.notok(err);
+        selfEvict.initiate(next);
+    }
+
+    function next(err) {
+        assert.ok(err);
+        assert.equal(err.type, 'ringpop.self-evict.already-evicting');
+        assert.equal(err.phase, selfEvict.currentPhase());
+
+        cleanup();
+    }
+});


### PR DESCRIPTION
This PR adds a way to add self-eviction: marking the local member faulty before shutdown. 
It adds two functions to ringpop's public API:
- `registerSelfEvictHooks`: Provide a way to register hooks
- `selfEvict`: initiate the self eviction process

TODO in seperate PR(s): 
- [x] ping members before ending the sequence so the self-eviction is guaranteed to be gossiped (#300)