### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/client_request.js
+++ b/client_request.js
@@ -26,7 +26,7 @@ var EventEmitter = require('events').EventEmitter;
 var LoggingLevels = require('./lib/logging/levels.js');
 var safeParse = require('./lib/util.js').safeParse;
 var validateHostPort = require('./lib/util.js').validateHostPort;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var util = require('util');
 var middleware = require('./lib/middleware');
 

--- a/lib/membership/update.js
+++ b/lib/membership/update.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 /**
  * Create a new Update

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
     "farmhash": "^1.2.0",
     "hammock": "^2.0.1",
     "metrics": "^0.1.8",
-    "node-uuid": "^1.4.3",
     "toobusy-js": "^0.5.0",
-    "underscore": "^1.5.2"
+    "underscore": "^1.5.2",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "after": "^0.8.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.