### PR TITLE
Disable healing on self

### DIFF
--- a/lib/partition_healing/discover_provider_healer.js
+++ b/lib/partition_healing/discover_provider_healer.js
@@ -208,7 +208,8 @@ DiscoverProviderHealer.prototype.heal = function heal(callback) {
  * @private
  */
 DiscoverProviderHealer.prototype._getTargets = function _getTargets(hosts) {
-    var membership = this.ringpop.membership;
+    var ringpop = this.ringpop;
+    var membership = ringpop.membership;
 
     return _.chain(hosts)
         .filter(isHostAValidTarget)
@@ -216,6 +217,9 @@ DiscoverProviderHealer.prototype._getTargets = function _getTargets(hosts) {
         .value();
 
     function isHostAValidTarget(host) {
+        if (host === ringpop.whoami()){
+            return false;
+        }
         var member = membership.findMemberByAddress(host);
         if (!member) {
             // host isn't known in current membership.


### PR DESCRIPTION
Since we now support a self declared faulty on the local member, during partition healing we need to explicitly exclude ourself from the list of targets during partition healing.
previously this was implied because the local member always changed it's status to `alive`.