### PR TITLE
[Fix] Consistent hash ring lookups 2 / Use replicaPoints as RBTree key

### DIFF
--- a/lib/ring/index.js
+++ b/lib/ring/index.js
@@ -34,8 +34,9 @@ function HashRing(options) {
     this.servers = {};
     this.checksum = null;
 }
+
 HashRing.comparator = function comparator(a, b) {
-    return a - b;
+    return a.hash - b.hash;
 };
 
 util.inherits(HashRing, EventEmitter);
@@ -52,13 +53,23 @@ HashRing.prototype.addServer = function addServer(name) {
     this.emit('added', name);
 };
 
+HashRing.prototype._newReplicaPoint = function(address, replica) {
+    var hash = this.hashFunc(address +  replica);
+
+    return {
+        hash: hash,
+        address: address,
+        index: replica
+    };
+};
+
 HashRing.prototype.addServerReplicas = function addServerReplicas(server) {
     // Assumes server has not been previously added.
     this.servers[server] = true;
 
     for (var i = 0; i < this.replicaPoints; i++) {
-        var hash = this.hashFunc(server + i);
-        this.rbtree.insert(hash, server);
+        var replicaPoint = this._newReplicaPoint(server, i);
+        this.rbtree.insert(replicaPoint, server);
     }
 };
 
@@ -146,14 +157,15 @@ HashRing.prototype.removeServerReplicas = function removeServerReplicas(server) 
     delete this.servers[server];
 
     for (var i = 0; i < this.replicaPoints; i++) {
-        var hash = this.hashFunc(server + i);
-        this.rbtree.remove(hash, server);
+        var replicaPoint = this._newReplicaPoint(server, i);
+        this.rbtree.remove(replicaPoint, server);
     }
 };
 
 HashRing.prototype.lookup = function lookup(str) {
     var hash = this.hashFunc(str);
-    var iter = this.rbtree.upperBound(hash);
+    var replicaPoint = {hash: hash};
+    var iter = this.rbtree.upperBound(replicaPoint);
     var res = iter.value();
     if (res === null) {
         var min = this.rbtree.min();
@@ -173,7 +185,8 @@ HashRing.prototype.lookupN = function lookupN(str, n) {
     var resultArray = [];
     var resultSet = {}; // for fast dedup
     var hash = this.hashFunc(str);
-    var iter = this.rbtree.upperBound(hash);
+    var replicaPoint = {hash: hash};
+    var iter = this.rbtree.upperBound(replicaPoint);
     // remember start of loop to prevent infinite loops
     // (This is to guard against the cases where serverCount is out of sync with
     // the rbtree (e.g., due to a bug), e.g., n === serverCount === 3 but the

--- a/test/lib/int-comparator.js
+++ b/test/lib/int-comparator.js
@@ -1,0 +1,25 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+function intComparator(a, b) {
+    return a-b;
+}
+
+module.exports = intComparator;

--- a/test/unit/hashring_test.js
+++ b/test/unit/hashring_test.js
@@ -165,3 +165,16 @@ test('servers removed out of order result in same checksum', function t(assert) 
         }
     }
 });
+
+test('hashring replica point comparator', function t(assert) {
+    var comparator = HashRing.comparator;
+
+    assert.true(comparator({hash: 1}, {hash: 2}) < 0, '1 < 2');
+    assert.true(comparator({hash: -1}, {hash: 1}) < 0, '-1 < 1');
+    assert.true(comparator({hash: 1}, {hash: 1}) == 0, '1 == 1');
+    assert.true(comparator({hash: -1}, {hash: -1}) == 0, '-1 == -1');
+    assert.true(comparator({hash: 2}, {hash: 1}) > 0, '2 > 1');
+    assert.true(comparator({hash: 2}, {hash: -1}) > 0, '2 > -1');
+
+    assert.end();
+});

--- a/test/unit/rbiterator_test.js
+++ b/test/unit/rbiterator_test.js
@@ -20,7 +20,7 @@
 
 var RBTree = require('../../lib/ring/rbtree').RBTree;
 var RBIterator = require('../../lib/ring/rbtree').RBIterator;
-var comparator = require('../../lib/ring').comparator;
+var comparator = require('../lib/int-comparator');
 
 var test = require('tape');
 

--- a/test/unit/rbtree_test.js
+++ b/test/unit/rbtree_test.js
@@ -20,7 +20,7 @@
 
 var RBTree = require('../../lib/ring/rbtree').RBTree;
 var RingNode = require('../../lib/ring/rbtree').RingNode;
-var comparator = require('../../lib/ring').comparator;
+var comparator = require('../lib/int-comparator');
 var test = require('tape');
 
 test('construct a new RBTree', function t(assert) {


### PR DESCRIPTION
This PR changes the key in the RBTree from the hash to a replica point in preparation for a better compare function.