### PR TITLE
Don’t stringify buffers in transports

### DIFF
--- a/lib/middleware/transport.js
+++ b/lib/middleware/transport.js
@@ -41,7 +41,7 @@ var transportServerMiddleware = {
         callback(arg2, arg3);
     },
     'response': function(req, err, res1, res2, callback) {
-        if (res2 !== undefined && typeof res2 !== 'string') {
+        if (res2 !== undefined && typeof res2 !== 'string' && !Buffer.isBuffer(res2)) {
             res2 = JSON.stringify(res2);
         }
         callback(err, res1, res2);

--- a/test/integration/proxy_test.js
+++ b/test/integration/proxy_test.js
@@ -911,6 +911,31 @@ test('can serialize response body', function t(assert) {
     });
 });
 
+test('proxies buffer responses', function t(assert) {
+    var cluster = allocCluster({
+        createHandler: function createHandler() {
+            return function handle(req, res) {
+                res.end(new Buffer('hello'));
+            };
+        }
+    }, function onReady() {
+        cluster.request({
+            host: 'one', key: cluster.keys.two
+        }, function onResponse(err, resp) {
+            assert.ifError(err);
+
+            assert.equal(resp.statusCode, 200);
+            assert.equal(
+                resp.body.toString('hex'),
+                new Buffer('hello').toString('hex')
+            );
+
+            cluster.destroy();
+            assert.end();
+        });
+    });
+});
+
 // new features
 test('can handle errors differently');
 test('adds forwarding header');

--- a/test/unit/transport_test.js
+++ b/test/unit/transport_test.js
@@ -85,3 +85,16 @@ test('res2 is not JSON encoded if string', function t(assert) {
         assert.equals(res2, 'string');
     });
 });
+
+test('buffer-res2 is not JSON encoded if string', function t(assert) {
+    assert.plan(3);
+    var req = {};
+    var error = null;
+    var res1 = null;
+    var res2 = new Buffer('string');
+    transportMiddleware.response(req, error, res1, res2, function(err, res1, res2) {
+        assert.equals(err, null);
+        assert.equals(res1, null);
+        assert.deepEquals(res2, new Buffer('string'));
+    });
+});


### PR DESCRIPTION
Due to changes in hammock, request-proxy is now serializing buffers as json.