### PR TITLE
[Feature] Key consistent forwarding

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,8 @@ function RingPop(options) {
         ringpop: this,
         maxRetries: options.requestProxyMaxRetries,
         retrySchedule: options.requestProxyRetrySchedule,
-        enforceConsistency: options.enforceConsistency
+        enforceConsistency: options.enforceConsistency,
+        enforceKeyConsistency: options.enforceKeyConsistency
     });
 
     this.ring = new this.Ring({

--- a/lib/request-proxy/index.js
+++ b/lib/request-proxy/index.js
@@ -44,6 +44,14 @@ var InvalidCheckSumError = TypedError({
     actual: null,
     expected: null
 });
+var InvalidKeyError = TypedError({
+    type: 'ringpop.request-proxy.invalid-key',
+    message: 'Expected the local node to resolve to the forwarded key.\n' +
+             'A lookup for "{key}" resulted in {target} instead of {whoami}.',
+    key: null,
+    target: null,
+    whoami: null
+});
 var TooManyRequestsError = TypedError({
     type: 'ringpop.request-proxy.too-many-requests',
     message: 'The number of inflight requests have exceeded a maximum of {max} at {egressOrIngress}',
@@ -59,7 +67,11 @@ function RequestProxy(opts) {
     this.ringpop = opts.ringpop;
     this.retrySchedule = opts.retrySchedule;
     this.maxRetries = opts.maxRetries;
+
+    // enforceConsistency enforces ring concistencty
     this.enforceConsistency = opts.enforceConsistency === undefined ? true : opts.enforceConsistency;
+    // defaults to false for backwards compatibility
+    this.enforceKeyConsistency = opts.enforceKeyConsistency === undefined ? false : opts.enforceKeyConsistency;
 
     this.sends = [];
 
@@ -203,9 +215,11 @@ RequestProxy.prototype.handleRequest = function handleRequest(head, body, cb) {
     var method = head.method;
     var httpVersion = head.httpVersion;
     var checksum = head.ringpopChecksum;
+    var keys = head.ringpopKeys || []; // default to an empty array in case the keys are missing from the request.
+    var err;
 
     if (checksum !== ringpop.ring.checksum) {
-        var err = InvalidCheckSumError({
+        err = InvalidCheckSumError({
             expected: ringpop.ring.checksum,
             actual: checksum
         });
@@ -218,6 +232,38 @@ RequestProxy.prototype.handleRequest = function handleRequest(head, body, cb) {
         this.ringpop.stat('increment', 'requestProxy.checksumsDiffer');
         if (this.enforceConsistency) {
             return cb(err);
+        }
+    }
+
+    var whoami = ringpop.whoami();
+    for (var i = 0; i < keys.length; i++) {
+        var key = keys[i];
+        var target = ringpop.lookup(key);
+
+        if (target !== whoami) {
+            err = InvalidKeyError({
+                key: key,
+                target: target,
+                whoami: whoami
+            });
+
+            ringpop.logger.warn('handleRequest got invalid key', {
+                error: err,
+                url: url,
+                enforceKeyConsistency: this.enforceKeyConsistency
+            });
+
+            ringpop.emit('requestProxy.keysDiffer');
+            ringpop.stat('increment', 'requestProxy.keysDiffer');
+
+            if (this.enforceKeyConsistency) {
+                return cb(err);
+            }
+
+            // make sure only 1 stat/log is emitted per call to not skew with
+            // ratio results if there are multiple keys in the call that don't
+            // match.
+            break;
         }
     }
 

--- a/lib/request-proxy/index.js
+++ b/lib/request-proxy/index.js
@@ -47,8 +47,7 @@ var InvalidCheckSumError = TypedError({
 var InvalidKeyError = TypedError({
     type: 'ringpop.request-proxy.invalid-key',
     message: 'Expected the local node to resolve to the forwarded key.\n' +
-             'A lookup for "{key}" resulted in {target} instead of {whoami}.',
-    key: null,
+             'A lookup resulted in {target} instead of {whoami}.',
     target: null,
     whoami: null
 });
@@ -242,7 +241,6 @@ RequestProxy.prototype.handleRequest = function handleRequest(head, body, cb) {
 
         if (target !== whoami) {
             err = InvalidKeyError({
-                key: key,
                 target: target,
                 whoami: whoami
             });

--- a/lib/request-proxy/index.js
+++ b/lib/request-proxy/index.js
@@ -217,6 +217,12 @@ RequestProxy.prototype.handleRequest = function handleRequest(head, body, cb) {
     var keys = head.ringpopKeys || []; // default to an empty array in case the keys are missing from the request.
     var err;
 
+    // The check here will validate the consistency of both hashrings for this
+    // node and the node that forwarded the request here. If it is configured
+    // the rings need to be consistent during forwarding it will respond with an
+    // error and prevent execution of the forwarded request. In any case it will
+    // emit stats that can be used to measure how often forwarded requests are
+    // inconsistent on the hash rings.
     if (checksum !== ringpop.ring.checksum) {
         err = InvalidCheckSumError({
             expected: ringpop.ring.checksum,
@@ -234,6 +240,11 @@ RequestProxy.prototype.handleRequest = function handleRequest(head, body, cb) {
         }
     }
 
+    // The check here will validate ownership of the forwarded keys. If it is
+    // configured the keys need to be consistent during forwarding it will
+    // respond with an error and prevent execution of the forwarded request. In
+    // any case it will emit stats that can be used to measure how often
+    // forwarded requests are inconsistent on keys.
     var whoami = ringpop.whoami();
     for (var i = 0; i < keys.length; i++) {
         var key = keys[i];

--- a/lib/request-proxy/index.js
+++ b/lib/request-proxy/index.js
@@ -219,10 +219,9 @@ RequestProxy.prototype.handleRequest = function handleRequest(head, body, cb) {
 
     // The check here will validate the consistency of both hashrings for this
     // node and the node that forwarded the request here. If it is configured
-    // the rings need to be consistent during forwarding it will respond with an
-    // error and prevent execution of the forwarded request. In any case it will
-    // emit stats that can be used to measure how often forwarded requests are
-    // inconsistent on the hash rings.
+    // that the rings need to be consistent during forwarding it will respond
+    // with an error and prevent execution of the forwarded request. Either way
+    // it will always emit a stat if there are inconsistencies between the rings
     if (checksum !== ringpop.ring.checksum) {
         err = InvalidCheckSumError({
             expected: ringpop.ring.checksum,
@@ -241,10 +240,10 @@ RequestProxy.prototype.handleRequest = function handleRequest(head, body, cb) {
     }
 
     // The check here will validate ownership of the forwarded keys. If it is
-    // configured the keys need to be consistent during forwarding it will
-    // respond with an error and prevent execution of the forwarded request. In
-    // any case it will emit stats that can be used to measure how often
-    // forwarded requests are inconsistent on keys.
+    // configured that the keys need to be consistent during forwarding it will
+    // respond with an error and prevent execution of the forwarded request.
+    // Either way it will always emit a stat if there are inconsistencies
+    // between the keys
     var whoami = ringpop.whoami();
     for (var i = 0; i < keys.length; i++) {
         var key = keys[i];


### PR DESCRIPTION
Currently ringpop can be configured to compare the hashring when a request is forwarded and drop the request if the hashrings are inconsistent. This causes a lot of requests that are actually forwarded to the correct node to fail, resulting in a lot of timeout and errors on rolling restarts.

The PR will add the possibility to loosen the requirement from ring consistency to key consistency eg. if the key from the forwarded request is believed to be owned by the receiving node based on a hashring lookup it will execute the request. When this happen both the forwarder and the receiver of the forwarded request agree on the key ownership for the key to the receiving end.

This showed a huge improvement in performance of a ringpop application during a rolling restart.