### PR TITLE
[Fix] Consistent hash ring lookups 1 / Use comparator function

### DIFF
--- a/lib/ring/index.js
+++ b/lib/ring/index.js
@@ -151,10 +151,10 @@ HashRing.prototype.removeServerReplicas = function removeServerReplicas(server) 
 HashRing.prototype.lookup = function lookup(str) {
     var hash = this.hashFunc(str);
     var iter = this.rbtree.upperBound(hash);
-    var res = iter.str();
+    var res = iter.value();
     if (res === null) {
         var min = this.rbtree.min();
-        res = min && min.str;
+        res = min && min.value;
     }
     return res;
 };
@@ -177,7 +177,7 @@ HashRing.prototype.lookupN = function lookupN(str, n) {
     // rbtree contains only 2 unique servers.)
     var firstVal = iter.key();
     do {
-        var res = iter.str();
+        var res = iter.value();
         if (res === null) {
             // reached end of rbtree, wrapping around
             iter = this.rbtree.iterator();

--- a/lib/ring/index.js
+++ b/lib/ring/index.js
@@ -175,7 +175,7 @@ HashRing.prototype.lookupN = function lookupN(str, n) {
     // (This is to guard against the cases where serverCount is out of sync with
     // the rbtree (e.g., due to a bug), e.g., n === serverCount === 3 but the
     // rbtree contains only 2 unique servers.)
-    var firstVal = iter.val();
+    var firstVal = iter.key();
     do {
         var res = iter.str();
         if (res === null) {
@@ -189,7 +189,7 @@ HashRing.prototype.lookupN = function lookupN(str, n) {
             }
         }
         iter.next();
-    } while (resultArray.length < n && iter.val() !== firstVal);
+    } while (resultArray.length < n && iter.key() !== firstVal);
 
     return resultArray;
 };

--- a/lib/ring/index.js
+++ b/lib/ring/index.js
@@ -30,10 +30,13 @@ function HashRing(options) {
     this.replicaPoints = this.options.replicaPoints || 100;
     this.hashFunc = this.options.hashFunc || farmhash.hash32v1;
 
-    this.rbtree = new RBTree();
+    this.rbtree = new RBTree(HashRing.comparator);
     this.servers = {};
     this.checksum = null;
 }
+HashRing.comparator = function comparator(a, b) {
+    return a - b;
+};
 
 util.inherits(HashRing, EventEmitter);
 

--- a/lib/ring/rbtree.js
+++ b/lib/ring/rbtree.js
@@ -172,9 +172,9 @@ RBTree.prototype.remove = function(key) {
         p = node;
         node = node.getChild(dir);
 
-        var cmp = this.comparator(node.key, key);
+        var cmp = this.comparator(key, node.key);
 
-        dir = cmp < 0;
+        dir = cmp > 0;
 
         // save found node
         if (cmp === 0) {

--- a/lib/ring/rbtree.js
+++ b/lib/ring/rbtree.js
@@ -20,10 +20,10 @@
 
 var RBIterator; // forward references
 
-// payload of this tree (key, str) is embedded into the node for performance
-function RingNode(key, str) {
+// payload of this tree (key, value) is embedded into the node for performance
+function RingNode(key, value) {
     this.key = key;
-    this.str = str;
+    this.value = value;
     this.left = null;
     this.right = null;
     this.red = true;
@@ -68,11 +68,11 @@ function doubleRotate(root, dir) {
 }
 
 // returns true if inserted, false if duplicate
-RBTree.prototype.insert = function(key, str) {
+RBTree.prototype.insert = function(key, value) {
     var ret = false;
 
     if (this.root === null) { // empty
-        this.root = new RingNode(key, str);
+        this.root = new RingNode(key, value);
         ret = true;
     } else {
         var head = new RingNode(undefined, undefined); // fake tree root
@@ -89,7 +89,7 @@ RBTree.prototype.insert = function(key, str) {
         while (true) {
             if (node === null) {
                 // insert new node at the bottom
-                node = new RingNode(key, str);
+                node = new RingNode(key, value);
                 p.setChild(dir, node);
                 ret = true;
             } else if (isRed(node.left) && isRed(node.right)) {
@@ -218,7 +218,7 @@ RBTree.prototype.remove = function(key) {
     // splice out the node that we've found
     if (found !== null) {
         found.key = node.key;
-        found.str = node.str;
+        found.value = node.value;
         p.setChild(p.right === node, node.getChild(node.left === null));
         this.size--;
     }
@@ -299,8 +299,8 @@ RBIterator.prototype.key = function() {
     return this.cursor !== null ? this.cursor.key : null;
 };
 
-RBIterator.prototype.str = function() {
-    return this.cursor !== null ? this.cursor.str : null;
+RBIterator.prototype.value = function() {
+    return this.cursor !== null ? this.cursor.value : null;
 };
 
 // if null-iterator, return first node, otherwise next node

--- a/lib/ring/rbtree.js
+++ b/lib/ring/rbtree.js
@@ -41,7 +41,8 @@ RingNode.prototype.setChild = function(dir, child) {
     }
 };
 
-var RBTree = function RBTree() {
+var RBTree = function RBTree(comparator) {
+    this.comparator = comparator;
     this.root = null;
     this.size = 0;
 };
@@ -110,7 +111,7 @@ RBTree.prototype.insert = function(key, value) {
                 }
             }
 
-            var cmp = node.key - key; // note inlined comparitor
+            var cmp = this.comparator(node.key, key);
 
             // stop if found
             if (cmp === 0) {
@@ -171,9 +172,9 @@ RBTree.prototype.remove = function(key) {
         p = node;
         node = node.getChild(dir);
 
-        var cmp = key - node.key; // note inlined comparitor
+        var cmp = this.comparator(node.key, key);
 
-        dir = cmp > 0;
+        dir = cmp < 0;
 
         // save found node
         if (cmp === 0) {
@@ -238,7 +239,7 @@ RBTree.prototype.lowerBound = function(key) {
     var iter = this.iterator();
 
     while (cur !== null) {
-        var c = key - cur.key;
+        var c = this.comparator(key, cur.key);
         if (c === 0) {
             iter.cursor = cur;
             return iter;
@@ -249,7 +250,7 @@ RBTree.prototype.lowerBound = function(key) {
 
     for (var i = iter.ancestors.length - 1; i >= 0; --i) {
         cur = iter.ancestors[i];
-        if (key - cur.key < 0) {
+        if (this.comparator(key, cur.key) < 0) {
             iter.cursor = cur;
             iter.ancestors.length = i;
             return iter;
@@ -264,7 +265,7 @@ RBTree.prototype.lowerBound = function(key) {
 RBTree.prototype.upperBound = function(key) {
     var iter = this.lowerBound(key);
 
-    while (iter.key() !== null && (iter.key() - key) < 0) { // inlined comparitor
+    while (iter.key() !== null && this.comparator(iter.key(), key) < 0) {
         iter.next();
     }
 

--- a/lib/ring/rbtree.js
+++ b/lib/ring/rbtree.js
@@ -20,9 +20,9 @@
 
 var RBIterator; // forward references
 
-// payload of this tree (val, str) is embedded into the node for performance
-function RingNode(val, str) {
-    this.val = val;
+// payload of this tree (key, str) is embedded into the node for performance
+function RingNode(key, str) {
+    this.key = key;
     this.str = str;
     this.left = null;
     this.right = null;
@@ -33,11 +33,11 @@ RingNode.prototype.getChild = function(dir) {
     return dir ? this.right : this.left;
 };
 
-RingNode.prototype.setChild = function(dir, val) {
+RingNode.prototype.setChild = function(dir, child) {
     if (dir) {
-        this.right = val;
+        this.right = child;
     } else {
-        this.left = val;
+        this.left = child;
     }
 };
 
@@ -68,11 +68,11 @@ function doubleRotate(root, dir) {
 }
 
 // returns true if inserted, false if duplicate
-RBTree.prototype.insert = function(val, str) {
+RBTree.prototype.insert = function(key, str) {
     var ret = false;
 
     if (this.root === null) { // empty
-        this.root = new RingNode(val, str);
+        this.root = new RingNode(key, str);
         ret = true;
     } else {
         var head = new RingNode(undefined, undefined); // fake tree root
@@ -89,7 +89,7 @@ RBTree.prototype.insert = function(val, str) {
         while (true) {
             if (node === null) {
                 // insert new node at the bottom
-                node = new RingNode(val, str);
+                node = new RingNode(key, str);
                 p.setChild(dir, node);
                 ret = true;
             } else if (isRed(node.left) && isRed(node.right)) {
@@ -110,7 +110,7 @@ RBTree.prototype.insert = function(val, str) {
                 }
             }
 
-            var cmp = node.val - val; // note inlined comparitor
+            var cmp = node.key - key; // note inlined comparitor
 
             // stop if found
             if (cmp === 0) {
@@ -150,7 +150,7 @@ RBTree.prototype.insert = function(val, str) {
 // delete a red node.
 
 // returns true if found and removed, false if not found
-RBTree.prototype.remove = function(val) {
+RBTree.prototype.remove = function(key) {
     if (this.root === null) {
         return false;
     }
@@ -171,7 +171,7 @@ RBTree.prototype.remove = function(val) {
         p = node;
         node = node.getChild(dir);
 
-        var cmp = val - node.val; // note inlined comparitor
+        var cmp = key - node.key; // note inlined comparitor
 
         dir = cmp > 0;
 
@@ -217,7 +217,7 @@ RBTree.prototype.remove = function(val) {
 
     // splice out the node that we've found
     if (found !== null) {
-        found.val = node.val;
+        found.key = node.key;
         found.str = node.str;
         p.setChild(p.right === node, node.getChild(node.left === null));
         this.size--;
@@ -233,12 +233,12 @@ RBTree.prototype.remove = function(val) {
 };
 
 // Returns an interator to the tree node at or immediately after the item
-RBTree.prototype.lowerBound = function(val) {
+RBTree.prototype.lowerBound = function(key) {
     var cur = this.root;
     var iter = this.iterator();
 
     while (cur !== null) {
-        var c = val - cur.val;
+        var c = key - cur.key;
         if (c === 0) {
             iter.cursor = cur;
             return iter;
@@ -249,7 +249,7 @@ RBTree.prototype.lowerBound = function(val) {
 
     for (var i = iter.ancestors.length - 1; i >= 0; --i) {
         cur = iter.ancestors[i];
-        if (val - cur.val < 0) {
+        if (key - cur.key < 0) {
             iter.cursor = cur;
             iter.ancestors.length = i;
             return iter;
@@ -261,10 +261,10 @@ RBTree.prototype.lowerBound = function(val) {
 };
 
 // Returns an interator to the tree node immediately after the item
-RBTree.prototype.upperBound = function(val) {
-    var iter = this.lowerBound(val);
+RBTree.prototype.upperBound = function(key) {
+    var iter = this.lowerBound(key);
 
-    while (iter.val() !== null && (iter.val() - val) < 0) { // inlined comparitor
+    while (iter.key() !== null && (iter.key() - key) < 0) { // inlined comparitor
         iter.next();
     }
 
@@ -295,8 +295,8 @@ RBIterator = function RBIterator(tree) {
     this.cursor = null;
 };
 
-RBIterator.prototype.val = function() {
-    return this.cursor !== null ? this.cursor.val : null;
+RBIterator.prototype.key = function() {
+    return this.cursor !== null ? this.cursor.key : null;
 };
 
 RBIterator.prototype.str = function() {
@@ -330,7 +330,7 @@ RBIterator.prototype.next = function() {
             this.minNode(this.cursor.right);
         }
     }
-    return this.cursor !== null ? this.cursor.val : null;
+    return this.cursor !== null ? this.cursor.key : null;
 };
 
 // find the left-most node from this subtree

--- a/test/unit/rbiterator_test.js
+++ b/test/unit/rbiterator_test.js
@@ -32,20 +32,20 @@ test('construct a new RBIterator', function t(assert) {
     assert.end();
 });
 
-test('RBIterator.key and RBIterator.str', function t(assert) {
+test('RBIterator.key and RBIterator.value', function t(assert) {
     var tree = new RBTree();
     var iterator = new RBIterator(tree);
 
     assert.strictEquals(iterator.key(), null, 'key on empty tree is null');
-    assert.strictEquals(iterator.str(), null, 'str on empty tree is null');
+    assert.strictEquals(iterator.value(), null, 'value on empty tree is null');
 
     iterator.cursor = {
         key: 1234,
-        str: '1234'
+        value: '1234'
     };
 
     assert.strictEquals(iterator.key(), 1234, 'key returns cursor key');
-    assert.strictEquals(iterator.str(), '1234', 'str returns cursor str');
+    assert.strictEquals(iterator.value(), '1234', 'value returns cursor value');
 
     assert.end();
 });
@@ -79,15 +79,15 @@ test('RBIterator.minNode', function t(assert) {
 
     iterator.minNode(tree.root);
     assert.strictEquals(iterator.key(), 1, 'key min from root is 1');
-    assert.strictEquals(iterator.str(), 'one', 'str min from root is one');
+    assert.strictEquals(iterator.value(), 'one', 'value min from root is one');
 
     iterator.minNode(tree.root.left.left);
     assert.strictEquals(iterator.key(), 1, 'key min from 1 is 1');
-    assert.strictEquals(iterator.str(), 'one', 'str min from 1 is one');
+    assert.strictEquals(iterator.value(), 'one', 'value min from 1 is one');
 
     iterator.minNode(tree.root.right);
     assert.strictEquals(iterator.key(), 5, 'key min from 6 is 5');
-    assert.strictEquals(iterator.str(), 'five', 'str min from 6 is five');
+    assert.strictEquals(iterator.value(), 'five', 'value min from 6 is five');
 
     assert.end();
 });

--- a/test/unit/rbiterator_test.js
+++ b/test/unit/rbiterator_test.js
@@ -32,19 +32,19 @@ test('construct a new RBIterator', function t(assert) {
     assert.end();
 });
 
-test('RBIterator.val and RBIterator.str', function t(assert) {
+test('RBIterator.key and RBIterator.str', function t(assert) {
     var tree = new RBTree();
     var iterator = new RBIterator(tree);
 
-    assert.strictEquals(iterator.val(), null, 'val on empty tree is null');
+    assert.strictEquals(iterator.key(), null, 'key on empty tree is null');
     assert.strictEquals(iterator.str(), null, 'str on empty tree is null');
 
     iterator.cursor = {
-        val: 1234,
+        key: 1234,
         str: '1234'
     };
 
-    assert.strictEquals(iterator.val(), 1234, 'val returns cursor val');
+    assert.strictEquals(iterator.key(), 1234, 'key returns cursor key');
     assert.strictEquals(iterator.str(), '1234', 'str returns cursor str');
 
     assert.end();
@@ -78,15 +78,15 @@ test('RBIterator.minNode', function t(assert) {
     var iterator = new RBIterator(tree);
 
     iterator.minNode(tree.root);
-    assert.strictEquals(iterator.val(), 1, 'val min from root is 1');
+    assert.strictEquals(iterator.key(), 1, 'key min from root is 1');
     assert.strictEquals(iterator.str(), 'one', 'str min from root is one');
 
     iterator.minNode(tree.root.left.left);
-    assert.strictEquals(iterator.val(), 1, 'val min from 1 is 1');
+    assert.strictEquals(iterator.key(), 1, 'key min from 1 is 1');
     assert.strictEquals(iterator.str(), 'one', 'str min from 1 is one');
 
     iterator.minNode(tree.root.right);
-    assert.strictEquals(iterator.val(), 5, 'val min from 6 is 5');
+    assert.strictEquals(iterator.key(), 5, 'key min from 6 is 5');
     assert.strictEquals(iterator.str(), 'five', 'str min from 6 is five');
 
     assert.end();
@@ -96,15 +96,15 @@ test('RBIterator.next walk the entire tree', function t(assert) {
     var tree = makeTree();
     var iterator = new RBIterator(tree);
 
-    assert.strictEquals(iterator.next(), 1, 'val is 1');
-    assert.strictEquals(iterator.next(), 2, 'val is 2');
-    assert.strictEquals(iterator.next(), 3, 'val is 3');
-    assert.strictEquals(iterator.next(), 4, 'val is 4');
-    assert.strictEquals(iterator.next(), 5, 'val is 5');
-    assert.strictEquals(iterator.next(), 6, 'val is 6');
-    assert.strictEquals(iterator.next(), 7, 'val is 7');
-    assert.strictEquals(iterator.next(), 8, 'val is 8');
-    assert.strictEquals(iterator.next(), null, 'val is null');
+    assert.strictEquals(iterator.next(), 1, 'key is 1');
+    assert.strictEquals(iterator.next(), 2, 'key is 2');
+    assert.strictEquals(iterator.next(), 3, 'key is 3');
+    assert.strictEquals(iterator.next(), 4, 'key is 4');
+    assert.strictEquals(iterator.next(), 5, 'key is 5');
+    assert.strictEquals(iterator.next(), 6, 'key is 6');
+    assert.strictEquals(iterator.next(), 7, 'key is 7');
+    assert.strictEquals(iterator.next(), 8, 'key is 8');
+    assert.strictEquals(iterator.next(), null, 'key is null');
 
     assert.end();
 });

--- a/test/unit/rbiterator_test.js
+++ b/test/unit/rbiterator_test.js
@@ -20,10 +20,12 @@
 
 var RBTree = require('../../lib/ring/rbtree').RBTree;
 var RBIterator = require('../../lib/ring/rbtree').RBIterator;
+var comparator = require('../../lib/ring').comparator;
+
 var test = require('tape');
 
 test('construct a new RBIterator', function t(assert) {
-    var tree = new RBTree();
+    var tree = new RBTree(comparator);
     var iterator = new RBIterator(tree);
 
     assert.strictEquals(iterator.tree, tree, 'tree is set to supplied tree');
@@ -33,7 +35,7 @@ test('construct a new RBIterator', function t(assert) {
 });
 
 test('RBIterator.key and RBIterator.value', function t(assert) {
-    var tree = new RBTree();
+    var tree = new RBTree(comparator);
     var iterator = new RBIterator(tree);
 
     assert.strictEquals(iterator.key(), null, 'key on empty tree is null');
@@ -51,7 +53,7 @@ test('RBIterator.key and RBIterator.value', function t(assert) {
 });
 
 function makeTree() {
-    var tree = new RBTree();
+    var tree = new RBTree(comparator);
 
     tree.insert(1, 'one');
     tree.insert(2, 'two');

--- a/test/unit/rbtree_test.js
+++ b/test/unit/rbtree_test.js
@@ -68,19 +68,19 @@ function validateRBTree(node) {
     var rightNode = node.right;
 
     if (isRed(node) && (isRed(leftNode) || isRed(rightNode))) {
-        throw new Error('red violation at node val' + node.val);
+        throw new Error('red violation at node key' + node.key);
     }
 
     var leftHeight = validateRBTree(leftNode);
     var rightHeight = validateRBTree(rightNode);
 
-    if (leftNode !== null && leftNode.val >= root.val || rightNode !== null && rightNode.val <= root.val) {
-        throw new Error('binary tree violation at node val ' + node.val);
+    if (leftNode !== null && leftNode.key >= root.key || rightNode !== null && rightNode.key <= root.key) {
+        throw new Error('binary tree violation at node key ' + node.key);
     }
 
     if (leftHeight !== 0 && rightHeight !== 0) {
         if (leftHeight !== rightHeight) {
-            throw new Error('black height violation at node val ' + node.val);
+            throw new Error('black height violation at node key ' + node.key);
         }
 
         if (isRed(node)) {
@@ -104,7 +104,7 @@ test('RBTree.insert', function t(assert) {
     assert.strictEquals(tree.size, 8, 'tree has 8 nodes');
 
     var node = tree.root;
-    assert.strictEquals(node.val, 4, 'tree root val is 4');
+    assert.strictEquals(node.key, 4, 'tree root key is 4');
     assert.strictEquals(node.str, 'four', 'tree root str is four');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
@@ -112,7 +112,7 @@ test('RBTree.insert', function t(assert) {
 
     // 1,B
     node = tree.root.left.left;
-    assert.strictEquals(node.val, 1, 'node val is correct');
+    assert.strictEquals(node.key, 1, 'node key is correct');
     assert.strictEquals(node.str, 'one', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -120,7 +120,7 @@ test('RBTree.insert', function t(assert) {
 
     // 2,R
     node = tree.root.left;
-    assert.strictEquals(node.val, 2, 'tree node val is correct');
+    assert.strictEquals(node.key, 2, 'tree node key is correct');
     assert.strictEquals(node.str, 'two', 'tree node str is correct');
     assert.strictEquals(node.red, true, 'tree node color is correct');
     assert.strictEquals(node.left instanceof RingNode, true, 'node left points to a RingNode');
@@ -128,7 +128,7 @@ test('RBTree.insert', function t(assert) {
 
     // 3,B
     node = tree.root.left.right;
-    assert.strictEquals(node.val, 3, 'node val is correct');
+    assert.strictEquals(node.key, 3, 'node key is correct');
     assert.strictEquals(node.str, 'three', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -136,7 +136,7 @@ test('RBTree.insert', function t(assert) {
 
     // 6,R
     node = tree.root.right;
-    assert.strictEquals(node.val, 6, 'tree node val is correct');
+    assert.strictEquals(node.key, 6, 'tree node key is correct');
     assert.strictEquals(node.str, 'six', 'tree node str is correct');
     assert.strictEquals(node.red, true, 'tree node color is correct');
     assert.strictEquals(node.left instanceof RingNode, true, 'node left points to a RingNode');
@@ -144,7 +144,7 @@ test('RBTree.insert', function t(assert) {
 
     // 5,B
     node = tree.root.right.left;
-    assert.strictEquals(node.val, 5, 'node val is correct');
+    assert.strictEquals(node.key, 5, 'node key is correct');
     assert.strictEquals(node.str, 'five', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -152,7 +152,7 @@ test('RBTree.insert', function t(assert) {
 
     // 7,B
     node = tree.root.right.right;
-    assert.strictEquals(node.val, 7, 'node val is correct');
+    assert.strictEquals(node.key, 7, 'node key is correct');
     assert.strictEquals(node.str, 'seven', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'node has no left pointer');
@@ -160,7 +160,7 @@ test('RBTree.insert', function t(assert) {
 
     // 8,R
     node = tree.root.right.right.right;
-    assert.strictEquals(node.val, 8, 'node val is correct');
+    assert.strictEquals(node.key, 8, 'node key is correct');
     assert.strictEquals(node.str, 'eight', 'node str is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -193,7 +193,7 @@ test('RBTree.remove', function t(assert) {
 
     // 4,B
     var node = tree.root;
-    assert.strictEquals(node.val, 4, 'tree root val is 4');
+    assert.strictEquals(node.key, 4, 'tree root key is 4');
     assert.strictEquals(node.str, 'four', 'tree root str is four');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
@@ -201,7 +201,7 @@ test('RBTree.remove', function t(assert) {
 
     // 2,R
     node = tree.root.left;
-    assert.strictEquals(node.val, 2, 'tree node val is correct');
+    assert.strictEquals(node.key, 2, 'tree node key is correct');
     assert.strictEquals(node.str, 'two', 'tree node str is correct');
     assert.strictEquals(node.red, false, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
@@ -209,7 +209,7 @@ test('RBTree.remove', function t(assert) {
 
     // 3,B
     node = tree.root.left.right;
-    assert.strictEquals(node.val, 3, 'node val is correct');
+    assert.strictEquals(node.key, 3, 'node key is correct');
     assert.strictEquals(node.str, 'three', 'node str is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -217,7 +217,7 @@ test('RBTree.remove', function t(assert) {
 
     // 6,R
     node = tree.root.right;
-    assert.strictEquals(node.val, 6, 'tree node val is correct');
+    assert.strictEquals(node.key, 6, 'tree node key is correct');
     assert.strictEquals(node.str, 'six', 'tree node str is correct');
     assert.strictEquals(node.red, true, 'tree node color is correct');
     assert.strictEquals(node.left instanceof RingNode, true, 'node left points to a RingNode');
@@ -225,7 +225,7 @@ test('RBTree.remove', function t(assert) {
 
     // 5,B
     node = tree.root.right.left;
-    assert.strictEquals(node.val, 5, 'node val is correct');
+    assert.strictEquals(node.key, 5, 'node key is correct');
     assert.strictEquals(node.str, 'five', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -233,7 +233,7 @@ test('RBTree.remove', function t(assert) {
 
     // 7,B
     node = tree.root.right.right;
-    assert.strictEquals(node.val, 7, 'node val is correct');
+    assert.strictEquals(node.key, 7, 'node key is correct');
     assert.strictEquals(node.str, 'seven', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'node has no left pointer');
@@ -241,7 +241,7 @@ test('RBTree.remove', function t(assert) {
 
     // 8,R
     node = tree.root.right.right.right;
-    assert.strictEquals(node.val, 8, 'node val is correct');
+    assert.strictEquals(node.key, 8, 'node key is correct');
     assert.strictEquals(node.str, 'eight', 'node str is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -262,7 +262,7 @@ test('RBTree.remove', function t(assert) {
 
     // 6,B
     var node = tree.root;
-    assert.strictEquals(node.val, 6, 'tree root val is 6');
+    assert.strictEquals(node.key, 6, 'tree root key is 6');
     assert.strictEquals(node.str, 'six', 'tree root str is six');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
@@ -270,7 +270,7 @@ test('RBTree.remove', function t(assert) {
 
     // 3,B
     node = tree.root.left.left;
-    assert.strictEquals(node.val, 3, 'node val is correct');
+    assert.strictEquals(node.key, 3, 'node key is correct');
     assert.strictEquals(node.str, 'three', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -278,7 +278,7 @@ test('RBTree.remove', function t(assert) {
 
     // 4,B
     node = tree.root.left;
-    assert.strictEquals(node.val, 4, 'node val is correct');
+    assert.strictEquals(node.key, 4, 'node key is correct');
     assert.strictEquals(node.str, 'four', 'node str is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left instanceof RingNode, true, 'left pointer is RingNode');
@@ -286,7 +286,7 @@ test('RBTree.remove', function t(assert) {
 
     // 5,R
     node = tree.root.left.right;
-    assert.strictEquals(node.val, 5, 'tree node val is correct');
+    assert.strictEquals(node.key, 5, 'tree node key is correct');
     assert.strictEquals(node.str, 'five', 'tree node str is correct');
     assert.strictEquals(node.red, false, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
@@ -294,7 +294,7 @@ test('RBTree.remove', function t(assert) {
 
     // 7,B
     node = tree.root.right;
-    assert.strictEquals(node.val, 7, 'node val is correct');
+    assert.strictEquals(node.key, 7, 'node key is correct');
     assert.strictEquals(node.str, 'seven', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'node has no left pointer');
@@ -302,7 +302,7 @@ test('RBTree.remove', function t(assert) {
 
     // 8,R
     node = tree.root.right.right;
-    assert.strictEquals(node.val, 8, 'node val is correct');
+    assert.strictEquals(node.key, 8, 'node key is correct');
     assert.strictEquals(node.str, 'eight', 'node str is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -323,7 +323,7 @@ test('RBTree.remove', function t(assert) {
 
     // 6,B
     var node = tree.root;
-    assert.strictEquals(node.val, 6, 'tree root val is 6');
+    assert.strictEquals(node.key, 6, 'tree root key is 6');
     assert.strictEquals(node.str, 'six', 'tree root str is six');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
@@ -331,7 +331,7 @@ test('RBTree.remove', function t(assert) {
 
     // 4,B
     node = tree.root.left;
-    assert.strictEquals(node.val, 4, 'node val is correct');
+    assert.strictEquals(node.key, 4, 'node key is correct');
     assert.strictEquals(node.str, 'four', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'left pointer is null');
@@ -339,7 +339,7 @@ test('RBTree.remove', function t(assert) {
 
     // 5,R
     node = tree.root.left.right;
-    assert.strictEquals(node.val, 5, 'tree node val is correct');
+    assert.strictEquals(node.key, 5, 'tree node key is correct');
     assert.strictEquals(node.str, 'five', 'tree node str is correct');
     assert.strictEquals(node.red, true, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
@@ -347,7 +347,7 @@ test('RBTree.remove', function t(assert) {
 
     // 7,B
     node = tree.root.right;
-    assert.strictEquals(node.val, 7, 'node val is correct');
+    assert.strictEquals(node.key, 7, 'node key is correct');
     assert.strictEquals(node.str, 'seven', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'node has no left pointer');
@@ -355,7 +355,7 @@ test('RBTree.remove', function t(assert) {
 
     // 8,R
     node = tree.root.right.right;
-    assert.strictEquals(node.val, 8, 'node val is correct');
+    assert.strictEquals(node.key, 8, 'node key is correct');
     assert.strictEquals(node.str, 'eight', 'node str is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -376,7 +376,7 @@ test('RBTree.remove', function t(assert) {
 
     // 6,B
     var node = tree.root;
-    assert.strictEquals(node.val, 6, 'tree root val is 6');
+    assert.strictEquals(node.key, 6, 'tree root key is 6');
     assert.strictEquals(node.str, 'six', 'tree root str is six');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
@@ -384,7 +384,7 @@ test('RBTree.remove', function t(assert) {
 
     // 5,B
     node = tree.root.left;
-    assert.strictEquals(node.val, 5, 'tree node val is correct');
+    assert.strictEquals(node.key, 5, 'tree node key is correct');
     assert.strictEquals(node.str, 'five', 'tree node str is correct');
     assert.strictEquals(node.red, false, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
@@ -392,7 +392,7 @@ test('RBTree.remove', function t(assert) {
 
     // 7,B
     node = tree.root.right;
-    assert.strictEquals(node.val, 7, 'node val is correct');
+    assert.strictEquals(node.key, 7, 'node key is correct');
     assert.strictEquals(node.str, 'seven', 'node str is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'node has no left pointer');
@@ -400,7 +400,7 @@ test('RBTree.remove', function t(assert) {
 
     // 8,R
     node = tree.root.right.right;
-    assert.strictEquals(node.val, 8, 'node val is correct');
+    assert.strictEquals(node.key, 8, 'node key is correct');
     assert.strictEquals(node.str, 'eight', 'node str is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
@@ -419,7 +419,7 @@ test('RBTree.remove', function t(assert) {
 
     // 7,B
     var node = tree.root;
-    assert.strictEquals(node.val, 7, 'tree root val is 7');
+    assert.strictEquals(node.key, 7, 'tree root key is 7');
     assert.strictEquals(node.str, 'seven', 'tree root str is seven');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
@@ -427,7 +427,7 @@ test('RBTree.remove', function t(assert) {
 
     // 6,B
     node = tree.root.left;
-    assert.strictEquals(node.val, 6, 'tree node val is correct');
+    assert.strictEquals(node.key, 6, 'tree node key is correct');
     assert.strictEquals(node.str, 'six', 'tree node str is correct');
     assert.strictEquals(node.red, false, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
@@ -435,7 +435,7 @@ test('RBTree.remove', function t(assert) {
 
     // 8,B
     node = tree.root.right;
-    assert.strictEquals(node.val, 8, 'tree node val is correct');
+    assert.strictEquals(node.key, 8, 'tree node key is correct');
     assert.strictEquals(node.str, 'eight', 'tree node str is correct');
     assert.strictEquals(node.red, false, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left is null');
@@ -454,7 +454,7 @@ test('RBTree.remove', function t(assert) {
 
     // 7,B
     var node = tree.root;
-    assert.strictEquals(node.val, 7, 'tree root val is 7');
+    assert.strictEquals(node.key, 7, 'tree root key is 7');
     assert.strictEquals(node.str, 'seven', 'tree root str is seven');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left, null, 'tree root left is null');
@@ -462,7 +462,7 @@ test('RBTree.remove', function t(assert) {
 
     // 8,R
     node = tree.root.right;
-    assert.strictEquals(node.val, 8, 'tree node val is correct');
+    assert.strictEquals(node.key, 8, 'tree node key is correct');
     assert.strictEquals(node.str, 'eight', 'tree node str is correct');
     assert.strictEquals(node.red, true, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
@@ -479,7 +479,7 @@ test('RBTree.remove', function t(assert) {
 
     // 7,B
     var node = tree.root;
-    assert.strictEquals(node.val, 8, 'tree root val is 8');
+    assert.strictEquals(node.key, 8, 'tree root key is 8');
     assert.strictEquals(node.str, 'eight', 'tree root str is eight');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left, null, 'tree root left is null');
@@ -556,19 +556,19 @@ test('RBTree lowerBound', function t(assert) {
     //                               7,R     10,R
 
     var iter = tree.lowerBound(1);
-    assert.strictEquals(iter.val(), 1, 'lowerBound(1) is 1');
+    assert.strictEquals(iter.key(), 1, 'lowerBound(1) is 1');
 
     iter = tree.lowerBound(9);
-    assert.strictEquals(iter.val(), 10, 'lowerBound(9) is 10');
+    assert.strictEquals(iter.key(), 10, 'lowerBound(9) is 10');
 
     iter = tree.lowerBound(10);
-    assert.strictEquals(iter.val(), 10, 'lowerBound(10) is 10');
+    assert.strictEquals(iter.key(), 10, 'lowerBound(10) is 10');
 
     iter = tree.lowerBound(11);
-    assert.strictEquals(iter.val(), null, 'lowerBound(11) is null');
+    assert.strictEquals(iter.key(), null, 'lowerBound(11) is null');
 
     iter = tree.lowerBound(0);
-    assert.strictEquals(iter.val(), 1, 'lowerBound(0) is 1');
+    assert.strictEquals(iter.key(), 1, 'lowerBound(0) is 1');
 
     assert.end();
 });
@@ -578,16 +578,16 @@ test('RBTree upperBound', function t(assert) {
     tree.insert(10, 'ten');
 
     var iter = tree.upperBound(1);
-    assert.strictEquals(iter.val(), 1, 'upperBound(1) is 1');
+    assert.strictEquals(iter.key(), 1, 'upperBound(1) is 1');
 
     iter = tree.upperBound(9);
-    assert.strictEquals(iter.val(), 10, 'upperBound(9) is 10');
+    assert.strictEquals(iter.key(), 10, 'upperBound(9) is 10');
 
     iter = tree.upperBound(10);
-    assert.strictEquals(iter.val(), 10, 'upperBound(10) is 10');
+    assert.strictEquals(iter.key(), 10, 'upperBound(10) is 10');
 
     iter = tree.upperBound(0);
-    assert.strictEquals(iter.val(), 1, 'upperBound(0) is 1');
+    assert.strictEquals(iter.key(), 1, 'upperBound(0) is 1');
 
     assert.end();
 });
@@ -605,7 +605,7 @@ test('RBTree payload copy bug', function t(assert) {
 
     var iter = tree.iterator();
     while (iter.next() !== null) {
-        assert.strictEquals(iter.val(), Number(iter.str()), 'node payloads match');
+        assert.strictEquals(iter.key(), Number(iter.str()), 'node payloads match');
     }
 
     assert.end();

--- a/test/unit/rbtree_test.js
+++ b/test/unit/rbtree_test.js
@@ -105,7 +105,7 @@ test('RBTree.insert', function t(assert) {
 
     var node = tree.root;
     assert.strictEquals(node.key, 4, 'tree root key is 4');
-    assert.strictEquals(node.str, 'four', 'tree root str is four');
+    assert.strictEquals(node.value, 'four', 'tree root value is four');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
     assert.strictEquals(node.right instanceof RingNode, true, 'tree root right points to a RingNode');
@@ -113,7 +113,7 @@ test('RBTree.insert', function t(assert) {
     // 1,B
     node = tree.root.left.left;
     assert.strictEquals(node.key, 1, 'node key is correct');
-    assert.strictEquals(node.str, 'one', 'node str is correct');
+    assert.strictEquals(node.value, 'one', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -121,7 +121,7 @@ test('RBTree.insert', function t(assert) {
     // 2,R
     node = tree.root.left;
     assert.strictEquals(node.key, 2, 'tree node key is correct');
-    assert.strictEquals(node.str, 'two', 'tree node str is correct');
+    assert.strictEquals(node.value, 'two', 'tree node value is correct');
     assert.strictEquals(node.red, true, 'tree node color is correct');
     assert.strictEquals(node.left instanceof RingNode, true, 'node left points to a RingNode');
     assert.strictEquals(node.right instanceof RingNode, true, 'node right points to a RingNode');
@@ -129,7 +129,7 @@ test('RBTree.insert', function t(assert) {
     // 3,B
     node = tree.root.left.right;
     assert.strictEquals(node.key, 3, 'node key is correct');
-    assert.strictEquals(node.str, 'three', 'node str is correct');
+    assert.strictEquals(node.value, 'three', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -137,7 +137,7 @@ test('RBTree.insert', function t(assert) {
     // 6,R
     node = tree.root.right;
     assert.strictEquals(node.key, 6, 'tree node key is correct');
-    assert.strictEquals(node.str, 'six', 'tree node str is correct');
+    assert.strictEquals(node.value, 'six', 'tree node value is correct');
     assert.strictEquals(node.red, true, 'tree node color is correct');
     assert.strictEquals(node.left instanceof RingNode, true, 'node left points to a RingNode');
     assert.strictEquals(node.right instanceof RingNode, true, 'node right points to a RingNode');
@@ -145,7 +145,7 @@ test('RBTree.insert', function t(assert) {
     // 5,B
     node = tree.root.right.left;
     assert.strictEquals(node.key, 5, 'node key is correct');
-    assert.strictEquals(node.str, 'five', 'node str is correct');
+    assert.strictEquals(node.value, 'five', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -153,7 +153,7 @@ test('RBTree.insert', function t(assert) {
     // 7,B
     node = tree.root.right.right;
     assert.strictEquals(node.key, 7, 'node key is correct');
-    assert.strictEquals(node.str, 'seven', 'node str is correct');
+    assert.strictEquals(node.value, 'seven', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'node has no left pointer');
     assert.strictEquals(node.right instanceof RingNode, true, 'node right points to a RingNode');
@@ -161,7 +161,7 @@ test('RBTree.insert', function t(assert) {
     // 8,R
     node = tree.root.right.right.right;
     assert.strictEquals(node.key, 8, 'node key is correct');
-    assert.strictEquals(node.str, 'eight', 'node str is correct');
+    assert.strictEquals(node.value, 'eight', 'node value is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -194,7 +194,7 @@ test('RBTree.remove', function t(assert) {
     // 4,B
     var node = tree.root;
     assert.strictEquals(node.key, 4, 'tree root key is 4');
-    assert.strictEquals(node.str, 'four', 'tree root str is four');
+    assert.strictEquals(node.value, 'four', 'tree root value is four');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
     assert.strictEquals(node.right instanceof RingNode, true, 'tree root right points to a RingNode');
@@ -202,7 +202,7 @@ test('RBTree.remove', function t(assert) {
     // 2,R
     node = tree.root.left;
     assert.strictEquals(node.key, 2, 'tree node key is correct');
-    assert.strictEquals(node.str, 'two', 'tree node str is correct');
+    assert.strictEquals(node.value, 'two', 'tree node value is correct');
     assert.strictEquals(node.red, false, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
     assert.strictEquals(node.right instanceof RingNode, true, 'node right points to a RingNode');
@@ -210,7 +210,7 @@ test('RBTree.remove', function t(assert) {
     // 3,B
     node = tree.root.left.right;
     assert.strictEquals(node.key, 3, 'node key is correct');
-    assert.strictEquals(node.str, 'three', 'node str is correct');
+    assert.strictEquals(node.value, 'three', 'node value is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -218,7 +218,7 @@ test('RBTree.remove', function t(assert) {
     // 6,R
     node = tree.root.right;
     assert.strictEquals(node.key, 6, 'tree node key is correct');
-    assert.strictEquals(node.str, 'six', 'tree node str is correct');
+    assert.strictEquals(node.value, 'six', 'tree node value is correct');
     assert.strictEquals(node.red, true, 'tree node color is correct');
     assert.strictEquals(node.left instanceof RingNode, true, 'node left points to a RingNode');
     assert.strictEquals(node.right instanceof RingNode, true, 'node right points to a RingNode');
@@ -226,7 +226,7 @@ test('RBTree.remove', function t(assert) {
     // 5,B
     node = tree.root.right.left;
     assert.strictEquals(node.key, 5, 'node key is correct');
-    assert.strictEquals(node.str, 'five', 'node str is correct');
+    assert.strictEquals(node.value, 'five', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -234,7 +234,7 @@ test('RBTree.remove', function t(assert) {
     // 7,B
     node = tree.root.right.right;
     assert.strictEquals(node.key, 7, 'node key is correct');
-    assert.strictEquals(node.str, 'seven', 'node str is correct');
+    assert.strictEquals(node.value, 'seven', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'node has no left pointer');
     assert.strictEquals(node.right instanceof RingNode, true, 'node right points to a RingNode');
@@ -242,7 +242,7 @@ test('RBTree.remove', function t(assert) {
     // 8,R
     node = tree.root.right.right.right;
     assert.strictEquals(node.key, 8, 'node key is correct');
-    assert.strictEquals(node.str, 'eight', 'node str is correct');
+    assert.strictEquals(node.value, 'eight', 'node value is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -263,7 +263,7 @@ test('RBTree.remove', function t(assert) {
     // 6,B
     var node = tree.root;
     assert.strictEquals(node.key, 6, 'tree root key is 6');
-    assert.strictEquals(node.str, 'six', 'tree root str is six');
+    assert.strictEquals(node.value, 'six', 'tree root value is six');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
     assert.strictEquals(node.right instanceof RingNode, true, 'tree root right points to a RingNode');
@@ -271,7 +271,7 @@ test('RBTree.remove', function t(assert) {
     // 3,B
     node = tree.root.left.left;
     assert.strictEquals(node.key, 3, 'node key is correct');
-    assert.strictEquals(node.str, 'three', 'node str is correct');
+    assert.strictEquals(node.value, 'three', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -279,7 +279,7 @@ test('RBTree.remove', function t(assert) {
     // 4,B
     node = tree.root.left;
     assert.strictEquals(node.key, 4, 'node key is correct');
-    assert.strictEquals(node.str, 'four', 'node str is correct');
+    assert.strictEquals(node.value, 'four', 'node value is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left instanceof RingNode, true, 'left pointer is RingNode');
     assert.strictEquals(node.right instanceof RingNode, true, 'right pointer is RingNode');
@@ -287,7 +287,7 @@ test('RBTree.remove', function t(assert) {
     // 5,R
     node = tree.root.left.right;
     assert.strictEquals(node.key, 5, 'tree node key is correct');
-    assert.strictEquals(node.str, 'five', 'tree node str is correct');
+    assert.strictEquals(node.value, 'five', 'tree node value is correct');
     assert.strictEquals(node.red, false, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
     assert.strictEquals(node.right, null, 'node right points to null');
@@ -295,7 +295,7 @@ test('RBTree.remove', function t(assert) {
     // 7,B
     node = tree.root.right;
     assert.strictEquals(node.key, 7, 'node key is correct');
-    assert.strictEquals(node.str, 'seven', 'node str is correct');
+    assert.strictEquals(node.value, 'seven', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'node has no left pointer');
     assert.strictEquals(node.right instanceof RingNode, true, 'node right points to a RingNode');
@@ -303,7 +303,7 @@ test('RBTree.remove', function t(assert) {
     // 8,R
     node = tree.root.right.right;
     assert.strictEquals(node.key, 8, 'node key is correct');
-    assert.strictEquals(node.str, 'eight', 'node str is correct');
+    assert.strictEquals(node.value, 'eight', 'node value is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -324,7 +324,7 @@ test('RBTree.remove', function t(assert) {
     // 6,B
     var node = tree.root;
     assert.strictEquals(node.key, 6, 'tree root key is 6');
-    assert.strictEquals(node.str, 'six', 'tree root str is six');
+    assert.strictEquals(node.value, 'six', 'tree root value is six');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
     assert.strictEquals(node.right instanceof RingNode, true, 'tree root right points to a RingNode');
@@ -332,7 +332,7 @@ test('RBTree.remove', function t(assert) {
     // 4,B
     node = tree.root.left;
     assert.strictEquals(node.key, 4, 'node key is correct');
-    assert.strictEquals(node.str, 'four', 'node str is correct');
+    assert.strictEquals(node.value, 'four', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'left pointer is null');
     assert.strictEquals(node.right instanceof RingNode, true, 'right pointer is RingNode');
@@ -340,7 +340,7 @@ test('RBTree.remove', function t(assert) {
     // 5,R
     node = tree.root.left.right;
     assert.strictEquals(node.key, 5, 'tree node key is correct');
-    assert.strictEquals(node.str, 'five', 'tree node str is correct');
+    assert.strictEquals(node.value, 'five', 'tree node value is correct');
     assert.strictEquals(node.red, true, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
     assert.strictEquals(node.right, null, 'node right points to null');
@@ -348,7 +348,7 @@ test('RBTree.remove', function t(assert) {
     // 7,B
     node = tree.root.right;
     assert.strictEquals(node.key, 7, 'node key is correct');
-    assert.strictEquals(node.str, 'seven', 'node str is correct');
+    assert.strictEquals(node.value, 'seven', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'node has no left pointer');
     assert.strictEquals(node.right instanceof RingNode, true, 'node right points to a RingNode');
@@ -356,7 +356,7 @@ test('RBTree.remove', function t(assert) {
     // 8,R
     node = tree.root.right.right;
     assert.strictEquals(node.key, 8, 'node key is correct');
-    assert.strictEquals(node.str, 'eight', 'node str is correct');
+    assert.strictEquals(node.value, 'eight', 'node value is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -377,7 +377,7 @@ test('RBTree.remove', function t(assert) {
     // 6,B
     var node = tree.root;
     assert.strictEquals(node.key, 6, 'tree root key is 6');
-    assert.strictEquals(node.str, 'six', 'tree root str is six');
+    assert.strictEquals(node.value, 'six', 'tree root value is six');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
     assert.strictEquals(node.right instanceof RingNode, true, 'tree root right points to a RingNode');
@@ -385,7 +385,7 @@ test('RBTree.remove', function t(assert) {
     // 5,B
     node = tree.root.left;
     assert.strictEquals(node.key, 5, 'tree node key is correct');
-    assert.strictEquals(node.str, 'five', 'tree node str is correct');
+    assert.strictEquals(node.value, 'five', 'tree node value is correct');
     assert.strictEquals(node.red, false, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
     assert.strictEquals(node.right, null, 'node right points to null');
@@ -393,7 +393,7 @@ test('RBTree.remove', function t(assert) {
     // 7,B
     node = tree.root.right;
     assert.strictEquals(node.key, 7, 'node key is correct');
-    assert.strictEquals(node.str, 'seven', 'node str is correct');
+    assert.strictEquals(node.value, 'seven', 'node value is correct');
     assert.strictEquals(node.red, false, 'node color is correct');
     assert.strictEquals(node.left, null, 'node has no left pointer');
     assert.strictEquals(node.right instanceof RingNode, true, 'node right points to a RingNode');
@@ -401,7 +401,7 @@ test('RBTree.remove', function t(assert) {
     // 8,R
     node = tree.root.right.right;
     assert.strictEquals(node.key, 8, 'node key is correct');
-    assert.strictEquals(node.str, 'eight', 'node str is correct');
+    assert.strictEquals(node.value, 'eight', 'node value is correct');
     assert.strictEquals(node.red, true, 'node color is correct');
     assert.strictEquals(node.left, null, 'leaf node has no left pointer');
     assert.strictEquals(node.right, null, 'leaf node has no right pointer');
@@ -420,7 +420,7 @@ test('RBTree.remove', function t(assert) {
     // 7,B
     var node = tree.root;
     assert.strictEquals(node.key, 7, 'tree root key is 7');
-    assert.strictEquals(node.str, 'seven', 'tree root str is seven');
+    assert.strictEquals(node.value, 'seven', 'tree root value is seven');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left instanceof RingNode, true, 'tree root left points to a RingNode');
     assert.strictEquals(node.right instanceof RingNode, true, 'tree root right points to a RingNode');
@@ -428,7 +428,7 @@ test('RBTree.remove', function t(assert) {
     // 6,B
     node = tree.root.left;
     assert.strictEquals(node.key, 6, 'tree node key is correct');
-    assert.strictEquals(node.str, 'six', 'tree node str is correct');
+    assert.strictEquals(node.value, 'six', 'tree node value is correct');
     assert.strictEquals(node.red, false, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
     assert.strictEquals(node.right, null, 'node right points to null');
@@ -436,7 +436,7 @@ test('RBTree.remove', function t(assert) {
     // 8,B
     node = tree.root.right;
     assert.strictEquals(node.key, 8, 'tree node key is correct');
-    assert.strictEquals(node.str, 'eight', 'tree node str is correct');
+    assert.strictEquals(node.value, 'eight', 'tree node value is correct');
     assert.strictEquals(node.red, false, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left is null');
     assert.strictEquals(node.right, null, 'node right is null');
@@ -455,7 +455,7 @@ test('RBTree.remove', function t(assert) {
     // 7,B
     var node = tree.root;
     assert.strictEquals(node.key, 7, 'tree root key is 7');
-    assert.strictEquals(node.str, 'seven', 'tree root str is seven');
+    assert.strictEquals(node.value, 'seven', 'tree root value is seven');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left, null, 'tree root left is null');
     assert.strictEquals(node.right instanceof RingNode, true, 'tree root right points to a RingNode');
@@ -463,7 +463,7 @@ test('RBTree.remove', function t(assert) {
     // 8,R
     node = tree.root.right;
     assert.strictEquals(node.key, 8, 'tree node key is correct');
-    assert.strictEquals(node.str, 'eight', 'tree node str is correct');
+    assert.strictEquals(node.value, 'eight', 'tree node value is correct');
     assert.strictEquals(node.red, true, 'tree node color is correct');
     assert.strictEquals(node.left, null, 'node left points to null');
     assert.strictEquals(node.right, null, 'node right points to null');
@@ -480,7 +480,7 @@ test('RBTree.remove', function t(assert) {
     // 7,B
     var node = tree.root;
     assert.strictEquals(node.key, 8, 'tree root key is 8');
-    assert.strictEquals(node.str, 'eight', 'tree root str is eight');
+    assert.strictEquals(node.value, 'eight', 'tree root value is eight');
     assert.strictEquals(node.red, false, 'tree root is black');
     assert.strictEquals(node.left, null, 'tree root left is null');
     assert.strictEquals(node.right, null, 'tree root right is null');
@@ -605,7 +605,7 @@ test('RBTree payload copy bug', function t(assert) {
 
     var iter = tree.iterator();
     while (iter.next() !== null) {
-        assert.strictEquals(iter.key(), Number(iter.str()), 'node payloads match');
+        assert.strictEquals(iter.key(), Number(iter.value()), 'node payloads match');
     }
 
     assert.end();

--- a/test/unit/rbtree_test.js
+++ b/test/unit/rbtree_test.js
@@ -20,10 +20,11 @@
 
 var RBTree = require('../../lib/ring/rbtree').RBTree;
 var RingNode = require('../../lib/ring/rbtree').RingNode;
+var comparator = require('../../lib/ring').comparator;
 var test = require('tape');
 
 test('construct a new RBTree', function t(assert) {
-    var tree = new RBTree();
+    var tree = new RBTree(comparator);
 
     assert.strictEquals(tree.root, null, 'root is null');
     assert.strictEquals(tree.size, 0, 'size is 0');
@@ -32,7 +33,7 @@ test('construct a new RBTree', function t(assert) {
 });
 
 function makeTree() {
-    var tree = new RBTree();
+    var tree = new RBTree(comparator);
 
     tree.insert(1, 'one');
     tree.insert(2, 'two');
@@ -593,7 +594,7 @@ test('RBTree upperBound', function t(assert) {
 });
 
 test('RBTree payload copy bug', function t(assert) {
-    var tree = new RBTree();
+    var tree = new RBTree(comparator);
 
     for (var i = 0; i < 2000; i++) {
         tree.insert(i, String(i));

--- a/test/unit/ringnode_test.js
+++ b/test/unit/ringnode_test.js
@@ -27,7 +27,7 @@ test('construct a new red node with supplied values', function t(assert) {
     var node = new RingNode(val, str);
 
     assert.strictEquals(node.key, val, 'key set to supplied key');
-    assert.strictEquals(node.str, str, 'str set to supplied str');
+    assert.strictEquals(node.value, str, 'value set to supplied value');
 
     assert.strictEquals(node.left, null, 'left is null');
     assert.strictEquals(node.right, null, 'right is null');

--- a/test/unit/ringnode_test.js
+++ b/test/unit/ringnode_test.js
@@ -26,7 +26,7 @@ test('construct a new red node with supplied values', function t(assert) {
     var str = 'just in time';
     var node = new RingNode(val, str);
 
-    assert.strictEquals(node.val, val, 'val set to supplied val');
+    assert.strictEquals(node.key, val, 'key set to supplied key');
     assert.strictEquals(node.str, str, 'str set to supplied str');
 
     assert.strictEquals(node.left, null, 'left is null');


### PR DESCRIPTION
This is the first part of the fix for consistent hashring lookups on hash collisions where we abstract the RBTree to not care about the datatypes stored. Comparison is done by a comparator function.

This will help in later stages where the `key` can contain more data points instead of the hash.