### PR TITLE
Update version of hammock for perf boost

### DIFF
--- a/index.js
+++ b/index.js
@@ -691,6 +691,13 @@ RingPop.prototype.handleOrProxyAll =
                 keys: keysByDest[dest]
             });
             if ((--pending === 0 || err) && cb) {
+                for (var i = 0; i < responses.length; i++) {
+                    var r = responses[i];
+                    if (Buffer.isBuffer(r.body)) {
+                        r.body = r.body.toString('utf8');
+                    }
+                }
+
                 cb(err, responses);
                 cb = null;
             }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "body": "^5.0.0",
     "error": "^5.0.0",
     "farmhash": "^1.2.0",
-    "hammock": "^1.1.1",
+    "hammock": "^2.0.1",
     "metrics": "^0.1.8",
     "node-uuid": "^1.4.3",
     "toobusy-js": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
     "body": "^5.0.0",
     "error": "^5.0.0",
     "farmhash": "^1.2.0",
+    "hammock": "^1.1.1",
     "metrics": "^0.1.8",
     "node-uuid": "^1.4.3",
     "toobusy-js": "^0.5.0",
-    "hammock": "^1.1.0",
     "underscore": "^1.5.2"
   },
   "devDependencies": {

--- a/test/integration/proxy_test.js
+++ b/test/integration/proxy_test.js
@@ -715,7 +715,7 @@ test('reroutes retry to remote', function t(assert) {
             retrySchedule: [1]
         }, function onRequest(err, res) {
             assert.ifError(err, 'no error occurs');
-            assert.equal(res.body, 'rerouted', 'response from rerouted request is correct');
+            assert.equal(res.body.toString(), 'rerouted', 'response from rerouted request is correct');
 
             cluster.destroy();
             assert.end();
@@ -896,7 +896,7 @@ test('can serialize response body', function t(assert) {
             assert.ifError(err);
 
             assert.equal(resp.statusCode, 200);
-            assert.equal(resp.body, 'hello');
+            assert.equal(resp.body.toString(), 'hello');
 
             cluster.destroy();
             assert.end();

--- a/test/integration/proxy_test.js
+++ b/test/integration/proxy_test.js
@@ -715,7 +715,11 @@ test('reroutes retry to remote', function t(assert) {
             retrySchedule: [1]
         }, function onRequest(err, res) {
             assert.ifError(err, 'no error occurs');
-            assert.equal(res.body.toString(), 'rerouted', 'response from rerouted request is correct');
+            assert.equal(
+                res.body.toString('hex'),
+                new Buffer('rerouted').toString('hex'),
+                'response from rerouted request is correct'
+            );
 
             cluster.destroy();
             assert.end();
@@ -896,7 +900,10 @@ test('can serialize response body', function t(assert) {
             assert.ifError(err);
 
             assert.equal(resp.statusCode, 200);
-            assert.equal(resp.body.toString(), 'hello');
+            assert.equal(
+                resp.body.toString('hex'),
+                new Buffer('hello').toString('hex')
+            );
 
             cluster.destroy();
             assert.end();


### PR DESCRIPTION
The hammock library is used in the ringpop proxy code
and had some performance issues in response buffering.

These are fixed in the latest version of hammock

r: @thanodl @motiejus @mennopruijssers